### PR TITLE
ecdsa v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.5.0-pre"
+version = "0.5.0"
 dependencies = [
  "elliptic-curve",
  "generic-array",

--- a/ecdsa/CHANGES.md
+++ b/ecdsa/CHANGES.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2020-04-18)
+### Changed
+- Upgrade `signature` crate to v1.0 final release ([#80])
+
+[#80]: https://github.com/RustCrypto/signatures/pull/80
+
 ## 0.4.0 (2020-01-07)
 ### Changed
 - Upgrade `elliptic-curve` crate to v0.3.0; make curves cargo features ([#68])

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ecdsa"
-version       = "0.5.0-pre" # Also update html_root_url in lib.rs when bumping this
+version       = "0.5.0" # Also update html_root_url in lib.rs when bumping this
 description   = """
 Signature and elliptic curve types providing interoperable support for the
 Elliptic Curve Digital Signature Algorithm (ECDSA)
@@ -44,7 +44,7 @@ optional = true
 default-features = false
 
 [dependencies.signature]
-version = "1"
+version = ">= 1.0.0, < 1.1.0"
 default-features = false
 
 [features]

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -36,7 +36,7 @@
 #![warn(missing_docs, rust_2018_idioms, intra_doc_link_resolution_failure)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png",
-    html_root_url = "https://docs.rs/ecdsa/0.5.0-pre"
+    html_root_url = "https://docs.rs/ecdsa/0.5.0"
 )]
 
 // Re-export the `generic-array` crate


### PR DESCRIPTION
### Changed
- Upgrade `signature` crate to v1.0 final release ([#80])

[#80]: https://github.com/RustCrypto/signatures/pull/80