### PR TITLE
ecdsa: Add FixedSignature type

### DIFF
--- a/ecdsa/src/curve.rs
+++ b/ecdsa/src/curve.rs
@@ -1,72 +1,17 @@
 //! Elliptic curves used by ECDSA
 
-use generic_array::{
-    typenum::{U32, U48},
-    ArrayLength,
-};
+pub mod nistp256;
+pub mod nistp384;
+pub mod secp256k1;
+
+pub use self::{nistp256::NistP256, nistp384::NistP384, secp256k1::Secp256k1};
+
+use core::{fmt::Debug, ops::Add};
 
 /// Elliptic curve in short Weierstrass form suitable for use with ECDSA
-pub trait Curve {
+pub trait Curve: Debug + Default + Send + Sync {
     /// Size of an integer modulo p (i.e. the curve's order) when serialized
     /// as octets (i.e. bytes). This also describes the size of an ECDSA
     /// private key, as well as half the size of a fixed-width signature.
-    type ScalarSize: ArrayLength<u8>;
-}
-
-/// The NIST P-256 elliptic curve: y² = x³ - 3x + b over a ~256-bit prime field
-/// where b is "verifiably random"† constant:
-///
-/// b = 41058363725152142129326129780047268409114441015993725554835256314039467401291
-///
-/// † NOTE: the specific origins of this constant have never been fully disclosed
-///   (it is the SHA-1 digest of an inexplicable NSA-selected constant)
-///
-/// NIST P-256 is also known as prime256v1 (ANSI X9.62) and secp256r1 (SECG)
-/// and is specified in FIPS 186-4: Digital Signature Standard (DSS):
-///
-/// <https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf>
-///
-/// This curve is part of the US National Security Agency's "Suite B" and
-/// and is widely used in protocols like TLS and the associated X.509 PKI.
-pub struct NistP256;
-
-impl Curve for NistP256 {
-    /// 256-bit (32-byte) private scalar
-    type ScalarSize = U32;
-}
-
-/// The NIST P-384 elliptic curve: y² = x³ - 3x + b over a ~384-bit prime field
-/// where b is "verifiably random"† constant:
-///
-/// b = 2758019355995970587784901184038904809305690585636156852142
-///     8707301988689241309860865136260764883745107765439761230575
-///
-/// † NOTE: the specific origins of this constant have never been fully disclosed
-///   (it is the SHA-1 digest of an inexplicable NSA-selected constant)
-///
-/// NIST P-384 is also known as secp384r1 (SECG) and is specified in
-/// FIPS 186-4: Digital Signature Standard (DSS):
-///
-/// <https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf>
-///
-/// This curve is part of the US National Security Agency's "Suite B" and
-/// and is widely used in protocols like TLS and the associated X.509 PKI.
-pub struct NistP384;
-
-impl Curve for NistP384 {
-    /// Random 384-bit (48-byte) private scalar
-    type ScalarSize = U48;
-}
-
-/// The secp256k1 elliptic curve: y² = x³ + 7 over a ~256-bit prime field.
-/// Specified in Certicom's SECG in SEC 2: Recommended Elliptic Curve Domain Parameters:
-///
-/// <http://www.secg.org/sec2-v2.pdf>
-///
-/// This curve is most notable for its use in Bitcoin and other cryptocurrencies.
-pub struct Secp256k1;
-
-impl Curve for Secp256k1 {
-    /// Random 256-bit (32-byte) private scalar
-    type ScalarSize = U32;
+    type ScalarSize: Add;
 }

--- a/ecdsa/src/curve/nistp256.rs
+++ b/ecdsa/src/curve/nistp256.rs
@@ -1,0 +1,30 @@
+//! NIST P-256 elliptic curve (a.k.a. prime256v1, secp256r1)
+
+use super::Curve;
+use generic_array::typenum::U32;
+
+/// The NIST P-256 elliptic curve: y² = x³ - 3x + b over a ~256-bit prime field
+/// where b is "verifiably random"† constant:
+///
+/// b = 41058363725152142129326129780047268409114441015993725554835256314039467401291
+///
+/// † NOTE: the specific origins of this constant have never been fully disclosed
+///   (it is the SHA-1 digest of an inexplicable NSA-selected constant)
+///
+/// NIST P-256 is also known as prime256v1 (ANSI X9.62) and secp256r1 (SECG)
+/// and is specified in FIPS 186-4: Digital Signature Standard (DSS):
+///
+/// <https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf>
+///
+/// This curve is part of the US National Security Agency's "Suite B" and
+/// and is widely used in protocols like TLS and the associated X.509 PKI.
+#[derive(Debug, Default)]
+pub struct NistP256;
+
+impl Curve for NistP256 {
+    /// 256-bit (32-byte) private scalar
+    type ScalarSize = U32;
+}
+
+/// Fixed-sized (a.k.a. "raw") NIST P-256 ECDSA signature
+pub type FixedSignature = crate::fixed_signature::FixedSignature<NistP256>;

--- a/ecdsa/src/curve/nistp384.rs
+++ b/ecdsa/src/curve/nistp384.rs
@@ -1,0 +1,31 @@
+//! NIST P-384 elliptic curve (a.k.a. secp384r1)
+
+use super::Curve;
+use generic_array::typenum::U48;
+
+/// The NIST P-384 elliptic curve: y² = x³ - 3x + b over a ~384-bit prime field
+/// where b is "verifiably random"† constant:
+///
+/// b = 2758019355995970587784901184038904809305690585636156852142
+///     8707301988689241309860865136260764883745107765439761230575
+///
+/// † NOTE: the specific origins of this constant have never been fully disclosed
+///   (it is the SHA-1 digest of an inexplicable NSA-selected constant)
+///
+/// NIST P-384 is also known as secp384r1 (SECG) and is specified in
+/// FIPS 186-4: Digital Signature Standard (DSS):
+///
+/// <https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf>
+///
+/// This curve is part of the US National Security Agency's "Suite B" and
+/// and is widely used in protocols like TLS and the associated X.509 PKI.
+#[derive(Debug, Default)]
+pub struct NistP384;
+
+impl Curve for NistP384 {
+    /// 384-bit (48-byte) private scalar
+    type ScalarSize = U48;
+}
+
+/// Fixed-sized (a.k.a. "raw") NIST P-384 ECDSA signature
+pub type FixedSignature = crate::fixed_signature::FixedSignature<NistP384>;

--- a/ecdsa/src/curve/secp256k1.rs
+++ b/ecdsa/src/curve/secp256k1.rs
@@ -1,0 +1,21 @@
+//! secp256k1 elliptic curve
+
+use super::Curve;
+use generic_array::typenum::U32;
+
+/// The secp256k1 elliptic curve: y² = x³ + 7 over a ~256-bit prime field.
+/// Specified in Certicom's SECG in SEC 2: Recommended Elliptic Curve Domain Parameters:
+///
+/// <http://www.secg.org/sec2-v2.pdf>
+///
+/// This curve is most notable for its use in Bitcoin and other cryptocurrencies.
+#[derive(Debug, Default)]
+pub struct Secp256k1;
+
+impl Curve for Secp256k1 {
+    /// 256-bit (32-byte) private scalar
+    type ScalarSize = U32;
+}
+
+/// Fixed-sized (a.k.a. "raw") secp256k1 ECDSA signature
+pub type FixedSignature = crate::fixed_signature::FixedSignature<Secp256k1>;

--- a/ecdsa/src/fixed_signature.rs
+++ b/ecdsa/src/fixed_signature.rs
@@ -1,0 +1,63 @@
+//! Fixed-sized (a.k.a. "raw") ECDSA signatures
+
+use crate::curve::Curve;
+use core::{fmt, ops::Add};
+use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
+use signature::Error;
+
+/// Size of a fixed sized signature: double that of the scalar size
+// TODO(tarcieri): use typenum's `Double` op or switch to const generics
+pub type FixedSignatureSize<C> =
+    <<C as Curve>::ScalarSize as Add<<C as Curve>::ScalarSize>>::Output;
+
+/// Fixed-sized (a.k.a. "raw") ECDSA signatures: serialized as fixed-sized
+/// big endian scalar values with no additional framing.
+#[derive(Clone, Eq, PartialEq)]
+pub struct FixedSignature<C>
+where
+    C: Curve,
+    FixedSignatureSize<C>: ArrayLength<u8>,
+{
+    bytes: GenericArray<u8, FixedSignatureSize<C>>,
+}
+
+impl<C> signature::Signature for FixedSignature<C>
+where
+    C: Curve,
+    FixedSignatureSize<C>: ArrayLength<u8>,
+{
+    fn from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, Error> {
+        if bytes.as_ref().len() == <FixedSignatureSize<C>>::to_usize() {
+            Ok(Self {
+                bytes: GenericArray::clone_from_slice(bytes.as_ref()),
+            })
+        } else {
+            Err(Error::new())
+        }
+    }
+}
+
+impl<C> AsRef<[u8]> for FixedSignature<C>
+where
+    C: Curve,
+    FixedSignatureSize<C>: ArrayLength<u8>,
+{
+    fn as_ref(&self) -> &[u8] {
+        self.bytes.as_slice()
+    }
+}
+
+impl<C> fmt::Debug for FixedSignature<C>
+where
+    C: Curve,
+    FixedSignatureSize<C>: ArrayLength<u8>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "FixedSignature<{:?}> {{ bytes: {:?}) }}",
+            C::default(),
+            self.as_ref()
+        )
+    }
+}

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -9,4 +9,9 @@
     html_root_url = "https://docs.rs/ecdsa/0.0.0"
 )]
 
+pub use signature;
+
 pub mod curve;
+mod fixed_signature;
+
+pub use self::{curve::Curve, fixed_signature::FixedSignature};


### PR DESCRIPTION
Type for representing fixed-sized (a.k.a. "raw") ECDSA signatures