### PR TITLE
ecdsa: elliptic curve points (compressed/uncompressed)

### DIFF
--- a/ecdsa/src/asn1_signature.rs
+++ b/ecdsa/src/asn1_signature.rs
@@ -26,7 +26,6 @@ use signature::Error;
 pub type MaxOverhead = generic_array::typenum::U9;
 
 /// Maximum size of an ASN.1 DER encoded signature for the given elliptic curve.
-// TODO(tarcieri): const generics
 pub type MaxSize<ScalarSize> = <<ScalarSize as Add>::Output as Add<MaxOverhead>>::Output;
 
 /// ASN.1 DER-encoded ECDSA signature generic over elliptic curves.

--- a/ecdsa/src/curve.rs
+++ b/ecdsa/src/curve.rs
@@ -1,18 +1,32 @@
 //! Elliptic curves used by ECDSA
 
+// Elliptic curves
 pub mod nistp256;
 pub mod nistp384;
 pub mod secp256k1;
 
-pub use self::{nistp256::NistP256, nistp384::NistP384, secp256k1::Secp256k1};
+// Elliptic curve points
+pub mod point;
+
+pub use self::{
+    nistp256::NistP256,
+    nistp384::NistP384,
+    point::{CompressedCurvePoint, UncompressedCurvePoint},
+    secp256k1::Secp256k1,
+};
 
 use core::{fmt::Debug, ops::Add};
-use generic_array::typenum::Unsigned;
+use generic_array::{
+    typenum::{Unsigned, U1},
+    ArrayLength,
+};
 
 /// Elliptic curve in short Weierstrass form suitable for use with ECDSA
