### PR TITLE
Improved signature::error::Error with cause

### DIFF
--- a/signature-crate/src/error.rs
+++ b/signature-crate/src/error.rs
@@ -1,25 +1,86 @@
 //! Signature error types
 
-use core::fmt;
+use core::fmt::{self, Display};
 
-/// Errors which can occur during signature operations
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
-pub enum Error {
-    /// Signature failed to verify
-    SignatureInvalid,
+#[cfg(feature = "std")]
+use std::{boxed::Box, error::Error as StdError};
+
+/// Signature errors
+#[derive(Debug, Default)]
+pub struct Error {
+    /// Cause of the error (if applicable)
+    #[cfg(feature = "std")]
+    cause: Option<Box<dyn StdError>>,
 }
 
 impl Error {
-    /// Get string description of this error
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Error::SignatureInvalid => "signature verification failed",
+    /// Create a new error with no cause
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a new error from a cause
+    #[cfg(feature = "std")]
+    pub fn from_cause<E>(cause: E) -> Self
+    where
+        E: Into<Box<dyn StdError>>,
+    {
+        Self {
+            cause: Some(cause.into()),
+        }
+    }
+
+    /// Extract the underlying cause of this error.
+    ///
+    /// Panics if the error does not have a cause.
+    #[cfg(feature = "std")]
+    pub fn into_cause(self) -> Box<dyn StdError> {
+        self.cause
+            .expect("into_cause called on an error with no cause")
+    }
+
+    /// Attempt to downcast this error's cause into a concrete type
+    #[cfg(feature = "std")]
+    pub fn downcast<T>(self) -> Result<Box<T>, Box<dyn StdError>>
+    where
+        T: StdError + 'static,
+    {
+        self.cause
+            .map(|cause| cause.downcast())
+            .unwrap_or_else(|| Err(Error::new().into()))
+    }
+
+    /// Attempt to downcast a reference to this error's cause into a concrete type
+    #[cfg(feature = "std")]
+    pub fn downcast_ref<T>(&self) -> Option<&T>
+    where
+        T: StdError + 'static,
+    {
+        self.cause.as_ref().and_then(|cause| cause.downcast_ref())
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "signature error")
+    }
+}
+
+#[cfg(feature = "std")]
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if let Some(ref cause) = self.cause {
+            write!(f, "{}", cause)
+        } else {
+            write!(f, "signature error")
         }
     }
 }
 
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.as_str())
+#[cfg(feature = "std")]
+impl StdError for Error {
+    fn cause(&self) -> Option<&dyn StdError> {
+        self.cause.as_ref().map(|cause| cause.as_ref())
     }
 }

--- a/signature-crate/src/lib.rs
+++ b/signature-crate/src/lib.rs
@@ -1,11 +1,16 @@
 //! Digital signature types and traits
 
-#![crate_name = "signature"]
-#![crate_type = "lib"]
 #![no_std]
 #![cfg_attr(all(feature = "nightly", not(feature = "std")), feature(alloc))]
-#![deny(warnings, missing_docs, trivial_casts, trivial_numeric_casts)]
-#![deny(unsafe_code, unused_import_braces, unused_qualifications)]
+#![deny(
+    warnings,
+    missing_docs,
+    trivial_casts,
+    trivial_numeric_casts,
+    unsafe_code,
+    unused_import_braces,
+    unused_qualifications
+)]
 
 #[cfg(any(feature = "std", test))]
 #[macro_use]
@@ -15,5 +20,4 @@ mod error;
 pub(crate) mod prelude;
 mod signature;
 
-pub use error::Error;
-pub use signature::Signature;
+pub use crate::{error::Error, signature::Signature};


### PR DESCRIPTION
Replaces the previous error `enum` with a struct that, on `std`, contains an optional cause which is captured as `Box<std::error::Error>`, but is otherwise opaque.

This allows the core signature traits to remain object safe (since they don't need a generic error type) but also allows passing through a provider-specific error type, e.g. for HSMs which may have any number of errors which prevent a signature operation from occuring (e.g. I/O errors, authentication errors, invalid key identifiers).

It also includes downcast methods that conveniently allow extracting provider-specific errors as concrete types if so desired.