### PR TITLE
ecdsa v0.3.0

### DIFF
--- a/ecdsa/CHANGES.md
+++ b/ecdsa/CHANGES.md
@@ -4,9 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2019-12-11)
+### Changed
+- Upgrade `elliptic-curve` crate to v0.2.0; MSRV 1.37+ ([#65])
+
+[#65]: https://github.com/RustCrypto/signatures/pull/65
+
 ## 0.2.1 (2019-12-06)
 ### Added
-- Re-export PublicKey and SecretKey from the `elliptic-curve` crate ([#61])
+- Re-export `PublicKey` and `SecretKey` from the `elliptic-curve` crate ([#61])
 
 [#61]: https://github.com/RustCrypto/signatures/pull/61
 

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ecdsa"
-version       = "0.2.1"
+version       = "0.3.0" # Also update html_root_url in lib.rs when bumping this
 description   = """
 Signature and elliptic curve types providing interoperable support for the
 Elliptic Curve Digital Signature Algorithm (ECDSA)

--- a/ecdsa/README.md
+++ b/ecdsa/README.md
@@ -3,7 +3,7 @@
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
 ![Apache2/MIT licensed][license-image]
-![Rust Version][rustc-image]
+![MSRV][rustc-image]
 [![Build Status][build-image]][build-link]
 
 Elliptic Curve Digital Signature Algorithm (ECDSA) as specified in
@@ -48,7 +48,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/ecdsa/badge.svg
 [docs-link]: https://docs.rs/ecdsa/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.34+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.37+-blue.svg
 [build-image]: https://travis-ci.org/RustCrypto/signatures.svg?branch=master
 [build-link]: https://travis-ci.org/RustCrypto/signatures
 

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -2,10 +2,20 @@
 //! [FIPS 186-4][1] (Digital Signature Standard)
 //!
 //! This crate doesn't contain an implementation of ECDSA itself, but instead
-//! contains [`ecdsa::Asn1Signature`] and [`ecdsa::FixedSignature`] types
-//! generic over an [`ecdsa::Curve`] type which other crates can use in
-//! conjunction with the [`signature::Signer`] and [`signature::Verifier`]
-//! traits.
+//! contains [`Asn1Signature`] and [`FixedSignature`] types which are generic
+//! over elliptic [`Curve`] types (e.g. `NistP256`, `NistP384`, `Secp256k1`)
+//! which can be used in conjunction with the [`signature::Signer`] and
+//! [`signature::Verifier`] traits to provide signature types which are
+//! reusable across multiple signing and verification provider crates.
+//!
+//! Transcoding between [`Asn1Signature`] and [`FixedSignature`] of the same
+//! [`Curve`] type is supported in the form of simple `From` impls.
+//!
+//! Additionally, the [`PublicKey`] and [`SecretKey`] types, also generic
+//! over elliptic curve types, provide reusable key types, sourced from the
+//! [`elliptic-curve`][2] crate. The [`PublicKey`] type supports both
+//! compressed and uncompressed points, and for the P-256 curve in particular
+//! supports converting between the compressed and uncompressed forms.
 //!
 //! These traits allow crates which produce and consume ECDSA signatures
 //! to be written abstractly in such a way that different signer/verifier
@@ -19,13 +29,14 @@
 //! - Const generics(!)
 //!
 //! [1]: https://csrc.nist.gov/publications/detail/fips/186/4/final
+//! [2]: http://docs.rs/elliptic-curve
 
 #![no_std]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, intra_doc_link_resolution_failure)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png",
-    html_root_url = "https://docs.rs/ecdsa/0.2.1"
+    html_root_url = "https://docs.rs/ecdsa/0.3.0"
 )]
 
 // Re-export the `generic-array` crate
@@ -41,5 +52,5 @@ pub mod fixed_signature;
 #[cfg(feature = "test-vectors")]
 pub mod test_vectors;
 
-pub use self::{asn1_signature::Asn1Signature, curve::Curve, fixed_signature::FixedSignature};
-pub use elliptic_curve::weierstrass::{PublicKey, SecretKey};
+pub use self::{asn1_signature::Asn1Signature, fixed_signature::FixedSignature};
+pub use elliptic_curve::weierstrass::{Curve, PublicKey, SecretKey};


### PR DESCRIPTION
### Changed
- Upgrade `elliptic-curve` crate to v0.2.0; MSRV 1.37+ ([#65])

[#65]: https://github.com/RustCrypto/signatures/pull/65