### PR TITLE
Digestable signatures

### DIFF
--- a/signature-crate/src/digest/digestable.rs
+++ b/signature-crate/src/digest/digestable.rs
@@ -25,7 +25,7 @@ where
     T: digest::Signer<S::Digest, S>,
 {
     fn sign(&self, msg: &[u8]) -> Result<S, Error> {
-        self.sign_digest(S::Digest::new().chain(msg))
+        self.sign_digest(S::Digest::digest(msg))
     }
 }
 
@@ -35,6 +35,6 @@ where
     T: digest::Verifier<S::Digest, S>,
 {
     fn verify(&self, msg: &[u8], signature: &S) -> Result<(), Error> {
-        self.verify_digest(S::Digest::new().chain(msg), signature)
+        self.verify_digest(S::Digest::digest(msg), signature)
     }
 }

--- a/signature-crate/src/digest/digestable.rs
+++ b/signature-crate/src/digest/digestable.rs
@@ -1,4 +1,4 @@
-use super::Digest;
+use crate::{digest::Digest, signature::Signature};
 
 /// Marker trait for `Signature` types computable as `S(H(m))` where:
 ///
@@ -8,6 +8,7 @@ use super::Digest;
 ///
 /// For signature types that implement this trait, a blanket impl of
 /// `Signer` will be provided for all types that `impl digest::Signer`.
-pub trait Signature: crate::signature::Signature {
+pub trait Digestable: Signature {
+    /// Preferred `Digest` algorithm to use when computing this signature type.
     type Digest: Digest;
 }

--- a/signature-crate/src/digest/mod.rs
+++ b/signature-crate/src/digest/mod.rs
@@ -1,7 +1,7 @@
 //! Support for using hash functions that impl the `Digest` trait in order
 //! to hash the input message in order to compute a signature.
 
-mod signature;
+mod digestable;
 mod signer;
 mod verifier;
 
@@ -9,4 +9,4 @@ mod verifier;
 /// trait this module depends on.
 pub use ::digest::Digest;
 
-pub use self::{signature::Signature, signer::Signer, verifier::Verifier};
+pub use self::{digestable::Digestable, signer::Signer, verifier::Verifier};

--- a/signature-crate/src/digest/mod.rs
+++ b/signature-crate/src/digest/mod.rs
@@ -1,6 +1,7 @@
 //! Support for using hash functions that impl the `Digest` trait in order
 //! to hash the input message in order to compute a signature.
 
+mod signature;
 mod signer;
 mod verifier;
 
@@ -8,4 +9,4 @@ mod verifier;
 /// trait this module depends on.
 pub use ::digest::Digest;
 
-pub use self::{signer::Signer, verifier::Verifier};
+pub use self::{signature::Signature, signer::Signer, verifier::Verifier};

--- a/signature-crate/src/digest/signature.rs
+++ b/signature-crate/src/digest/signature.rs
@@ -1,0 +1,13 @@
+use super::Digest;
+
+/// Marker trait for `Signature` types computable as `S(H(m))` where:
+///
+/// - `S`: signature algorithm
+/// - `H`: hash (a.k.a. digest) function
+/// - `m`: message
+///
+/// For signature types that implement this trait, a blanket impl of
+/// `Signer` will be provided for all types that `impl digest::Signer`.
+pub trait Signature: crate::signature::Signature {
+    type Digest: Digest;
+}

--- a/signature-crate/src/digest/signer.rs
+++ b/signature-crate/src/digest/signer.rs
@@ -13,5 +13,15 @@ where
     S: Signature,
 {
     /// Sign the given prehashed message `Digest`, returning a signature.
-    fn sign(&self, digest: D) -> Result<S, Error>;
+    fn sign_digest(&self, digest: D) -> Result<S, Error>;
+}
+
+impl<S, T> crate::Signer<S> for T
+where
+    S: crate::digest::Signature,
+    T: Signer<S::Digest, S>,
+{
+    fn sign(&self, msg: &[u8]) -> Result<S, Error> {
+        self.sign_digest(S::Digest::new().chain(msg))
+    }
 }

--- a/signature-crate/src/digest/signer.rs
+++ b/signature-crate/src/digest/signer.rs
@@ -4,7 +4,7 @@
 //! For use signature algorithms that support an Initialize-Update-Finalize
 //! (IUF) API, such as ECDSA or Ed25519ph.
 
-use super::{Digest, Digestable};
+use super::Digest;
 use crate::{error::Error, signature::Signature};
 
 /// Sign the given prehashed message `Digest` using `Self`.
@@ -15,14 +15,4 @@ where
 {
     /// Sign the given prehashed message `Digest`, returning a signature.
     fn sign_digest(&self, digest: D) -> Result<S, Error>;
-}
-
-impl<S, T> crate::signer::Signer<S> for T
-where
-    S: Digestable + Signature,
-    T: Signer<S::Digest, S>,
-{
-    fn sign(&self, msg: &[u8]) -> Result<S, Error> {
-        self.sign_digest(S::Digest::new().chain(msg))
-    }
 }

--- a/signature-crate/src/digest/signer.rs
+++ b/signature-crate/src/digest/signer.rs
@@ -6,6 +6,7 @@
 
 use super::Digest;
 use crate::{error::Error, signature::Signature};
+use digest::generic_array::GenericArray;
 
 /// Sign the given prehashed message `Digest` using `Self`.
 pub trait Signer<D, S>
@@ -14,5 +15,5 @@ where
     S: Signature,
 {
     /// Sign the given prehashed message `Digest`, returning a signature.
-    fn sign_digest(&self, digest: D) -> Result<S, Error>;
+    fn sign_digest(&self, digest: GenericArray<u8, D::OutputSize>) -> Result<S, Error>;
 }

--- a/signature-crate/src/digest/signer.rs
+++ b/signature-crate/src/digest/signer.rs
@@ -4,7 +4,8 @@
 //! For use signature algorithms that support an Initialize-Update-Finalize
 //! (IUF) API, such as ECDSA or Ed25519ph.
 
-use crate::{digest::Digest, error::Error, Signature};
+use super::{Digest, Digestable};
+use crate::{error::Error, signature::Signature};
 
 /// Sign the given prehashed message `Digest` using `Self`.
 pub trait Signer<D, S>
@@ -16,9 +17,9 @@ where
     fn sign_digest(&self, digest: D) -> Result<S, Error>;
 }
 
