### PR TITLE
Add "raw digest" signature marker trait and sign/verify traits

### DIFF
--- a/signature-crate/src/sign/digest.rs
+++ b/signature-crate/src/sign/digest.rs
@@ -4,7 +4,11 @@
 //! For use signature algorithms that support an Initialize-Update-Finalize
 //! (IUF) API, such as ECDSA or Ed25519ph.
 
-use crate::{error::Error, Signature};
+use super::Sign;
+use crate::{
+    error::Error,
+    signature::{RawDigestSignature, Signature},
+};
 use digest::Digest;
 
 /// Sign the given prehashed message `Digest` using `Self`.
@@ -14,5 +18,47 @@ where
     S: Signature,
 {
     /// Sign the given prehashed message `Digest`, returning a signature.
-    fn sign(&self, digest: D) -> Result<S, Error>;
+    fn sign_digest(&self, digest: D) -> Result<S, Error>;
+}
+
+/// Sign the given message using a "raw digest" signature algorithm, i.e.
+/// any algorithm where signatures are always computed as `S(H(m)))` where:
+///
+/// - `S`: signature algorithm
+/// - `H`: hash (a.k.a. digest) function
+/// - `m`: message
+///
+/// This is the preferred trait to be `impl`'d for such algorithms, and when
+/// used will take advantage of a blanket `impl` of `Sign` which will hash
+/// the original message in advance using the relevant `Digest` algorithm
+pub trait SignRawDigest<S>: Send + Sync
+where
+    S: Signature + RawDigestSignature,
+{
+    /// Digest algorithm to hash the input message with
+    type Digest: Digest;
+
+    /// Sign the given prehashed message `Digest`, returning a signature.
+    fn sign_raw_digest(&self, digest: Self::Digest) -> Result<S, Error>;
+}
+
+impl<D, S, T> SignDigest<D, S> for T
+where
+    D: Digest,
+    S: Signature + RawDigestSignature,
+    T: SignRawDigest<S, Digest = D>,
+{
+    fn sign_digest(&self, digest: D) -> Result<S, Error> {
+        self.sign_raw_digest(digest)
+    }
+}
+
+impl<S, T> Sign<S> for T
+where
+    S: Signature + RawDigestSignature,
+    T: SignRawDigest<S>,
+{
+    fn sign(&self, msg: &[u8]) -> Result<S, Error> {
+        self.sign_digest(<T as SignRawDigest<S>>::Digest::new().chain(msg))
+    }
 }

--- a/signature-crate/src/signature.rs
+++ b/signature-crate/src/signature.rs
@@ -22,3 +22,15 @@ pub trait Signature: AsRef<[u8]> + Debug + Sized {
         self.as_slice().into()
     }
 }
+
+/// Marker trait for "raw digest" signature algorithms, i.e. any algorithm
+/// where signatures are exclusively computed as `S(H(m)))` where:
+///
+/// - `S`: signature algorithm
+/// - `H`: hash (a.k.a. digest) function
+/// - `m`: message
+///
+/// Notably this does not hold true for Ed25519, which hashes the input message
+/// twice in an effort to remain secure even in the event of collisions in the
+/// underlying hash function.
+pub trait RawDigestSignature {}

--- a/signature-crate/src/verify/digest.rs
+++ b/signature-crate/src/verify/digest.rs
@@ -4,7 +4,11 @@
 //! For use signature algorithms that support an Initialize-Update-Finalize
 //! (IUF) API, such as ECDSA or Ed25519ph.
 
-use crate::{error::Error, Signature};
+use super::Verify;
+use crate::{
+    error::Error,
+    signature::{RawDigestSignature, Signature},
+};
 use digest::Digest;
 
 /// Verify the provided signature for the given prehashed message `Digest`
@@ -15,5 +19,50 @@ where
     S: Signature,
 {
     /// Verify the signature against the given `Digest`
-    fn verify(&self, digest: D, signature: &S) -> Result<(), Error>;
+    fn verify_digest(&self, digest: D, signature: &S) -> Result<(), Error>;
+}
+
+/// Verify the given message using a "raw digest" signature algorithm, i.e.
+/// any algorithm where signatures are always computed as `S(H(m)))` where:
+///
+/// - `S`: signature algorithm
+/// - `H`: hash (a.k.a. digest) function
+/// - `m`: message
+///
+/// This is the preferred trait to be `impl`'d for such algorithms, and when
+/// used will take advantage of a blanket `impl` of `Sign` which will hash
+/// the original message in advance using the relevant `Digest` algorithm
+pub trait VerifyRawDigest<S>: Send + Sync
+where
+    S: Signature + RawDigestSignature,
+{
+    /// Digest algorithm to hash the input message with
+    type Digest: Digest;
+
+    /// Verify the signature against given prehashed message `Digest`
+    fn verify_raw_digest(&self, digest: Self::Digest, signature: &S) -> Result<(), Error>;
+}
+
+impl<D, S, T> VerifyDigest<D, S> for T
+where
+    D: Digest,
+    S: Signature + RawDigestSignature,
+    T: VerifyRawDigest<S, Digest = D>,
+{
+    fn verify_digest(&self, digest: D, signature: &S) -> Result<(), Error> {
+        self.verify_raw_digest(digest, signature)
+    }
+}
+
+impl<S, T> Verify<S> for T
+where
+    S: Signature + RawDigestSignature,
+    T: VerifyRawDigest<S>,
+{
+    fn verify(&self, msg: &[u8], signature: &S) -> Result<(), Error> {
+        self.verify_raw_digest(
+            <T as VerifyRawDigest<S>>::Digest::new().chain(msg),
+            signature,
+        )
+    }
 }


### PR DESCRIPTION
Introduces the notion of a "raw digest" signature algorithm, i.e. any algorithm where signatures are always computed as `S(H(m)))` where:

- `S`: signature algorithm
- `H`: hash (a.k.a. digest) function
- `m`: message

Notably this does not hold true for Ed25519, which hashes the input message twice in an effort to remain secure even in the event of collisions in the underlying hash function.

However, it supports a separate IUF mode Ed25519ph, which is trivial for any Ed25519 implementation to implement (it hashes the message in advance, then performs a regular Ed25519 signature albeit with a domain separation tweak).

For cases like this, where the IUF mode is deliberately domain separated from the normal mode, it would be nice to avoid a blanket impl which assumes all signature algorithms are composed as `S(H(m))`, so signers can, if they so desire, impl both traits and support both modes using a single underlying type (e.g. `KeyPair` for signers and `PublicKey` for verifiers), as the keys used for either algorithm are identical and both modes can be used safely under the same key due to domain separation.

To accomplish this, this commit adds a `RawDigestSignature` marker trait to be applied at the algorithm level to the corresponding signature trait.

For signature types marked as `RawDigestSignature`, it's possible to `impl` a corresponding `SignRawDigest` trait for which a blanket `impl` of `Sign` exists which hashes the message with the corresponding `Digest` algorithm.

Additionally, `SignDigest` is blanket impl'd for all `SignRawDigest` types.