### PR TITLE
elliptic-curve-crate: Extract from `ecdsa` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "ecdsa",
     "ed25519",
+    "elliptic-curve-crate",
     "signature-crate",
     "signature-crate/signature_derive"
 ]

--- a/elliptic-curve-crate/.gitignore
+++ b/elliptic-curve-crate/.gitignore
@@ -1,0 +1,3 @@
+/target
+**/*.rs.bk
+Cargo.lock

--- a/elliptic-curve-crate/Cargo.toml
+++ b/elliptic-curve-crate/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "elliptic-curve"
+description = """
+Types and traits providing generic support for Elliptic Curve Cryptography,
+including a registry of commonly used elliptic curve types.
+"""
+version       = "0.0.0" # Also update html_root_url in lib.rs when bumping this
+authors       = ["RustCrypto Developers"]
+license       = "Apache-2.0 OR MIT"
+documentation = "https://docs.rs/elliptic-curve"
+repository    = "https://github.com/RustCrypto/signatures/tree/master/elliptic-curve-crate"
+readme        = "README.md"
+edition       = "2018"
+categories    = ["cryptography", "no-std"]
+keywords      = ["ecc", "edwards", "elliptic", "montgomery", "weierstrass"]
+
+[dependencies.getrandom]
+version = "0.1"
+optional = true
+
+[dependencies.generic-array]
+version = "0.12"
+default-features = false
+
+[dependencies.zeroize]
+version = "1"
+optional = true
+default-features = false
+
+[features]
+default = ["getrandom", "weierstrass", "std", "zeroize"]
+weierstrass = []
+std = []
+
+[package.metadata.docs.rs]
+all-features = true

--- a/elliptic-curve-crate/src/error.rs
+++ b/elliptic-curve-crate/src/error.rs
@@ -1,0 +1,16 @@
+//! Elliptic curve error types (opaque)
+
+use core::fmt::{self, Display};
+
+/// Elliptic curve errors
+#[derive(Copy, Clone, Debug)]
+pub struct Error;
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("crypto error")
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}

--- a/elliptic-curve-crate/src/lib.rs
+++ b/elliptic-curve-crate/src/lib.rs
@@ -1,0 +1,30 @@
+//! General purpose Elliptic Curve Cryptography (ECC) support, including types
+//! and traits for representing various elliptic curve forms.
+//!
+//! ## Minimum Supported Rust Version
+//!
+//! Rust **1.34** or higher.
+//!
+//! Minimum supported Rust version can be changed in the future, but it will be
+//! done with a minor version bump.
+
+#![no_std]
+#![forbid(unsafe_code)]
+#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png",
+    html_root_url = "https://docs.rs/elliptic-curve/0.0.0"
+)]
+
+#[cfg(feature = "std")]
+extern crate std;
+
+pub use generic_array;
+
+pub mod error;
+
+// TODO(tarcieri): other curve forms
+#[cfg(feature = "weierstrass")]
+pub mod weierstrass;
+
+pub use self::error::Error;

--- a/elliptic-curve-crate/src/weierstrass.rs
+++ b/elliptic-curve-crate/src/weierstrass.rs
@@ -1,0 +1,11 @@
+//! Elliptic curves in short Weierstrass form.
+
+pub mod curve;
+pub mod point;
+pub mod public_key;
+pub mod secret_key;
+
+pub use self::curve::{Curve, Scalar};
+pub use self::point::{
+    CompressedCurvePoint, CompressedPointSize, UncompressedCurvePoint, UncompressedPointSize,
+};

--- a/elliptic-curve-crate/src/weierstrass/curve.rs
+++ b/elliptic-curve-crate/src/weierstrass/curve.rs
@@ -1,0 +1,24 @@
+//! Registry of elliptic curves in short Weierstrass form
+
+// Weierstrass curves
+pub mod nistp256;
+pub mod nistp384;
+pub mod secp256k1;
+
+pub use self::{nistp256::NistP256, nistp384::NistP384, secp256k1::Secp256k1};
+
+use core::{fmt::Debug, ops::Add};
+use generic_array::{
+    typenum::{Unsigned, U1},
+    ArrayLength, GenericArray,
+};
+
+/// Elliptic curve in short Weierstrass form
+pub trait Curve: Clone + Debug + Default + Eq + Ord + Send + Sync {
+    /// Size of an integer modulo p (i.e. the curve's order) when serialized
+    /// as octets (i.e. bytes).
+    type ScalarSize: ArrayLength<u8> + Add + Add<U1> + Eq + Ord + Unsigned;
+}
+
+/// Alias for `GenericArray` which is the size of the curve's scalar
+pub type Scalar<C> = GenericArray<u8, <C as Curve>::ScalarSize>;

--- a/elliptic-curve-crate/src/weierstrass/curve/nistp256.rs
+++ b/elliptic-curve-crate/src/weierstrass/curve/nistp256.rs
@@ -1,0 +1,31 @@
+//! NIST P-256 elliptic curve (a.k.a. prime256v1, secp256r1)
+
+use super::Curve;
+use generic_array::typenum::U32;
+
+/// NIST P-256 elliptic curve.
+///
+/// This curve is also known as prime256v1 (ANSI X9.62) and secp256r1 (SECG)
+/// and is specified in FIPS 186-4: Digital Signature Standard (DSS):
+///
+/// <https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf>
+///
+/// It's included in the US National Security Agency's "Suite B" and is widely
+/// used in protocols like TLS and the associated X.509 PKI.
+///
+/// Its equation is `y² = x³ - 3x + b` over a ~256-bit prime field where `b` is
+/// the "verifiably random"† constant:
+///
+/// ```text
+/// b = 41058363725152142129326129780047268409114441015993725554835256314039467401291
+/// ```
+///
+/// † *NOTE: the specific origins of this constant have never been fully disclosed
+///   (it is the SHA-1 digest of an inexplicable NSA-selected constant)*
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
+pub struct NistP256;
+
+impl Curve for NistP256 {
+    /// 256-bit (32-byte) private scalar
+    type ScalarSize = U32;
+}

--- a/elliptic-curve-crate/src/weierstrass/curve/nistp384.rs
+++ b/elliptic-curve-crate/src/weierstrass/curve/nistp384.rs
@@ -1,0 +1,32 @@
+//! NIST P-384 elliptic curve (a.k.a. secp384r1)
+
+use super::Curve;
+use generic_array::typenum::U48;
+
+/// NIST P-384 elliptic curve.
+///
+/// This curve is also known as secp384r1 (SECG) and is specified in
+/// FIPS 186-4: Digital Signature Standard (DSS):
+///
+/// <https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf>
+///
+/// It's included in the US National Security Agency's "Suite B" and is widely
+/// used in protocols like TLS and the associated X.509 PKI.
+///
+/// Its equation is `y² = x³ - 3x + b` over a ~384-bit prime field where `b` is
+/// the "verifiably random"† constant:
+///
+/// ```text
+/// b = 2758019355995970587784901184038904809305690585636156852142
+///     8707301988689241309860865136260764883745107765439761230575
+/// ```
+///
+/// † *NOTE: the specific origins of this constant have never been fully disclosed
+///   (it is the SHA-1 digest of an inexplicable NSA-selected constant)*
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
+pub struct NistP384;
+
+impl Curve for NistP384 {
+    /// 384-bit (48-byte) private scalar
+    type ScalarSize = U48;
+}

--- a/elliptic-curve-crate/src/weierstrass/curve/secp256k1.rs
+++ b/elliptic-curve-crate/src/weierstrass/curve/secp256k1.rs
@@ -1,0 +1,21 @@
+//! secp256k1 elliptic curve
+
+use super::Curve;
+use generic_array::typenum::U32;
+
+/// secp256k1 elliptic curve.
+///
+/// Specified in Certicom's SECG in SEC 2: Recommended Elliptic Curve Domain Parameters:
+///
+/// <https://www.secg.org/sec2-v2.pdf>
+///
+/// The curve's equation is `y² = x³ + 7` over a ~256-bit prime field.
+///
+/// It's primarily notable for its use in Bitcoin and other cryptocurrencies.
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
+pub struct Secp256k1;
+
+impl Curve for Secp256k1 {
+    /// 256-bit (32-byte) private scalar
+    type ScalarSize = U32;
+}

--- a/elliptic-curve-crate/src/weierstrass/point.rs
+++ b/elliptic-curve-crate/src/weierstrass/point.rs
@@ -1,0 +1,171 @@
+//! Compressed and uncompressed Weierstrass elliptic curve points.
+//!
+//! Serialized according to the `Elliptic-Curve-Point-to-Octet-String`
+//! algorithm described in SEC 1: Elliptic Curve Cryptography (Version 2.0)
+//! section 2.3.3 (page 10):
+//!
+//! <https://www.secg.org/sec1-v2.pdf>
+
+use super::Curve;
+use core::ops::Add;
+use generic_array::{typenum::U1, ArrayLength, GenericArray};
+
+/// Size of a compressed elliptic curve point for the given curve when
+/// serialized using `Elliptic-Curve-Point-to-Octet-String` encoding
+/// (including leading `0x02` or `0x03` tag byte).
+pub type CompressedPointSize<ScalarSize> = <ScalarSize as Add<U1>>::Output;
+
+/// Size of an uncompressed elliptic curve point for the given curve when
+/// serialized using the `Elliptic-Curve-Point-to-Octet-String` encoding
+/// (including leading `0x04` tag byte).
+pub type UncompressedPointSize<ScalarSize> = <<ScalarSize as Add>::Output as Add<U1>>::Output;
+
+/// Compressed elliptic curve points serialized according to the
+/// `Elliptic-Curve-Point-to-Octet-String` algorithm.
+///
+/// See section 2.3.3 of SEC 1: Elliptic Curve Cryptography (Version 2.0):
+///
+/// <https://www.secg.org/sec1-v2.pdf>
+#[derive(Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub struct CompressedCurvePoint<C: Curve>
+where
+    CompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
+{
+    /// Raw serialized bytes of the compressed point
+    bytes: GenericArray<u8, CompressedPointSize<C::ScalarSize>>,
+}
+
+impl<C: Curve> CompressedCurvePoint<C>
+where
+    CompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
+{
+    /// Create a new compressed elliptic curve point
+    pub fn from_bytes<B>(into_bytes: B) -> Option<Self>
+    where
+        B: Into<GenericArray<u8, CompressedPointSize<C::ScalarSize>>>,
+    {
+        let bytes = into_bytes.into();
+        let tag_byte = bytes.as_ref()[0];
+
+        if tag_byte == 0x02 || tag_byte == 0x03 {
+            Some(Self { bytes })
+        } else {
+            None
+        }
+    }
+
+    /// Borrow byte slice containing compressed curve point
+    #[inline]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// Obtain owned array containing compressed curve point
+    #[inline]
+    pub fn into_bytes(self) -> GenericArray<u8, CompressedPointSize<C::ScalarSize>> {
+        self.bytes
+    }
+}
+
+impl<C: Curve> AsRef<[u8]> for CompressedCurvePoint<C>
+where
+    CompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
+{
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        self.bytes.as_ref()
+    }
+}
+
+impl<C: Curve> Copy for CompressedCurvePoint<C>
+where
+    CompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
+    <CompressedPointSize<C::ScalarSize> as ArrayLength<u8>>::ArrayType: Copy,
+{
+}
+
+impl<C: Curve> Clone for CompressedCurvePoint<C>
+where
+    CompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
+{
+    fn clone(&self) -> Self {
+        Self::from_bytes(self.bytes.clone()).unwrap()
+    }
+}
+
+/// Uncompressed elliptic curve points serialized according to the
+/// `Elliptic-Curve-Point-to-Octet-String` algorithm.
+///
+/// See section 2.3.3 of SEC 1: Elliptic Curve Cryptography (Version 2.0):
+///
+/// <https://www.secg.org/sec1-v2.pdf>
+#[derive(Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub struct UncompressedCurvePoint<C: Curve>
+where
+    <C::ScalarSize as Add>::Output: Add<U1>,
+    UncompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
+{
+    /// Raw serialized bytes of the uncompressed point
+    bytes: GenericArray<u8, UncompressedPointSize<C::ScalarSize>>,
+}
+
+impl<C: Curve> UncompressedCurvePoint<C>
+where
+    <C::ScalarSize as Add>::Output: Add<U1>,
+    UncompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
+{
+    /// Create a new uncompressed elliptic curve point
+    pub fn from_bytes<B>(into_bytes: B) -> Option<Self>
+    where
+        B: Into<GenericArray<u8, UncompressedPointSize<C::ScalarSize>>>,
+    {
+        let bytes = into_bytes.into();
+
+        if bytes.get(0) == Some(&0x04) {
+            Some(Self { bytes })
+        } else {
+            None
+        }
+    }
+
+    /// Borrow byte slice containing uncompressed curve point
+    #[inline]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// Convert public key into owned byte array
+    #[inline]
+    pub fn into_bytes(self) -> GenericArray<u8, UncompressedPointSize<C::ScalarSize>> {
+        self.bytes
+    }
+}
+
+impl<C: Curve> AsRef<[u8]> for UncompressedCurvePoint<C>
+where
+    <C::ScalarSize as Add>::Output: Add<U1>,
+    UncompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
+{
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        self.bytes.as_ref()
+    }
+}
+
+impl<C: Curve> Copy for UncompressedCurvePoint<C>
+where
+    <C::ScalarSize as Add>::Output: Add<U1>,
+    UncompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
+    <UncompressedPointSize<C::ScalarSize> as ArrayLength<u8>>::ArrayType: Copy,
+{
+}
+
+impl<C: Curve> Clone for UncompressedCurvePoint<C>
+where
+    <C::ScalarSize as Add>::Output: Add<U1>,
+    UncompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
+{
+    fn clone(&self) -> Self {
+        Self::from_bytes(self.bytes.clone()).unwrap()
+    }
+}

--- a/elliptic-curve-crate/src/weierstrass/public_key.rs
+++ b/elliptic-curve-crate/src/weierstrass/public_key.rs
@@ -1,0 +1,135 @@
+//! Public keys for Weierstrass curves: wrapper around compressed or
+//! uncompressed elliptic curve points.
+
+use super::point::{
+    CompressedCurvePoint, CompressedPointSize, UncompressedCurvePoint, UncompressedPointSize,
+};
+use super::Curve;
+use core::fmt::{self, Debug};
+use core::ops::Add;
+use generic_array::{
+    typenum::{Unsigned, U1},
+    ArrayLength, GenericArray,
+};
+
+/// Size of an untagged point for given elliptic curve.
+// TODO(tarcieri): const generics
+pub type UntaggedPointSize<ScalarSize> = <ScalarSize as Add>::Output;
+
+/// Public keys for Weierstrass curves
+#[derive(Clone, Eq, PartialEq, PartialOrd, Ord)]
+pub enum PublicKey<C: Curve>
+where
+    <C::ScalarSize as Add>::Output: Add<U1>,
+    CompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
+    UncompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
+{
+    /// Compressed Weierstrass elliptic curve point
+    Compressed(CompressedCurvePoint<C>),
+
+    /// Uncompressed Weierstrass elliptic curve point
+    Uncompressed(UncompressedCurvePoint<C>),
+}
+
+impl<C: Curve> PublicKey<C>
+where
+    <C::ScalarSize as Add>::Output: Add<U1>,
+    CompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
+    UncompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
+{
+    /// Decode public key from an elliptic curve point
+    /// (compressed or uncompressed) encoded using the
+    /// `Elliptic-Curve-Point-to-Octet-String` algorithm described in
+    /// SEC 1: Elliptic Curve Cryptography (Version 2.0) section
+    /// 2.3.3 (page 10).
+    ///
+    /// <http://www.secg.org/sec1-v2.pdf>
+    pub fn from_bytes<B: AsRef<[u8]>>(bytes: B) -> Option<Self> {
+        let slice = bytes.as_ref();
+        let length = slice.len();
+
+        if length == <CompressedPointSize<C::ScalarSize>>::to_usize() {
+            let array = GenericArray::clone_from_slice(slice);
+            let point = CompressedCurvePoint::from_bytes(array)?;
+            Some(PublicKey::Compressed(point))
+        } else if length == <UncompressedPointSize<C::ScalarSize>>::to_usize() {
+            let array = GenericArray::clone_from_slice(slice);
+            let point = UncompressedCurvePoint::from_bytes(array)?;
+            Some(PublicKey::Uncompressed(point))
+        } else {
+            None
+        }
+    }
+
+    /// Decode public key from an compressed elliptic curve point
+    /// encoded using the `Elliptic-Curve-Point-to-Octet-String` algorithm
+    /// described in SEC 1: Elliptic Curve Cryptography (Version 2.0) section
+    /// 2.3.3 (page 10).
+    ///
+    /// <http://www.secg.org/sec1-v2.pdf>
+    pub fn from_compressed_point<B>(into_bytes: B) -> Option<Self>
+    where
+        B: Into<GenericArray<u8, CompressedPointSize<C::ScalarSize>>>,
+    {
+        CompressedCurvePoint::from_bytes(into_bytes).map(PublicKey::Compressed)
+    }
+
+    /// Decode public key from a raw uncompressed point serialized
+    /// as a bytestring, without a `0x04`-byte tag.
+    ///
+    /// This will be twice the modulus size, or 1-byte smaller than the
+    /// `Elliptic-Curve-Point-to-Octet-String` encoding i.e
+    /// with the leading `0x04` byte in that encoding removed.
+    pub fn from_untagged_point(bytes: &GenericArray<u8, UntaggedPointSize<C::ScalarSize>>) -> Self
+    where
+        <C::ScalarSize as Add>::Output: ArrayLength<u8>,
+    {
+        let mut tagged_bytes = GenericArray::default();
+        tagged_bytes.as_mut_slice()[0] = 0x04;
+        tagged_bytes.as_mut_slice()[1..].copy_from_slice(bytes.as_ref());
+
+        PublicKey::Uncompressed(UncompressedCurvePoint::from_bytes(tagged_bytes).unwrap())
+    }
+
+    /// Obtain public key as a byte array reference
+    #[inline]
+    pub fn as_bytes(&self) -> &[u8] {
+        match self {
+            PublicKey::Compressed(ref point) => point.as_bytes(),
+            PublicKey::Uncompressed(ref point) => point.as_bytes(),
+        }
+    }
+}
+
+impl<C: Curve> AsRef<[u8]> for PublicKey<C>
+where
+    <C::ScalarSize as Add>::Output: Add<U1>,
+    CompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
+    UncompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
+{
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+
+impl<C: Curve> Copy for PublicKey<C>
+where
+    <C::ScalarSize as Add>::Output: Add<U1>,
+    CompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
+    UncompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
+    <CompressedPointSize<C::ScalarSize> as ArrayLength<u8>>::ArrayType: Copy,
+    <UncompressedPointSize<C::ScalarSize> as ArrayLength<u8>>::ArrayType: Copy,
+{
+}
+
+impl<C: Curve> Debug for PublicKey<C>
+where
+    <C::ScalarSize as Add>::Output: Add<U1>,
+    CompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
+    UncompressedPointSize<C::ScalarSize>: ArrayLength<u8>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "PublicKey<{:?}>({:?})", C::default(), self.as_ref())
+    }
+}

--- a/elliptic-curve-crate/src/weierstrass/secret_key.rs
+++ b/elliptic-curve-crate/src/weierstrass/secret_key.rs
@@ -1,0 +1,72 @@
+//! Secret keys for Weierstrass curves: private scalars.
+
+use super::{Curve, Scalar};
+use crate::error::Error;
+use core::convert::{TryFrom, TryInto};
+use generic_array::{typenum::Unsigned, GenericArray};
+
+#[cfg(feature = "getrandom")]
+use getrandom::getrandom;
+
+/// Secret keys for Weierstrass curves: wrapper around scalar values used as
+/// secret keys.
+///
+/// Prevents accidental exposure and handles zeroization.
+pub struct SecretKey<C: Curve> {
+    /// Serialized private scalar value as bytes
+    bytes: Scalar<C>,
+}
+
+impl<C: Curve> SecretKey<C> {
+    /// Create a new secret key from a serialized scalar value
+    pub fn new(into_bytes: impl Into<GenericArray<u8, C::ScalarSize>>) -> Self {
+        Self {
+            bytes: into_bytes.into(),
+        }
+    }
+
+    /// Deserialize this secret key from a bytestring
+    pub fn from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, Error> {
+        bytes.as_ref().try_into()
+    }
+
+    /// Generate a new secret key using the operating system's
+    /// cryptographically secure random number generator
+    #[cfg(feature = "getrandom")]
+    pub fn generate() -> Self {
+        let mut bytes = GenericArray::default();
+        getrandom(bytes.as_mut_slice()).expect("RNG failure!");
+        Self { bytes }
+    }
+
+    /// Expose the secret `Scalar<C>` value this `SecretKey` wraps
+    pub fn secret_scalar(&self) -> &Scalar<C> {
+        &self.bytes
+    }
+}
+
+impl<C: Curve> Clone for SecretKey<C> {
+    fn clone(&self) -> Self {
+        Self::new(self.bytes.clone())
+    }
+}
+
+#[cfg(feature = "zeroize")]
+impl<C: Curve> Drop for SecretKey<C> {
+    fn drop(&mut self) {
+        use zeroize::Zeroize;
+        self.bytes.as_mut().zeroize();
+    }
+}
+
+impl<'a, C: Curve> TryFrom<&'a [u8]> for SecretKey<C> {
+    type Error = Error;
+
+    fn try_from(slice: &'a [u8]) -> Result<Self, Error> {
+        if slice.len() == C::ScalarSize::to_usize() {
+            Ok(Self::new(GenericArray::clone_from_slice(slice)))
+        } else {
+            Err(Error)
+        }
+    }
+}


### PR DESCRIPTION
The `ecdsa` crate contains types, traits, and a complete registry for common Weierstrass curves which is reusable for both the signing and encryption use case.

This extracts the reusable functionality into the `elliptic-curve` crate, with the goal of rewriting the duplicated parts of the current `ecdsa` crate to use types from the `elliptic-curve` crate, and once
that's done, finding a better home, e.g. https://github.com/RustCrypto/traits

It seems we collectively own the following crates:

- `curve25519`
- `ed25519`
- `p256`
- `p384`
- `p521`
- `k256`

...so it would be nice to extract the curve registry in these crates into those crates respectively, e.g. under a hypothetical https://github.com/RustCrypto/elliptic-curves

But for now, this structures the crate the same way the `ecdsa` crate was previously structured: with an all-in-one curve registry contained within the crate.