### PR TITLE
signature 1.0.0-pre.1

### DIFF
--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -10,4 +10,4 @@ categories = ["cryptography", "no-std"]
 keywords = ["crypto", "ecc", "ecdsa", "signature", "signing"]
 
 [dependencies]
-signature = { version = "1.0.0-pre.0", path = "../signature-crate" }
+signature = { version = "1.0.0-pre.1", path = "../signature-crate" }

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -12,7 +12,7 @@ categories    = ["cryptography", "no-std"]
 keywords      = ["crypto", "curve25519", "ecc", "signature", "signing"]
 
 [dependencies.signature]
-version = "1.0.0-pre.0"
+version = "1.0.0-pre.1"
 path = "../signature-crate"
 default-features = false
 

--- a/signature-crate/CHANGES.md
+++ b/signature-crate/CHANGES.md
@@ -4,9 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.0-pre.1 (2019-10-27)
+### Changed
+- Use `Error::source` instead of `::cause` ([#37])
+
+### Removed
+- Remove `alloc` feature; MSRV 1.34+ ([#38])
+
+[#38]: https://github.com/RustCrypto/signatures/pull/38
+[#37]: https://github.com/RustCrypto/signatures/pull/37
+
 ## 1.0.0-pre.0 (2019-10-11)
 ### Changed
-- Revert removal of DigestSignature ([#33])
+- Revert removal of `DigestSignature` ([#33])
 - 1.0 stabilization proposal ([#32])
 
 [#33]: https://github.com/RustCrypto/signatures/pull/33

--- a/signature-crate/Cargo.toml
+++ b/signature-crate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "signature"
 description   = "Traits for cryptographic signature algorithms (e.g. ECDSA, Ed25519)"
-version       = "1.0.0-pre.0" # Also update html_root_url in lib.rs when bumping this
+version       = "1.0.0-pre.1" # Also update html_root_url in lib.rs when bumping this
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/signature"
@@ -11,9 +11,15 @@ edition       = "2018"
 keywords      = ["crypto", "ecdsa", "ed25519", "signature", "signing"]
 categories    = ["cryptography", "no-std"]
 
-[dependencies]
-digest = { version = "0.8", optional = true, default-features = false }
-signature_derive = { version = "1.0.0-pre.0", optional = true, path = "signature_derive" }
+[dependencies.digest]
+version = "0.8"
+optional = true
+default-features = false
+
+[dependencies.signature_derive]
+version = "1.0.0-pre.0"
+optional = true
+path = "signature_derive"
 
 [dev-dependencies]
 hex-literal = "0.2"

--- a/signature-crate/src/lib.rs
+++ b/signature-crate/src/lib.rs
@@ -23,7 +23,7 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png",
-    html_root_url = "https://docs.rs/ed25519/1.0.0-pre.0"
+    html_root_url = "https://docs.rs/signature/1.0.0-pre.1"
 )]
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
### Changed
- Use `Error::source` instead of `::cause` ([#37])

### Removed
- Remove `alloc` feature; MSRV 1.34+ ([#38])

[#38]: https://github.com/RustCrypto/signatures/pull/38
[#37]: https://github.com/RustCrypto/signatures/pull/37