### PR TITLE
ed25519 v1.0.0-pre.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.0.0-pre.2"
+version = "1.0.0-pre.3"
 dependencies = [
  "serde",
  "signature",

--- a/ed25519/CHANGES.md
+++ b/ed25519/CHANGES.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.0-pre.3 (2020-03-16)
+### Changed
+- Upgrade to `signature` crate v1.0.0-pre.3 ([#74])
+- Bump MSRV to 1.40 ([#75])
+
+[#74]: https://github.com/RustCrypto/signatures/pull/74
+[#75]: https://github.com/RustCrypto/signatures/pull/75
+
 ## 1.0.0-pre.2 (2020-03-08)
 ### Changed
 - Upgrade to `signature` crate v1.0.0-pre.3 ([#71])

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ed25519"
-version       = "1.0.0-pre.2"
+version       = "1.0.0-pre.3"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 description   = "Edwards Digital Signature Algorithm (EdDSA) over Curve25519 (as specified in RFC 8032)"

--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -18,7 +18,7 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png",
-    html_root_url = "https://docs.rs/ed25519/1.0.0-pre.2"
+    html_root_url = "https://docs.rs/ed25519/1.0.0-pre.3"
 )]
 
 #[cfg(feature = "serde")]


### PR DESCRIPTION
### Changed
- Upgrade to `signature` crate v1.0.0-pre.3 ([#74])
- Bump MSRV to 1.40 ([#75])

[#74]: https://github.com/RustCrypto/signatures/pull/74
[#75]: https://github.com/RustCrypto/signatures/pull/75