### PR TITLE
.travis.yml: Test all crates for no_std and WASM compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,12 @@ matrix:
   include:
     - name: "Rust: stable (thumbv7em-none-eabihf)"
       rust: stable
-      install: rustup target add thumbv7em-none-eabihf
-      script: cd signature-crate && cargo build --target thumbv7em-none-eabihf --no-default-features --release
+      install: rustup target add thumbv7em-none-eabi
+      script: ./build_nostd.sh
     - name: "Rust: stable (wasm32-unknown-unknown)"
       rust: stable
       install: rustup target add wasm32-unknown-unknown
-      script: cd signature-crate && cargo build --target wasm32-unknown-unknown --no-default-features --release
+      script: ./build_wasm.sh
     - name: rustfmt
       rust: stable
       install: rustup component add rustfmt

--- a/build_nostd.sh
+++ b/build_nostd.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -eux
+
+# Due to the fact that cargo does not disable default features when we use
+# cargo build --all --no-default-features we have to explicitly iterate over
+# all crates (see https://github.com/rust-lang/cargo/issues/4753 )
+DIRS=`ls -d */`
+TARGET="thumbv7em-none-eabi"
+
+for dir in $DIRS; do
+    if [ $dir = "target/" ]
+    then
+        continue
+    fi
+    cd $dir
+    cargo build --no-default-features --verbose --target $TARGET --release || {
+        echo $dir failed
+        exit 1
+    }
+    cd -
+done

--- a/build_wasm.sh
+++ b/build_wasm.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -eux
+
+# Due to the fact that cargo does not disable default features when we use
+# cargo build --all --no-default-features we have to explicitly iterate over
+# all crates (see https://github.com/rust-lang/cargo/issues/4753 )
+DIRS=`ls -d */`
+TARGET="wasm32-unknown-unknown"
+
+for dir in $DIRS; do
+    if [ $dir = "target/" ]
+    then
+        continue
+    fi
+    cd $dir
+    cargo build --verbose --target $TARGET --release || {
+        echo $dir failed
+        exit 1
+    }
+    cd -
+done

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -10,6 +10,16 @@ edition       = "2018"
 categories    = ["cryptography", "no-std"]
 keywords      = ["crypto", "ecc", "ecdsa", "signature", "signing"]
 
-[dependencies]
-generic-array = { version = "0.12", default-features = false }
-signature     = { version = "1.0.0-pre.1", path = "../signature-crate" }
+[dependencies.generic-array]
+version = "0.12"
+default-features = false
+
+[dependencies.signature]
+version = "1.0.0-pre.1"
+path = "../signature-crate"
+default-features = false
+
+[features]
+default = ["std"]
+std = ["signature/std"]
+

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -20,3 +20,7 @@ default-features = false
 version = "1"
 optional = true
 default-features = false
+
+[features]
+default = ["std"]
+std = ["signature/std"]


### PR DESCRIPTION
Previously only the `signature` crate was being tested