### PR TITLE
ed25519 v1.0.0-pre.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.0.0-pre.3"
+version = "1.0.0-pre.4"
 dependencies = [
  "bincode",
  "serde",

--- a/ed25519/CHANGES.md
+++ b/ed25519/CHANGES.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.0-pre.4 (2020-03-17)
+### Changed
+- Avoid serializing a length prefix with `serde` ([#78])
+
+[#78]: https://github.com/RustCrypto/signatures/pull/78
+
 ## 1.0.0-pre.3 (2020-03-16)
 ### Changed
 - Upgrade to `signature` crate v1.0.0-pre.3 ([#74])

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ed25519"
-version       = "1.0.0-pre.3"
+version       = "1.0.0-pre.4"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 description   = "Edwards Digital Signature Algorithm (EdDSA) over Curve25519 (as specified in RFC 8032)"

--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -18,7 +18,7 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png",
-    html_root_url = "https://docs.rs/ed25519/1.0.0-pre.3"
+    html_root_url = "https://docs.rs/ed25519/1.0.0-pre.4"
 )]
 
 #[cfg(feature = "serde")]


### PR DESCRIPTION
### Changed
- Avoid serializing a length prefix with `serde` ([#78])

[#78]: https://github.com/RustCrypto/signatures/pull/78