### PR TITLE
Bump `p256` and `k256` to v0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,9 +120,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4407bc616f76afb6bccd8a813b86fe622752b15b43c5e60fec94d21af2393a72"
+checksum = "f8a010224d825405c12a840fc269094683abe1282222f46c368318a02fa8876b"
 dependencies = [
  "elliptic-curve",
 ]
@@ -141,9 +141,9 @@ checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "p256"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812a058a5afc96a52a8ab6e250325d025254ff030ff737dc5b62576e4e604c42"
+checksum = "86640e33ca638ec215c74de317696bbca5daa7d52cf55b905bd20a6bd2cfd133"
 dependencies = [
  "elliptic-curve",
 ]

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -24,12 +24,12 @@ version = "0.12"
 default-features = false
 
 [dependencies.k256]
-version = "0.1"
+version = "0.2"
 optional = true
 default-features = false
 
 [dependencies.p256]
-version = "0.1"
+version = "0.2"
 optional = true
 default-features = false
 


### PR DESCRIPTION
Release announcement:

https://www.reddit.com/r/rust/comments/gbjsr9/ann_rustcrypto_p256_and_k256_v020_pure_rust_nist/