### PR TITLE
Initial Signature trait and Error enum

### DIFF
--- a/signature-crate/Cargo.toml
+++ b/signature-crate/Cargo.toml
@@ -10,3 +10,8 @@ keywords = ["crypto", "signature", "signing"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
+
+[features]
+alloc = []
+default = ["std"]
+std = ["alloc"]

--- a/signature-crate/src/error.rs
+++ b/signature-crate/src/error.rs
@@ -1,0 +1,25 @@
+//! Signature error types
+
+use core::fmt;
+
+/// Errors which can occur during signature operations
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum Error {
+    /// Signature failed to verify
+    SignatureInvalid,
+}
+
+impl Error {
+    /// Get string description of this error
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Error::SignatureInvalid => "signature verification failed",
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}

--- a/signature-crate/src/lib.rs
+++ b/signature-crate/src/lib.rs
@@ -1,1 +1,22 @@
+//! Digital signature types and traits
+
 #![crate_name = "signature"]
+#![crate_type = "lib"]
+#![no_std]
+#![cfg_attr(
+    all(feature = "nightly", not(feature = "std")),
+    feature(alloc)
+)]
+#![deny(warnings, missing_docs, trivial_casts, trivial_numeric_casts)]
+#![deny(unsafe_code, unused_import_braces, unused_qualifications)]
+
+#[cfg(any(feature = "std", test))]
+#[macro_use]
+extern crate std;
+
+mod error;
+pub(crate) mod prelude;
+mod signature;
+
+pub use error::Error;
+pub use signature::Signature;

--- a/signature-crate/src/prelude.rs
+++ b/signature-crate/src/prelude.rs
@@ -1,0 +1,8 @@
+//! Crate-local prelude (for alloc-dependent features like `Vec`)
+
+// TODO: switch to alloc::prelude
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+pub use alloc::vec::Vec;
+
+#[cfg(feature = "std")]
+pub use std::vec::Vec;

--- a/signature-crate/src/signature.rs
+++ b/signature-crate/src/signature.rs
@@ -1,0 +1,24 @@
+use core::fmt::Debug;
+
+use error::Error;
+#[allow(unused_imports)]
+use prelude::*;
+
+/// Trait impl'd by concrete types that represent digital signatures
+pub trait Signature: AsRef<[u8]> + Debug + Sized {
+    /// Parse a signature from its byte representation
+    fn from_bytes<B: AsRef<[u8]>>(bytes: B) -> Result<Self, Error>;
+
+    /// Borrow this signature as serialized bytes
+    #[inline]
+    fn as_slice(&self) -> &[u8] {
+        self.as_ref()
+    }
+
+    /// Convert this signature into a byte vector
+    #[cfg(feature = "alloc")]
+    #[inline]
+    fn into_vec(self) -> Vec<u8> {
+        self.as_slice().into()
+    }
+}


### PR DESCRIPTION
Adds a `Signature` trait which serialized signature types implement.

Adds an initial `Error` type to be returned from `Signature::from_bytes` in the event the signature is not valid.