### PR TITLE
ed25519 v1.0.0-pre.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-link]: https://travis-ci.org/RustCrypto/signatures
 [deps-image]: https://deps.rs/repo/github/RustCrypto/signatures/status.svg
 [deps-link]: https://deps.rs/repo/github/RustCrypto/signatures
-[rustc-image]: https://img.shields.io/badge/rustc-1.34+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.37+-blue.svg
 
 [//]: # (general links)
 

--- a/ed25519/CHANGES.md
+++ b/ed25519/CHANGES.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.0-pre.2 (2020-03-08)
+### Changed
+- Upgrade to `signature` crate v1.0.0-pre.3 ([#71])
+- Bump MSRV to 1.37 ([#63])
+
+[#71]: https://github.com/RustCrypto/signatures/pull/71
+[#63]: https://github.com/RustCrypto/signatures/pull/63
+
 ## 1.0.0-pre.1 (2019-10-11)
 ### Added
 - Optional `serde` support ([#40])

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ed25519"
-version       = "1.0.0-pre.1"
+version       = "1.0.0-pre.2"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 description   = "Edwards Digital Signature Algorithm (EdDSA) over Curve25519 (as specified in RFC 8032)"

--- a/ed25519/README.md
+++ b/ed25519/README.md
@@ -47,7 +47,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/ed25519/badge.svg
 [docs-link]: https://docs.rs/ed25519/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.34+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.37+-blue.svg
 [build-image]: https://travis-ci.org/RustCrypto/signatures.svg?branch=master
 [build-link]: https://travis-ci.org/RustCrypto/signatures
 

--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -18,7 +18,7 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png",
-    html_root_url = "https://docs.rs/ed25519/1.0.0-pre.1"
+    html_root_url = "https://docs.rs/ed25519/1.0.0-pre.2"
 )]
 
 #[cfg(feature = "serde")]


### PR DESCRIPTION
### Changed
- Upgrade to `signature` crate v1.0.0-pre.3 ([#71])
- Bump MSRV to 1.37 ([#63])

[#71]: https://github.com/RustCrypto/signatures/pull/71
[#63]: https://github.com/RustCrypto/signatures/pull/63