### PR TITLE
signature v0.2.0

### DIFF
--- a/signature-crate/CHANGES.md
+++ b/signature-crate/CHANGES.md
@@ -1,3 +1,13 @@
-## 0.1.0 (2019-05-25)
+## [0.2.0] (2019-06-06)
+
+- `signature_derive`: Custom derive support for `Signer`/`Verifier` ([#18])
+- Have `DigestSigner`/`DigestVerifier` take `Digest` instance ([#17])
+
+## [0.1.0] (2019-05-25)
 
 - Initial release
+
+[0.2.0]: https://github.com/RustCrypto/signatures/pull/19
+[#18]: https://github.com/RustCrypto/signatures/pull/18
+[#17]: https://github.com/RustCrypto/signatures/pull/17
+[0.1.0]: https://github.com/RustCrypto/signatures/pull/15

--- a/signature-crate/Cargo.toml
+++ b/signature-crate/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name          = "signature"
-version       = "0.1.0"
+description   = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
+version       = "0.2.0" # Also update html_root_url in lib.rs when bumping this
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
-description   = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
 documentation = "https://docs.rs/signature"
 repository    = "https://github.com/RustCrypto/signatures/tree/master/signature-crate"
 readme        = "README.md"
@@ -13,7 +13,7 @@ categories    = ["cryptography", "no-std"]
 
 [dependencies]
 digest = { version = "0.8", optional = true, default-features = false }
-signature_derive = { version = "0", optional = true, path = "signature_derive" }
+signature_derive = { version = "0.2", optional = true, path = "signature_derive" }
 
 [dev-dependencies]
 hex-literal = "0.2"

--- a/signature-crate/signature_derive/Cargo.toml
+++ b/signature-crate/signature_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "signature_derive"
-version       = "0.0.0"
+version       = "0.2.0"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 description   = "Custom derive support for the 'signature' crate"

--- a/signature-crate/src/lib.rs
+++ b/signature-crate/src/lib.rs
@@ -3,7 +3,6 @@
 //! cryptography.
 
 #![no_std]
-#![cfg_attr(all(feature = "nightly", not(feature = "std")), feature(alloc))]
 #![deny(
     warnings,
     missing_docs,
@@ -13,6 +12,12 @@
     unused_import_braces,
     unused_qualifications
 )]
+#![doc(html_root_url = "https://docs.rs/signature/0.2.0")]
+
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+#[allow(unused_imports)] // rustc bug?
+#[macro_use]
+extern crate alloc;
 
 #[cfg(feature = "std")]
 #[macro_use]

--- a/signature-crate/src/prelude.rs
+++ b/signature-crate/src/prelude.rs
@@ -1,6 +1,5 @@
 //! Crate-local prelude (for alloc-dependent features like `Vec`)
 
-// TODO: switch to alloc::prelude
 #[cfg(all(feature = "alloc", not(feature = "std")))]
 pub use alloc::vec::Vec;
 


### PR DESCRIPTION
- `signature_derive`: Custom derive support for `Signer`/`Verifier` (#18)
- Have `DigestSigner`/`DigestVerifier` take `Digest` instance (#17)