### PR TITLE
ecdsa v0.2.1

### DIFF
--- a/ecdsa/CHANGES.md
+++ b/ecdsa/CHANGES.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.1 (2019-12-06)
+### Added
+- Re-export PublicKey and SecretKey from the `elliptic-curve` crate ([#61])
+
+[#61]: https://github.com/RustCrypto/signatures/pull/61
+
 ## 0.2.0 (2019-12-06)
 ### Changed
 - Use curve types from the `elliptic-curve` crate ([#58])

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ecdsa"
-version       = "0.2.0"
+version       = "0.2.1"
 description   = """
 Signature and elliptic curve types providing interoperable support for the
 Elliptic Curve Digital Signature Algorithm (ECDSA)

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -25,7 +25,7 @@
 #![warn(missing_docs, rust_2018_idioms, intra_doc_link_resolution_failure)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png",
-    html_root_url = "https://docs.rs/ecdsa/0.2.0"
+    html_root_url = "https://docs.rs/ecdsa/0.2.1"
 )]
 
 // Re-export the `generic-array` crate


### PR DESCRIPTION
### Added
- Re-export PublicKey and SecretKey from the `elliptic-curve` crate ([#61])

[#61]: https://github.com/RustCrypto/signatures/pull/61