### PR TITLE
ecdsa: Initial curves (NIST P-256/384, secp256k1)

### DIFF
--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,13 +1,15 @@
 [package]
-name = "ecdsa"
-version = "0.0.0"
-authors = ["RustCrypto Developers"]
-license = "Apache-2.0 OR MIT"
-description = "Elliptic Curve Digital Signature Algorithm"
+name          = "ecdsa"
+version       = "0.0.0"
+authors       = ["RustCrypto Developers"]
+license       = "Apache-2.0 OR MIT"
+description   = "Elliptic Curve Digital Signature Algorithm"
 documentation = "https://docs.rs/ecdsa"
-repository = "https://github.com/RustCrypto/signatures"
-categories = ["cryptography", "no-std"]
-keywords = ["crypto", "ecc", "ecdsa", "signature", "signing"]
+repository    = "https://github.com/RustCrypto/signatures"
+edition       = "2018"
+categories    = ["cryptography", "no-std"]
+keywords      = ["crypto", "ecc", "ecdsa", "signature", "signing"]
 
 [dependencies]
-signature = { version = "1.0.0-pre.1", path = "../signature-crate" }
+generic-array = { version = "0.12", default-features = false }
+signature     = { version = "1.0.0-pre.1", path = "../signature-crate" }

--- a/ecdsa/src/curve.rs
+++ b/ecdsa/src/curve.rs
@@ -1,0 +1,72 @@
+//! Elliptic curves used by ECDSA
+
+use generic_array::{
+    typenum::{U32, U48},
+    ArrayLength,
+};
+
+/// Elliptic curve in short Weierstrass form suitable for use with ECDSA
+pub trait Curve {
+    /// Size of an integer modulo p (i.e. the curve's order) when serialized
+    /// as octets (i.e. bytes). This also describes the size of an ECDSA
+    /// private key, as well as half the size of a fixed-width signature.
+    type ScalarSize: ArrayLength<u8>;
+}
+
+/// The NIST P-256 elliptic curve: y² = x³ - 3x + b over a ~256-bit prime field
+/// where b is "verifiably random"† constant:
+///
+/// b = 41058363725152142129326129780047268409114441015993725554835256314039467401291
+///
+/// † NOTE: the specific origins of this constant have never been fully disclosed
+///   (it is the SHA-1 digest of an inexplicable NSA-selected constant)
+///
+/// NIST P-256 is also known as prime256v1 (ANSI X9.62) and secp256r1 (SECG)
+/// and is specified in FIPS 186-4: Digital Signature Standard (DSS):
+///
+/// <https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf>
+///
+/// This curve is part of the US National Security Agency's "Suite B" and
+/// and is widely used in protocols like TLS and the associated X.509 PKI.
+pub struct NistP256;
+
+impl Curve for NistP256 {
+    /// 256-bit (32-byte) private scalar
+    type ScalarSize = U32;
+}
+
+/// The NIST P-384 elliptic curve: y² = x³ - 3x + b over a ~384-bit prime field
+/// where b is "verifiably random"† constant:
+///
+/// b = 2758019355995970587784901184038904809305690585636156852142
+///     8707301988689241309860865136260764883745107765439761230575
+///
+/// † NOTE: the specific origins of this constant have never been fully disclosed
+///   (it is the SHA-1 digest of an inexplicable NSA-selected constant)
+///
+/// NIST P-384 is also known as secp384r1 (SECG) and is specified in
+/// FIPS 186-4: Digital Signature Standard (DSS):
+///
+/// <https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf>
+///
+/// This curve is part of the US National Security Agency's "Suite B" and
+/// and is widely used in protocols like TLS and the associated X.509 PKI.
+pub struct NistP384;
+
+impl Curve for NistP384 {
+    /// Random 384-bit (48-byte) private scalar
+    type ScalarSize = U48;
+}
+
+/// The secp256k1 elliptic curve: y² = x³ + 7 over a ~256-bit prime field.
+/// Specified in Certicom's SECG in SEC 2: Recommended Elliptic Curve Domain Parameters:
+///
+/// <http://www.secg.org/sec2-v2.pdf>
+///
+/// This curve is most notable for its use in Bitcoin and other cryptocurrencies.
+pub struct Secp256k1;
+
+impl Curve for Secp256k1 {
+    /// Random 256-bit (32-byte) private scalar
+    type ScalarSize = U32;
+}

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -1,1 +1,12 @@
-#![crate_name = "ecdsa"]
+//! Elliptic Curve Digital Signature Algorithm (ECDSA) as specified in
+//! [FIPS 186-4] (Digital Signature Standard)
+
+#![no_std]
+#![forbid(unsafe_code)]
+#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png",
+    html_root_url = "https://docs.rs/ecdsa/0.0.0"
+)]
+
+pub mod curve;


### PR DESCRIPTION
Adds a `Curve` trait representing short Weirstrass curves suitable for use with ECDSA, along with an initial set of curves and their associated private scalar size.