### PR TITLE
ed25519 v1.0.0-pre.1

### DIFF
--- a/ed25519/CHANGES.md
+++ b/ed25519/CHANGES.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.0-pre.1 (2019-10-11)
+### Added
+- Optional `serde` support ([#40])
+- Add `TryFrom` impl for `Signature` ([#39])
+
+### Changed
+- Upgrade to `signature` 1.0.0-pre.1 ([#41])
+
+[#41]: https://github.com/RustCrypto/signatures/pull/41
+[#40]: https://github.com/RustCrypto/signatures/pull/40
+[#39]: https://github.com/RustCrypto/signatures/pull/39
+
 ## 1.0.0-pre.0 (2019-10-11)
 ### Changed
 - Upgrade to `signature` 1.0.0-pre.0 ([#34])

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ed25519"
-version       = "1.0.0-pre.0"
+version       = "1.0.0-pre.1"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 description   = "Edwards Digital Signature Algorithm (EdDSA) over Curve25519 (as specified in RFC 8032)"

--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -18,7 +18,7 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png",
-    html_root_url = "https://docs.rs/ed25519/1.0.0-pre.0"
+    html_root_url = "https://docs.rs/ed25519/1.0.0-pre.1"
 )]
 
 #[cfg(feature = "serde")]


### PR DESCRIPTION
### Added
- Optional `serde` support ([#40])
- Add `TryFrom` impl for `Signature` ([#39])

### Changed
- Upgrade to `signature` 1.0.0-pre.1 ([#41])

[#41]: https://github.com/RustCrypto/signatures/pull/41
[#40]: https://github.com/RustCrypto/signatures/pull/40
[#39]: https://github.com/RustCrypto/signatures/pull/39