-impl<S, T> crate::Signer<S> for T
+impl<S, T> crate::signer::Signer<S> for T
 where
-    S: crate::digest::Signature,
+    S: Digestable + Signature,
     T: Signer<S::Digest, S>,
 {
     fn sign(&self, msg: &[u8]) -> Result<S, Error> {

--- a/signature-crate/src/digest/verifier.rs
+++ b/signature-crate/src/digest/verifier.rs
@@ -6,6 +6,7 @@
 
 use super::Digest;
 use crate::{error::Error, signature::Signature};
+use digest::generic_array::GenericArray;
 
 /// Verify the provided signature for the given prehashed message `Digest`
 /// is authentic.
@@ -15,5 +16,9 @@ where
     S: Signature,
 {
     /// Verify the signature against the given `Digest`
-    fn verify_digest(&self, digest: D, signature: &S) -> Result<(), Error>;
+    fn verify_digest(
+        &self,
+        digest: GenericArray<u8, D::OutputSize>,
+        signature: &S,
+    ) -> Result<(), Error>;
 }

--- a/signature-crate/src/digest/verifier.rs
+++ b/signature-crate/src/digest/verifier.rs
@@ -4,7 +4,8 @@
 //! For use signature algorithms that support an Initialize-Update-Finalize
 //! (IUF) API, such as ECDSA or Ed25519ph.
 
-use crate::{digest::Digest, error::Error, Signature};
+use super::{Digest, Digestable};
+use crate::{error::Error, signature::Signature};
 
 /// Verify the provided signature for the given prehashed message `Digest`
 /// is authentic.
@@ -17,9 +18,9 @@ where
     fn verify_digest(&self, digest: D, signature: &S) -> Result<(), Error>;
 }
 
-impl<S, T> crate::Verifier<S> for T
+impl<S, T> crate::verifier::Verifier<S> for T
 where
-    S: crate::digest::Signature,
+    S: Digestable + Signature,
     T: Verifier<S::Digest, S>,
 {
     fn verify(&self, msg: &[u8], signature: &S) -> Result<(), Error> {

--- a/signature-crate/src/digest/verifier.rs
+++ b/signature-crate/src/digest/verifier.rs
@@ -4,7 +4,7 @@
 //! For use signature algorithms that support an Initialize-Update-Finalize
 //! (IUF) API, such as ECDSA or Ed25519ph.
 
-use super::{Digest, Digestable};
+use super::Digest;
 use crate::{error::Error, signature::Signature};
 
 /// Verify the provided signature for the given prehashed message `Digest`
@@ -16,14 +16,4 @@ where
 {
     /// Verify the signature against the given `Digest`
     fn verify_digest(&self, digest: D, signature: &S) -> Result<(), Error>;
-}
-
-impl<S, T> crate::verifier::Verifier<S> for T
-where
-    S: Digestable + Signature,
-    T: Verifier<S::Digest, S>,
-{
-    fn verify(&self, msg: &[u8], signature: &S) -> Result<(), Error> {
-        self.verify_digest(S::Digest::new().chain(msg), signature)
-    }
 }

--- a/signature-crate/src/digest/verifier.rs
+++ b/signature-crate/src/digest/verifier.rs
@@ -14,5 +14,15 @@ where
     S: Signature,
 {
     /// Verify the signature against the given `Digest`
-    fn verify(&self, digest: D, signature: &S) -> Result<(), Error>;
+    fn verify_digest(&self, digest: D, signature: &S) -> Result<(), Error>;
+}
+
+impl<S, T> crate::Verifier<S> for T
+where
+    S: crate::digest::Signature,
+    T: Verifier<S::Digest, S>,
+{
+    fn verify(&self, msg: &[u8], signature: &S) -> Result<(), Error> {
+        self.verify_digest(S::Digest::new().chain(msg), signature)
+    }
 }

--- a/signature-crate/src/lib.rs
+++ b/signature-crate/src/lib.rs
@@ -19,12 +19,12 @@
 extern crate std;
 
 #[cfg(feature = "digest")]
-mod digest;
+pub mod digest;
 mod error;
 mod prelude;
 mod signature;
-pub mod signer;
-pub mod verifier;
+mod signer;
+mod verifier;
 
 pub use crate::{error::Error, signature::Signature, signer::Signer, verifier::Verifier};
 

--- a/signature-crate/src/lib.rs
+++ b/signature-crate/src/lib.rs
@@ -27,3 +27,6 @@ pub mod signer;
 pub mod verifier;
 
 pub use crate::{error::Error, signature::Signature, signer::Signer, verifier::Verifier};
+
+#[cfg(feature = "digest")]
+pub use crate::digest::Digestable;


### PR DESCRIPTION
Adds a marker trait for `Signature` types computable as `S(H(m))` where:

- `S`: signature algorithm
- `H`: hash (a.k.a. digest) function
- `m`: message

For signature types that implement this trait, a blanket impl of `Signer` will be provided for all types that `impl signature::digest::Signer`.