### PR TITLE
ecdsa: Add `DigestSignature` impls

### DIFF
--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -14,12 +14,18 @@ keywords      = ["crypto", "ecc", "ecdsa", "signature", "signing"]
 version = "0.12"
 default-features = false
 
+[dependencies.sha2]
+version = "0.8"
+optional = true
+default-features = false
+
 [dependencies.signature]
 version = "1.0.0-pre.1"
 path = "../signature-crate"
 default-features = false
 
 [features]
-default = ["std"]
+default = ["digest", "std"]
+digest = ["signature/digest-preview", "sha2"]
 std = ["signature/std"]
 

--- a/ecdsa/src/curve/nistp256.rs
+++ b/ecdsa/src/curve/nistp256.rs
@@ -31,3 +31,13 @@ pub type Asn1Signature = crate::Asn1Signature<NistP256>;
 
 /// Fixed-sized (a.k.a. "raw") NIST P-256 ECDSA signature
 pub type FixedSignature = crate::FixedSignature<NistP256>;
+
+#[cfg(feature = "digest")]
+impl signature::DigestSignature for Asn1Signature {
+    type Digest = sha2::Sha256;
+}
+
+#[cfg(feature = "digest")]
+impl signature::DigestSignature for FixedSignature {
+    type Digest = sha2::Sha256;
+}

--- a/ecdsa/src/curve/nistp384.rs
+++ b/ecdsa/src/curve/nistp384.rs
@@ -32,3 +32,13 @@ pub type Asn1Signature = crate::Asn1Signature<NistP384>;
 
 /// Fixed-sized (a.k.a. "raw") NIST P-384 ECDSA signature
 pub type FixedSignature = crate::FixedSignature<NistP384>;
+
+#[cfg(feature = "digest")]
+impl signature::DigestSignature for Asn1Signature {
+    type Digest = sha2::Sha384;
+}
+
+#[cfg(feature = "digest")]
+impl signature::DigestSignature for FixedSignature {
+    type Digest = sha2::Sha384;
+}

--- a/ecdsa/src/curve/secp256k1.rs
+++ b/ecdsa/src/curve/secp256k1.rs
@@ -22,3 +22,13 @@ pub type Asn1Signature = crate::Asn1Signature<Secp256k1>;
 
 /// Fixed-sized (a.k.a. "raw") secp256k1 ECDSA signature
 pub type FixedSignature = crate::FixedSignature<Secp256k1>;
+
+#[cfg(feature = "digest")]
+impl signature::DigestSignature for Asn1Signature {
+    type Digest = sha2::Sha256;
+}
+
+#[cfg(feature = "digest")]
+impl signature::DigestSignature for FixedSignature {
+    type Digest = sha2::Sha256;
+}


### PR DESCRIPTION
...gated under a `digest` cargo feature.

These are useful when doing `derive(Signer)` or `derive(Verifier)` using the `signature_derive` crate.