### PR TITLE
Rename to Signer/Verifier; add 'digest' module

### DIFF
--- a/signature-crate/src/digest/mod.rs
+++ b/signature-crate/src/digest/mod.rs
@@ -1,0 +1,11 @@
+//! Support for using hash functions that impl the `Digest` trait in order
+//! to hash the input message in order to compute a signature.
+
+mod signer;
+mod verifier;
+
+/// Re-export the `Digest` trait from the `digest` crate, as it's the main
+/// trait this module depends on.
+pub use ::digest::Digest;
+
+pub use self::{signer::Signer, verifier::Verifier};

--- a/signature-crate/src/digest/signer.rs
+++ b/signature-crate/src/digest/signer.rs
@@ -4,11 +4,10 @@
 //! For use signature algorithms that support an Initialize-Update-Finalize
 //! (IUF) API, such as ECDSA or Ed25519ph.
 
-use crate::{error::Error, Signature};
-use digest::Digest;
+use crate::{digest::Digest, error::Error, Signature};
 
 /// Sign the given prehashed message `Digest` using `Self`.
-pub trait SignDigest<D, S>: Send + Sync
+pub trait Signer<D, S>
 where
     D: Digest,
     S: Signature,

--- a/signature-crate/src/digest/verifier.rs
+++ b/signature-crate/src/digest/verifier.rs
@@ -4,12 +4,11 @@
 //! For use signature algorithms that support an Initialize-Update-Finalize
 //! (IUF) API, such as ECDSA or Ed25519ph.
 
-use crate::{error::Error, Signature};
-use digest::Digest;
+use crate::{digest::Digest, error::Error, Signature};
 
 /// Verify the provided signature for the given prehashed message `Digest`
 /// is authentic.
-pub trait VerifyDigest<D, S>: Send + Sync
+pub trait Verifier<D, S>
 where
     D: Digest,
     S: Signature,

--- a/signature-crate/src/lib.rs
+++ b/signature-crate/src/lib.rs
@@ -14,17 +14,16 @@
     unused_qualifications
 )]
 
-#[cfg(feature = "digest")]
-pub extern crate digest;
-
 #[cfg(any(feature = "std", test))]
 #[macro_use]
 extern crate std;
 
+#[cfg(feature = "digest")]
+mod digest;
 mod error;
 mod prelude;
-pub mod sign;
 mod signature;
-pub mod verify;
+pub mod signer;
+pub mod verifier;
 
-pub use crate::{error::Error, sign::Sign, signature::Signature, verify::Verify};
+pub use crate::{error::Error, signature::Signature, signer::Signer, verifier::Verifier};

--- a/signature-crate/src/signer.rs
+++ b/signature-crate/src/signer.rs
@@ -1,15 +1,10 @@
 //! Traits for generating digital signatures
 
-#[cfg(feature = "digest")]
-pub(crate) mod digest;
-
-#[cfg(feature = "digest")]
-pub use self::digest::SignDigest;
 use crate::{error::Error, Signature};
 
 /// Sign the provided message bytestring using `Self` (e.g. a cryptographic key
 /// or connection to an HSM), returning a digital signature.
-pub trait Sign<S: Signature>: Send + Sync {
+pub trait Signer<S: Signature> {
     /// Sign the given message and return a digital signature
     fn sign(&self, msg: &[u8]) -> Result<S, Error>;
 }

--- a/signature-crate/src/verifier.rs
+++ b/signature-crate/src/verifier.rs
@@ -1,14 +1,9 @@
 //! Trait for verifying digital signatures
 
-#[cfg(feature = "digest")]
-pub(crate) mod digest;
-
-#[cfg(feature = "digest")]
-pub use self::digest::VerifyDigest;
 use crate::{error::Error, Signature};
 
 /// Verify the provided message bytestring using `Self` (e.g. a public key)
-pub trait Verify<S: Signature>: Send + Sync {
+pub trait Verifier<S: Signature> {
     /// Use `Self` to verify that the provided signature for a given message
     /// bytestring is authentic.
     ///


### PR DESCRIPTION
Some sweeping refactoring here which hopefully cleans up the project organization and helps simplify its implementation:

- `Sign` => `Signer`, `Verify` => `Verifier`
- Move all `digest`-related functionality under the `digest` module:
  - `signature::digest::Signer`
  - `signature::digest::Verifier`
- Re-export `::digest::Digest` as `signature::digest::Digest`
- Remove `Send` + `Sync` bounds on traits: if people wants these bounds
  they can add them themselves.