### PR TITLE
ed25519: optional serde support

### DIFF
--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -11,5 +11,12 @@ readme        = "README.md"
 categories    = ["cryptography", "no-std"]
 keywords      = ["crypto", "curve25519", "ecc", "signature", "signing"]
 
-[dependencies]
-signature = { version = "1.0.0-pre.0", path = "../signature-crate", default-features = false }
+[dependencies.signature]
+version = "1.0.0-pre.0"
+path = "../signature-crate"
+default-features = false
+
+[dependencies.serde]
+version = "1"
+optional = true
+default-features = false


### PR DESCRIPTION
Serializes and deserializes Ed25519 signatures as 64-byte "octet strings"