### PR TITLE
signature: Use `Error::source` instead of `::cause`

### DIFF
--- a/signature-crate/src/lib.rs
+++ b/signature-crate/src/lib.rs
@@ -19,9 +19,9 @@
 //!   version bump.
 
 #![no_std]
+#![doc(html_root_url = "https://docs.rs/signature/1.0.0-pre.0")]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
-#![doc(html_root_url = "https://docs.rs/signature/1.0.0-pre.0")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;


### PR DESCRIPTION
This upgrades to the `std::error::Error` features for boxed, downcastable error sources introduced in Rust 1.30, namely switching from `Error::cause` to `Error::source`, which adds a `'static` bound and
therefore allows it to support downcasting.

Additionally, it defines a `BoxError` type incorporating those bounds along with `Send + Sync`, ensuring that `signature::Error` itself is `Send + Sync`, which should improve the ergonomics.