### PR TITLE
signature: Remove `alloc` feature; MSRV 1.31+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: rust
 cache: cargo
 
 rust:
-  - 1.36.0
+  - 1.31.0
   - stable
   - beta
   - nightly

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ for bare-metal or WebAssembly programming.
 
 ## Minimum Supported Rust Version
 
-All crates in this repository support Rust **1.36** or higher. In future minimum
+All crates in this repository support Rust **1.31** or higher. In future minimum
 supported Rust version can be changed, but it will be done with the minor
 version bump.
 
@@ -51,7 +51,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-link]: https://travis-ci.org/RustCrypto/signatures
 [deps-image]: https://deps.rs/repo/github/RustCrypto/signatures/status.svg
 [deps-link]: https://deps.rs/repo/github/RustCrypto/signatures
-[rustc-image]: https://img.shields.io/badge/rustc-1.36+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.31+-blue.svg
 
 [//]: # (general links)
 

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -13,7 +13,3 @@ keywords      = ["crypto", "curve25519", "ecc", "signature", "signing"]
 
 [dependencies]
 signature = { version = "1.0.0-pre.0", path = "../signature-crate", default-features = false }
-
-[features]
-default = ["alloc"]
-alloc = ["signature/alloc"]

--- a/ed25519/README.md
+++ b/ed25519/README.md
@@ -23,7 +23,7 @@ Ed25519 implementations, including HSMs or Cloud KMS services.
 
 ## Requirements
 
-- Rust **1.36+**
+- Rust **1.31+**
 
 ## License
 
@@ -47,7 +47,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/ed25519/badge.svg
 [docs-link]: https://docs.rs/ed25519/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.36+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.31+-blue.svg
 [build-image]: https://travis-ci.org/RustCrypto/signatures.svg?branch=master
 [build-link]: https://travis-ci.org/RustCrypto/signatures
 

--- a/signature-crate/Cargo.toml
+++ b/signature-crate/Cargo.toml
@@ -21,10 +21,9 @@ sha2 = { version = "0.8", default-features = false }
 
 [features]
 default = ["std"]
-alloc = []
 derive-preview = ["digest-preview", "signature_derive"]
 digest-preview = ["digest"]
-std = ["alloc"]
+std = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/signature-crate/README.md
+++ b/signature-crate/README.md
@@ -16,7 +16,7 @@ Support is also planned for the [`ecdsa`][3] and [`rsa`][4] crates.
 
 ## Minimum Supported Rust Version
 
-All crates in this repository support Rust **1.36** or higher.
+All crates in this repository support Rust **1.31** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -52,7 +52,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/signature/badge.svg
 [docs-link]: https://docs.rs/signature/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.36+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.31+-blue.svg
 [build-image]: https://travis-ci.org/RustCrypto/signatures.svg?branch=master
 [build-link]: https://travis-ci.org/RustCrypto/signatures
 

--- a/signature-crate/src/lib.rs
+++ b/signature-crate/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust **1.36** or higher.
+//! Rust **1.31** or higher.
 //!
 //! Minimum supported Rust version can be changed in the future, but it will be
 //! done with a minor version bump.
@@ -22,9 +22,6 @@
 #![doc(html_root_url = "https://docs.rs/signature/1.0.0-pre.0")]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
-
-#[cfg(feature = "alloc")]
-extern crate alloc;
 
 #[cfg(feature = "std")]
 #[macro_use]

--- a/signature-crate/src/signature.rs
+++ b/signature-crate/src/signature.rs
@@ -1,8 +1,7 @@
-use core::fmt::Debug;
+//! Signature traits
 
 use crate::error::Error;
-#[cfg(feature = "alloc")]
-use alloc::vec::Vec;
+use core::fmt::Debug;
 
 /// Trait impl'd by concrete types that represent digital signatures
 pub trait Signature: AsRef<[u8]> + Debug + Sized {
@@ -13,13 +12,6 @@ pub trait Signature: AsRef<[u8]> + Debug + Sized {
     #[inline]
     fn as_slice(&self) -> &[u8] {
         self.as_ref()
-    }
-
-    /// Convert this signature into a byte vector
-    #[cfg(feature = "alloc")]
-    #[inline]
-    fn into_vec(self) -> Vec<u8> {
-        self.as_slice().into()
     }
 }
 


### PR DESCRIPTION
The only thing the `signature` crate uses `alloc` for is the `Signature::to_vec` method, which is trivially accomplished otherwise as `sig.as_ref().to_vec()` or various other ways.

By getting rid of it, we can completely get rid of the `alloc` feature, and with that reduce the MSRV back to 1.31.

It might be worth considering a 1.0 release with a higher MSRV so we can leverage `TryFrom`, but for now, this provides wider compatibility by removing a single (mis)feature.