-pub trait Curve: Debug + Default + Eq + PartialEq + Send + Sync {
+pub trait Curve: Clone + Debug + Default + Eq + Ord + Send + Sync {
     /// Size of an integer modulo p (i.e. the curve's order) when serialized
-    /// as octets (i.e. bytes). This also describes the size of an ECDSA
-    /// private key, as well as half the size of a fixed-width signature.
-    type ScalarSize: Unsigned + Add; // `Add<Self>` impl from typenum used for doubling
+    /// as octets (i.e. bytes).
+    ///
+    /// This is also the size of a raw ECDSA private key (as such a key is a
+    /// scalar), and is equal to half the size of a fixed-width signature.
+    type ScalarSize: ArrayLength<u8> + Add + Add<U1> + Eq + Ord + Unsigned;
 }

--- a/ecdsa/src/curve/nistp256.rs
+++ b/ecdsa/src/curve/nistp256.rs
@@ -18,7 +18,7 @@ use generic_array::typenum::U32;
 ///
 /// This curve is part of the US National Security Agency's "Suite B" and
 /// and is widely used in protocols like TLS and the associated X.509 PKI.
-#[derive(Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
 pub struct NistP256;
 
 impl Curve for NistP256 {

--- a/ecdsa/src/curve/nistp384.rs
+++ b/ecdsa/src/curve/nistp384.rs
@@ -19,7 +19,7 @@ use generic_array::typenum::U48;
 ///
 /// This curve is part of the US National Security Agency's "Suite B" and
 /// and is widely used in protocols like TLS and the associated X.509 PKI.
-#[derive(Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
 pub struct NistP384;
 
 impl Curve for NistP384 {

--- a/ecdsa/src/curve/point.rs
+++ b/ecdsa/src/curve/point.rs
@@ -1,0 +1,162 @@
+//! Compressed and uncompressed Weierstrass elliptic curve points serialized
+//! according to the `Elliptic-Curve-Point-to-Octet-String` algorithm described
+//! in SEC 1: Elliptic Curve Cryptography (Version 2.0) section 2.3.3 (page 10)
+//!
+//! <https://www.secg.org/sec1-v2.pdf>
+
+use super::Curve;
+use core::ops::Add;
+use generic_array::{typenum::U1, ArrayLength, GenericArray};
+
+/// Size of a compressed elliptic curve point for the given curve when
+/// serialized using `Elliptic-Curve-Point-to-Octet-String` encoding.
+pub type CompressedPointSize<ScalarSize> = <ScalarSize as Add<U1>>::Output;
+
+/// Size of an uncompressed elliptic curve point for the given curve when
+/// serialized using the `Elliptic-Curve-Point-to-Octet-String` encoding
+/// (including the `0x04` tag).
+pub type UncompressedPointSize<ScalarSize> = <ScalarSize as Add<ScalarSize>>::Output;
+
+/// Compressed elliptic curve points serialized according to the
+/// `Elliptic-Curve-Point-to-Octet-String` algorithm defined
+/// in section 2.3.3 of SEC 1: Elliptic Curve Cryptography (Version 2.0):
+///
+/// <https://www.secg.org/sec1-v2.pdf>
+#[derive(Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub struct CompressedCurvePoint<C: Curve>
+where
+    CompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
+{
+    /// Raw serialized bytes of the compressed point
+    bytes: GenericArray<u8, CompressedPointSize<C::ScalarSize>>,
+}
+
+impl<C: Curve> CompressedCurvePoint<C>
+where
+    CompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
+{
+    /// Create a new compressed elliptic curve point
+    pub fn from_bytes<B>(into_bytes: B) -> Option<Self>
+    where
+        B: Into<GenericArray<u8, CompressedPointSize<C::ScalarSize>>>,
+    {
+        let bytes = into_bytes.into();
+        let tag_byte = bytes.as_ref()[0];
+
+        if tag_byte == 0x02 || tag_byte == 0x03 {
+            Some(Self { bytes })
+        } else {
+            None
+        }
+    }
+
+    /// Obtain public key as a byte array reference
+    #[inline]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// Convert public key into owned byte array
+    #[inline]
+    pub fn into_bytes(self) -> GenericArray<u8, CompressedPointSize<C::ScalarSize>> {
+        self.bytes
+    }
+}
+
+impl<C: Curve> AsRef<[u8]> for CompressedCurvePoint<C>
+where
+    CompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
+{
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        self.bytes.as_ref()
+    }
+}
+
+impl<C: Curve> Copy for CompressedCurvePoint<C>
+where
+    CompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
+    <CompressedPointSize<C::ScalarSize> as ArrayLength<u8>>::ArrayType: Copy,
+{
+}
+
+impl<C: Curve> Clone for CompressedCurvePoint<C>
+where
+    CompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
+{
+    fn clone(&self) -> Self {
+        Self::from_bytes(self.bytes.clone()).unwrap()
+    }
+}
+
+/// Uncompressed elliptic curve points serialized according to the
+/// `Elliptic-Curve-Point-to-Octet-String` algorithm, including the `0x04`
+/// tag identifying the bytestring as a curve point, as defined
+/// in section 2.3.3 of SEC 1: Elliptic Curve Cryptography (Version 2.0):
+///
+/// <https://www.secg.org/sec1-v2.pdf>
+#[derive(Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub struct UncompressedCurvePoint<C: Curve>
+where
+    UncompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
+{
+    /// Raw serialized bytes of the uncompressed point
+    bytes: GenericArray<u8, UncompressedPointSize<C::ScalarSize>>,
+}
+
+impl<C: Curve> UncompressedCurvePoint<C>
+where
+    UncompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
+{
+    /// Create a new uncompressed elliptic curve point
+    pub fn from_bytes<B>(into_bytes: B) -> Option<Self>
+    where
+        B: Into<GenericArray<u8, UncompressedPointSize<C::ScalarSize>>>,
+    {
+        let bytes = into_bytes.into();
+
+        if bytes.get(0) == Some(&0x04) {
+            Some(Self { bytes })
+        } else {
+            None
+        }
+    }
+
+    /// Obtain public key as a byte array reference
+    #[inline]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// Convert public key into owned byte array
+    #[inline]
+    pub fn into_bytes(self) -> GenericArray<u8, UncompressedPointSize<C::ScalarSize>> {
+        self.bytes
+    }
+}
+
+impl<C: Curve> AsRef<[u8]> for UncompressedCurvePoint<C>
+where
+    UncompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
+{
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        self.bytes.as_ref()
+    }
+}
+
+impl<C: Curve> Copy for UncompressedCurvePoint<C>
+where
+    UncompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
+    <UncompressedPointSize<C::ScalarSize> as ArrayLength<u8>>::ArrayType: Copy,
+{
+}
+
+impl<C: Curve> Clone for UncompressedCurvePoint<C>
+where
+    UncompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
+{
+    fn clone(&self) -> Self {
+        Self::from_bytes(self.bytes.clone()).unwrap()
+    }
+}

--- a/ecdsa/src/curve/secp256k1.rs
+++ b/ecdsa/src/curve/secp256k1.rs
@@ -9,7 +9,7 @@ use generic_array::typenum::U32;
 /// <http://www.secg.org/sec2-v2.pdf>
 ///
 /// This curve is most notable for its use in Bitcoin and other cryptocurrencies.
-#[derive(Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Secp256k1;
 
 impl Curve for Secp256k1 {

--- a/ecdsa/src/fixed_signature.rs
+++ b/ecdsa/src/fixed_signature.rs
@@ -10,7 +10,6 @@ use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
 use signature::Error;
 
 /// Size of a fixed sized signature for the given elliptic curve.
-// TODO(tarcieri): const generics
 pub type Size<ScalarSize> = <ScalarSize as Add>::Output;
 
 /// Fixed-sized (a.k.a. "raw") ECDSA signatures generic over elliptic curves.

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -12,6 +12,11 @@
 //! providers can be plugged in, enabling support for using different
 //! ECDSA implementations, including HSMs or Cloud KMS services.
 //!
+//! ## TODO
+//!
+//! - NIST P521
+//! - Const generics(!)
+//!
 //! [1]: https://csrc.nist.gov/publications/detail/fips/186/4/final
 
 #![no_std]
@@ -22,6 +27,10 @@
     html_root_url = "https://docs.rs/ecdsa/0.0.0"
 )]
 
+// Re-export the `generic-array` crate
+pub use generic_array;
+
+// Re-export the `signature` crate
 pub use signature;
 
 pub mod asn1_signature;


### PR DESCRIPTION
Adds `CompressedCurvePoint` and `UncompressedCurvePoint` as representations of bytestrings serialized according to the `Elliptic-Curve-Point-to-Octet-String` encoding as defined in section 2.3.3 of SEC 1: Elliptic Curve Cryptography (Version 2.0):

https://www.secg.org/sec1-v2.pdf