### PR TITLE
ecdsa v0.5.0-pre

### DIFF
--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ecdsa"
-version       = "0.4.0" # Also update html_root_url in lib.rs when bumping this
+version       = "0.5.0-pre" # Also update html_root_url in lib.rs when bumping this
 description   = """
 Signature and elliptic curve types providing interoperable support for the
 Elliptic Curve Digital Signature Algorithm (ECDSA)

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -36,7 +36,7 @@
 #![warn(missing_docs, rust_2018_idioms, intra_doc_link_resolution_failure)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png",
-    html_root_url = "https://docs.rs/ecdsa/0.4.0"
+    html_root_url = "https://docs.rs/ecdsa/0.5.0-pre"
 )]
 
 // Re-export the `generic-array` crate


### PR DESCRIPTION
Pre-release with bump to `signature` crate v1.0.0-pre.3. See:

https://github.com/RustCrypto/traits/issues/78
