### PR TITLE
ecdsa: Reorganize size-related trait bounds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ script:
   - cd signature-crate && cargo build --no-default-features --release
 
 matrix:
+  fast_finish: true
   allow_failures:
     - rust: nightly
   include:

--- a/ecdsa/src/curve.rs
+++ b/ecdsa/src/curve.rs
@@ -6,12 +6,12 @@ pub mod secp256k1;
 
 pub use self::{nistp256::NistP256, nistp384::NistP384, secp256k1::Secp256k1};
 
-use core::{fmt::Debug, ops::Add};
+use core::fmt::Debug;
 
 /// Elliptic curve in short Weierstrass form suitable for use with ECDSA
 pub trait Curve: Debug + Default + Send + Sync {
     /// Size of an integer modulo p (i.e. the curve's order) when serialized
     /// as octets (i.e. bytes). This also describes the size of an ECDSA
     /// private key, as well as half the size of a fixed-width signature.
-    type ScalarSize: Add;
+    type ScalarSize;
 }

--- a/ecdsa/src/fixed_signature.rs
+++ b/ecdsa/src/fixed_signature.rs
@@ -7,8 +7,7 @@ use signature::Error;
 
 /// Size of a fixed sized signature: double that of the scalar size
 // TODO(tarcieri): use typenum's `Double` op or switch to const generics
-pub type FixedSignatureSize<C> =
-    <<C as Curve>::ScalarSize as Add<<C as Curve>::ScalarSize>>::Output;
+pub type Size<ScalarSize> = <ScalarSize as Add<ScalarSize>>::Output;
 
 /// Fixed-sized (a.k.a. "raw") ECDSA signatures: serialized as fixed-sized
 /// big endian scalar values with no additional framing.
@@ -16,18 +15,20 @@ pub type FixedSignatureSize<C> =
 pub struct FixedSignature<C>
 where
     C: Curve,
-    FixedSignatureSize<C>: ArrayLength<u8>,
+    C::ScalarSize: Add<C::ScalarSize>,
+    Size<C::ScalarSize>: ArrayLength<u8>,
 {
-    bytes: GenericArray<u8, FixedSignatureSize<C>>,
+    bytes: GenericArray<u8, Size<C::ScalarSize>>,
 }
 
 impl<C> signature::Signature for FixedSignature<C>
 where
     C: Curve,
-    FixedSignatureSize<C>: ArrayLength<u8>,
+    C::ScalarSize: Add<C::ScalarSize>,
+    Size<C::ScalarSize>: ArrayLength<u8>,
 {
     fn from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, Error> {
-        if bytes.as_ref().len() == <FixedSignatureSize<C>>::to_usize() {
+        if bytes.as_ref().len() == <Size<C::ScalarSize>>::to_usize() {
             Ok(Self {
                 bytes: GenericArray::clone_from_slice(bytes.as_ref()),
             })
@@ -40,7 +41,8 @@ where
 impl<C> AsRef<[u8]> for FixedSignature<C>
 where
     C: Curve,
-    FixedSignatureSize<C>: ArrayLength<u8>,
+    C::ScalarSize: Add<C::ScalarSize>,
+    Size<C::ScalarSize>: ArrayLength<u8>,
 {
     fn as_ref(&self) -> &[u8] {
         self.bytes.as_slice()
@@ -50,7 +52,8 @@ where
 impl<C> fmt::Debug for FixedSignature<C>
 where
     C: Curve,
-    FixedSignatureSize<C>: ArrayLength<u8>,
+    C::ScalarSize: Add<C::ScalarSize>,
+    Size<C::ScalarSize>: ArrayLength<u8>,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(


### PR DESCRIPTION
Moves all trait bounds related to `FixedSignature` from the `Curve` trait to the `FixedSignature` type.

This avoids compounding the complexity of the trait bounds on `Curve` when ASN.1 DER signatures are added.