### PR TITLE
signature v0.3.0

### DIFF
--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -10,4 +10,4 @@ categories = ["cryptography", "no-std"]
 keywords = ["crypto", "ecc", "ecdsa", "signature", "signing"]
 
 [dependencies]
-signature = { version = "0", path = "../signature-crate" }
+signature = { version = "0.3", path = "../signature-crate" }

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -11,7 +11,7 @@ categories    = ["cryptography", "no-std"]
 keywords      = ["crypto", "curve25519", "ecc", "signature", "signing"]
 
 [dependencies]
-signature = { version = "0", path = "../signature-crate", default-features = false }
+signature = { version = "0.3", path = "../signature-crate", default-features = false }
 
 [features]
 default = ["alloc"]

--- a/signature-crate/CHANGES.md
+++ b/signature-crate/CHANGES.md
@@ -1,13 +1,29 @@
-## [0.2.0] (2019-06-06)
+# Changelog
+All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.3.0 (2019-10-10)
+### Changed
+- Simplify alloc gating; MSRV 1.36+ ([#28])
+- Replace `DigestSignature` trait with `#[digest(...)]` attribute ([#27])
+- signature_derive: Upgrade to 1.x proc macro crates ([#26])
+
+[#28]: https://github.com/RustCrypto/signatures/pull/28
+[#27]: https://github.com/RustCrypto/signatures/pull/27
+[#26]: https://github.com/RustCrypto/signatures/pull/27
+
+## 0.2.0 (2019-06-06)
+### Added
 - `signature_derive`: Custom derive support for `Signer`/`Verifier` ([#18])
+
+### Changed
 - Have `DigestSigner`/`DigestVerifier` take `Digest` instance ([#17])
 
-## [0.1.0] (2019-05-25)
-
-- Initial release
-
-[0.2.0]: https://github.com/RustCrypto/signatures/pull/19
 [#18]: https://github.com/RustCrypto/signatures/pull/18
 [#17]: https://github.com/RustCrypto/signatures/pull/17
-[0.1.0]: https://github.com/RustCrypto/signatures/pull/15
+
+## 0.1.0 (2019-05-25)
+
+- Initial release

--- a/signature-crate/Cargo.toml
+++ b/signature-crate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "signature"
 description   = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
-version       = "0.2.0" # Also update html_root_url in lib.rs when bumping this
+version       = "0.3.0" # Also update html_root_url in lib.rs when bumping this
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/signature"
@@ -13,7 +13,7 @@ categories    = ["cryptography", "no-std"]
 
 [dependencies]
 digest = { version = "0.8", optional = true, default-features = false }
-signature_derive = { version = "0.2", optional = true, path = "signature_derive" }
+signature_derive = { version = "0.3", optional = true, path = "signature_derive" }
 
 [dev-dependencies]
 hex-literal = "0.2"

--- a/signature-crate/signature_derive/Cargo.toml
+++ b/signature-crate/signature_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "signature_derive"
-version       = "0.2.1"
+version       = "0.3.0"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 description   = "Custom derive support for the 'signature' crate"

--- a/signature-crate/src/error.rs
+++ b/signature-crate/src/error.rs
@@ -19,7 +19,13 @@ impl Error {
         Self::default()
     }
 
-    /// Create a new error from a cause
+    /// Create a new error with an associated cause.
+    ///
+    /// NOTE: The "cause" should NOT be used to propagate cryptographic errors
+    /// e.g. signature parsing or verification errors.
+    ///
+    /// The intended use cases are for propagating errors related to external
+    /// signers, e.g. communication/authentication errors with HSMs, KMS, etc.
     #[cfg(feature = "std")]
     pub fn from_cause<E>(cause: E) -> Self
     where


### PR DESCRIPTION
### Changed
- Simplify alloc gating; MSRV 1.36+ ([#28])
- Replace `DigestSignature` trait with `#[digest(...)]` attribute ([#27])
- signature_derive: Upgrade to 1.x proc macro crates ([#26])

[#28]: https://github.com/RustCrypto/signatures/pull/28
[#27]: https://github.com/RustCrypto/signatures/pull/27
[#26]: https://github.com/RustCrypto/signatures/pull/27