### PR TITLE
ed25519 1.0.0-pre.0

### DIFF
--- a/ed25519/CHANGES.md
+++ b/ed25519/CHANGES.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.0-pre.0 (2019-10-11)
+### Changed
+- Upgrade to `signature` 1.0.0-pre.0 ([#34])
+
+[#34]: https://github.com/RustCrypto/signatures/pull/34
+
 ## 0.2.0 (2019-10-10)
 ### Changed
 - Upgrade to `signature` v0.3; MSRV 1.36+ ([#29])

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ed25519"
-version       = "0.2.0"
+version       = "1.0.0-pre.0"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 description   = "Edwards Digital Signature Algorithm (EdDSA) over Curve25519 (as specified in RFC 8032)"

--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -16,7 +16,7 @@
 #![no_std]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
-#![doc(html_root_url = "https://docs.rs/ed25519/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/ed25519/1.0.0-pre.0")]
 
 /// Re-export the `signature` crate
 pub use signature::{self, Error};


### PR DESCRIPTION
### Changed
- Upgrade to `signature` 1.0.0-pre.0 ([#34])

[#34]: https://github.com/RustCrypto/signatures/pull/34