### PR TITLE
ed25519 v1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.0.0-pre.4"
+version = "1.0.0"
 dependencies = [
  "bincode",
  "serde",

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RustCrypto: signatures [![Dependency Status][deps-image]][deps-link] ![Rust Version][rustc-image]
+# RustCrypto: signatures ![Rust Version][rustc-image]
 
 Support for [digital signatures][1], which provide authentication of data using
 public-key cryptography.
@@ -44,8 +44,6 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[deps-image]: https://deps.rs/repo/github/RustCrypto/signatures/status.svg
-[deps-link]: https://deps.rs/repo/github/RustCrypto/signatures
 [rustc-image]: https://img.shields.io/badge/rustc-1.40+-blue.svg
 
 [//]: # (crates)

--- a/ed25519/CHANGES.md
+++ b/ed25519/CHANGES.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.0 (2020-04-18)
+### Changed
+- Upgrade `signature` crate to v1.0 final release ([#80])
+
+[#80]: https://github.com/RustCrypto/signatures/pull/80
+
 ## 1.0.0-pre.4 (2020-03-17)
 ### Changed
 - Avoid serializing a length prefix with `serde` ([#78])
@@ -12,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 1.0.0-pre.3 (2020-03-16)
 ### Changed
-- Upgrade to `signature` crate v1.0.0-pre.3 ([#74])
+- Upgrade `signature` crate to v1.0.0-pre.3 ([#74])
 - Bump MSRV to 1.40 ([#75])
 
 [#74]: https://github.com/RustCrypto/signatures/pull/74

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ed25519"
-version       = "1.0.0-pre.4"
+version       = "1.0.0"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 description   = "Edwards Digital Signature Algorithm (EdDSA) over Curve25519 (as specified in RFC 8032)"

--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -18,7 +18,7 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png",
-    html_root_url = "https://docs.rs/ed25519/1.0.0-pre.4"
+    html_root_url = "https://docs.rs/ed25519/1.0.0"
 )]
 
 #[cfg(feature = "serde")]


### PR DESCRIPTION
- Upgrade `signature` crate to v1.0 final release ([#80])

[#80]: https://github.com/RustCrypto/signatures/pull/80