### PR TITLE
Revert removal of DigestSignature

### DIFF
--- a/signature-crate/signature_derive/src/lib.rs
+++ b/signature-crate/signature_derive/src/lib.rs
@@ -12,102 +12,96 @@ extern crate proc_macro;
 
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{Attribute, Meta, NestedMeta};
 use synstructure::{decl_derive, AddBounds};
-
-/// Name of the digest attribute
-const DIGEST_ATTRIBUTE_NAME: &str = "digest";
 
 /// Derive the `Signer` trait for `DigestSigner` types
 fn derive_signer(mut s: synstructure::Structure) -> TokenStream {
-    let digest_path = DigestAttribute::parse(&s).into_meta("Signer");
-
     s.add_bounds(AddBounds::None);
     s.gen_impl(quote! {
         gen impl<S> signature::Signer<S> for @Self
         where
-            S: Signature,
-            Self: signature::DigestSigner<#digest_path, S>
+            S: signature::DigestSignature,
+            Self: signature::DigestSigner<S::Digest, S>
         {
             fn try_sign(&self, msg: &[u8]) -> Result<S, signature::Error> {
-                self.try_sign_digest(#digest_path::new().chain(msg))
+                self.try_sign_digest(S::Digest::new().chain(msg))
             }
         }
     })
 }
-decl_derive!([Signer, attributes(digest)] => derive_signer);
+decl_derive!([Signer] => derive_signer);
 
 /// Derive the `Verifier` trait for `DigestVerifier` types
 fn derive_verifier(mut s: synstructure::Structure) -> TokenStream {
-    let digest_path = DigestAttribute::parse(&s).into_meta("Verifier");
-
     s.add_bounds(AddBounds::None);
     s.gen_impl(quote! {
         gen impl<S> signature::Verifier<S> for @Self
         where
-            S: Signature,
-            Self: signature::DigestVerifier<#digest_path, S>
+            S: signature::DigestSignature,
+            Self: signature::DigestVerifier<S::Digest, S>
         {
             fn verify(&self, msg: &[u8], signature: &S) -> Result<(), signature::Error> {
-                self.verify_digest(#digest_path::new().chain(msg), signature)
+                self.verify_digest(S::Digest::new().chain(msg), signature)
             }
         }
     })
 }
-decl_derive!([Verifier, attributes(digest)] => derive_verifier);
+decl_derive!([Verifier] => derive_verifier);
 
-/// The `#[digest(...)]` attribute passed to the proc macro
-#[derive(Default)]
-struct DigestAttribute {
-    digest: Option<Meta>,
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use synstructure::test_derive;
 
-impl DigestAttribute {
-    /// Parse attributes from the incoming AST
-    fn parse(s: &synstructure::Structure<'_>) -> Self {
-        let mut result = Self::default();
-
-        for v in s.variants().iter() {
-            for attr in v.ast().attrs.iter() {
-                result.parse_attr(attr);
-            }
-        }
-
-        result
-    }
-
-    /// Parse attribute and handle `#[digest(...)]` attribute
-    fn parse_attr(&mut self, attr: &Attribute) {
-        let meta = attr
-            .parse_meta()
-            .unwrap_or_else(|e| panic!("error parsing digest attribute: {:?} ({})", attr, e));
-
-        if let Meta::List(list) = meta {
-            if !list.path.is_ident(DIGEST_ATTRIBUTE_NAME) {
-                return;
-            }
-
-            for nested_meta in &list.nested {
-                if let NestedMeta::Meta(meta) = nested_meta {
-                    if self.digest.is_none() {
-                        self.digest = Some(meta.to_owned());
-                    } else {
-                        panic!("multiple digest attributes in custom derive");
-                    }
-                } else {
-                    panic!("malformed digest attribute: {:?}", nested_meta);
+    #[test]
+    fn signer() {
+        test_derive! {
+            derive_signer {
+                struct MySigner<C: EllipticCurve> {
+                    scalar: Scalar<C::ScalarSize>
                 }
             }
+            expands to {
+                #[allow(non_upper_case_globals)]
+                const _DERIVE_signature_Signer_S_FOR_MySigner: () = {
+                    impl<S, C: EllipticCurve> signature::Signer<S> for MySigner<C>
+                    where
+                        S: signature::DigestSignature,
+                        Self: signature::DigestSigner<S::Digest, S>
+                    {
+                        fn try_sign(&self, msg: &[u8]) -> Result <S, signature::Error> {
+                            self.try_sign_digest(S::Digest::new().chain(msg))
+                        }
+                    }
+                };
+            }
+            no_build // tests in `signature-crate/tests`
         }
     }
 
-    /// Convert parsed attributes into the recovered `Meta`
-    fn into_meta(self, trait_name: &str) -> Meta {
-        self.digest.unwrap_or_else(|| {
-            panic!(
-                "#[digest(...)] attribute is mandatory when deriving {}",
-                trait_name
-            )
-        })
+    #[test]
+    fn verifier() {
+        test_derive! {
+            derive_verifier {
+                struct MyVerifier<C: EllipticCurve> {
+                    point: UncompressedPoint<C>
+                }
+            }
+            expands to {
+                #[allow(non_upper_case_globals)]
+                const _DERIVE_signature_Verifier_S_FOR_MyVerifier: () = {
+                    impl<S, C: EllipticCurve> signature::Verifier<S> for MyVerifier<C>
+                    where
+                        S: signature::DigestSignature,
+                        Self: signature::DigestVerifier<S::Digest, S>
+                    {
+                        fn verify(&self, msg: &[u8], signature: &S) -> Result<(), signature::Error> {
+                            self.verify_digest(S::Digest::new().chain(msg), signature)
+                        }
+                    }
+                };
+            }
+            no_build // tests in `signature-crate/tests`
+        }
     }
 }

--- a/signature-crate/src/signature.rs
+++ b/signature-crate/src/signature.rs
@@ -22,3 +22,19 @@ pub trait Signature: AsRef<[u8]> + Debug + Sized {
         self.as_slice().into()
     }
 }
+
+/// Marker trait for `Signature` types computable as `S(H(m))`
+///
+/// - `S`: signature algorithm
+/// - `H`: hash (a.k.a. digest) function
+/// - `m`: message
+///
+/// For signature types that implement this trait, a blanket impl of
+/// `Signer` will be provided for all types that `impl DigestSigner`
+/// along with a corresponding impl of `Verifier` for all types that
+/// `impl DigestVerifier`.
+#[cfg(feature = "digest")]
+pub trait DigestSignature: Signature {
+    /// Preferred `Digest` algorithm to use when computing this signature type.
+    type Digest: digest::Digest;
+}

--- a/signature-crate/src/signature.rs
+++ b/signature-crate/src/signature.rs
@@ -29,10 +29,10 @@ pub trait Signature: AsRef<[u8]> + Debug + Sized {
 /// - `H`: hash (a.k.a. digest) function
 /// - `m`: message
 ///
-/// For signature types that implement this trait, a blanket impl of
-/// `Signer` will be provided for all types that `impl DigestSigner`
-/// along with a corresponding impl of `Verifier` for all types that
-/// `impl DigestVerifier`.
+/// For signature types that implement this trait, when the `signature_derive`
+/// Cargo feature is enabled a custom derive for `Signer` is available for any
+/// types that impl `DigestSigner`, and likewise for deriving `Verifier` for
+/// types which impl `DigestVerifier`.
 #[cfg(feature = "digest")]
 pub trait DigestSignature: Signature {
     /// Preferred `Digest` algorithm to use when computing this signature type.

--- a/signature-crate/tests/signature_derive.rs
+++ b/signature-crate/tests/signature_derive.rs
@@ -4,7 +4,9 @@ mod tests {
     use digest::{generic_array::GenericArray, Digest};
     use hex_literal::hex;
     use sha2::Sha256;
-    use signature::{DigestSigner, DigestVerifier, Error, Signature, Signer, Verifier};
+    use signature::{
+        DigestSignature, DigestSigner, DigestVerifier, Error, Signature, Signer, Verifier,
+    };
 
     /// Test vector to compute SHA-256 digest of
     const INPUT_STRING: &[u8] = b"abc";
@@ -31,9 +33,12 @@ mod tests {
         }
     }
 
+    impl DigestSignature for DummySignature {
+        type Digest = Sha256;
+    }
+
     /// Dummy signer which just returns the message digest as a `DummySignature`
     #[derive(Signer, Default)]
-    #[digest(Sha256)]
     struct DummySigner {}
 
     impl DigestSigner<Sha256, DummySignature> for DummySigner {
@@ -47,7 +52,6 @@ mod tests {
     ///
     /// Panics (via `assert_eq!`) if the value is not what is expected.
     #[derive(Verifier, Default)]
-    #[digest(Sha256)]
     struct DummyVerifier {}
 
     impl DigestVerifier<Sha256, DummySignature> for DummyVerifier {


### PR DESCRIPTION
This reverts the changes from #27 to replace `DigestSignature` with a custom derive attribute: `#[digest(...)]`

After updating my downstream consumers of this crate to try to use this functionality, I encountered an important case where this falls down: deriving `Signer` and `Verifier` on generic types where the `Digest` *can only* be generically specified as an associated type, as the `yubihsm` crate is doing here:

https://github.com/tendermint/yubihsm-rs/blob/develop/src/ecdsa/signer.rs#L22

The goal of switching to a derive attribute was to make this functionality more flexible and eliminate the need for a marker trait, but in this particular case (one I personally consider very important) it had the opposite effect.