### PR TITLE
ecdsa: bump all elliptic curve crates; MSRV 1.41+

### DIFF
--- a/.github/workflows/ecdsa.yml
+++ b/.github/workflows/ecdsa.yml
@@ -6,9 +6,14 @@ on:
       - "Cargo.*"
   push:
     branches: master
-    paths:
-      - "ecdsa/**"
-      - "Cargo.*"
+
+defaults:
+  run:
+    working-directory: ecdsa
+
+env:
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: "-Dwarnings"
 
 jobs:
   build:
@@ -19,7 +24,7 @@ jobs:
           - thumbv7em-none-eabi
           - wasm32-unknown-unknown
         toolchain:
-          - 1.40.0 # MSRV
+          - 1.41.0 # MSRV
           - stable
     steps:
       - name: Checkout sources
@@ -51,10 +56,6 @@ jobs:
           override: true
 
       - name: Run cargo build --no-default-features
-        working-directory: ecdsa
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTFLAGS: -D warnings
         run: cargo build --no-default-features --release --target ${{ matrix.target }}
 
   test:
@@ -65,7 +66,7 @@ jobs:
           - macos-latest
           - windows-latest
         toolchain:
-          - 1.40.0 # MSRV
+          - 1.41.0 # MSRV
           - stable
     runs-on: ${{ matrix.platform }}
     steps:
@@ -97,15 +98,7 @@ jobs:
           override: true
 
       - name: Run cargo test --lib
-        working-directory: ecdsa
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTFLAGS: -D warnings
         run: cargo test --lib --release
 
       - name: Run cargo test --all-features
-        working-directory: ecdsa
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTFLAGS: -D warnings
         run: cargo test --all-features --release

--- a/.github/workflows/ed25519.yml
+++ b/.github/workflows/ed25519.yml
@@ -6,9 +6,14 @@ on:
       - "Cargo.*"
   push:
     branches: master
-    paths:
-      - "ed25519/**"
-      - "Cargo.*"
+
+defaults:
+  run:
+    working-directory: ed25519
+
+env:
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: "-Dwarnings"
 
 jobs:
   build:
@@ -19,7 +24,7 @@ jobs:
           - thumbv7em-none-eabi
           - wasm32-unknown-unknown
         toolchain:
-          - 1.40.0 # MSRV
+          - 1.41.0 # MSRV
           - stable
     steps:
       - name: Checkout sources
@@ -51,10 +56,6 @@ jobs:
           override: true
 
       - name: Run cargo build --no-default-features
-        working-directory: ed25519
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTFLAGS: -D warnings
         run: cargo build --no-default-features --release --target ${{ matrix.target }}
 
   test:
@@ -65,7 +66,7 @@ jobs:
           - macos-latest
           - windows-latest
         toolchain:
-          - 1.40.0 # MSRV
+          - 1.41.0 # MSRV
           - stable
     runs-on: ${{ matrix.platform }}
     steps:
@@ -97,15 +98,7 @@ jobs:
           override: true
 
       - name: Run cargo test --lib
-        working-directory: ed25519
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTFLAGS: -D warnings
         run: cargo test --lib --release
 
       - name: Run cargo test --all-features
-        working-directory: ed25519
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTFLAGS: -D warnings
         run: cargo test --all-features --release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
  "block-padding",
  "byte-tools",
  "byteorder",
- "generic-array",
+ "generic-array 0.12.3",
 ]
 
 [[package]]
@@ -55,7 +55,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
- "generic-array",
+ "generic-array 0.12.3",
 ]
 
 [[package]]
@@ -63,7 +63,6 @@ name = "ecdsa"
 version = "0.5.0"
 dependencies = [
  "elliptic-curve",
- "generic-array",
  "k256",
  "p256",
  "p384",
@@ -82,11 +81,11 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01f69be7d1feb7a7a04f158aaf32c7deaa7604e9bd58145525e536438c4e5096"
+checksum = "2298f66754d859f4c099b0e645cfd258d2dfdfd1bac9496fd514d603ff6a5c6b"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.1",
  "getrandom",
  "subtle",
  "zeroize",
@@ -108,6 +107,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2664c2cf08049036f31015b04c6ac3671379a1d86f52ed2416893f16022deb"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a010224d825405c12a840fc269094683abe1282222f46c368318a02fa8876b"
+checksum = "c34f5cb67f9625a99c159fc0776e75d2e37f988cdf31c115e9c25225e61d858c"
 dependencies = [
  "elliptic-curve",
 ]
@@ -141,18 +149,18 @@ checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "p256"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86640e33ca638ec215c74de317696bbca5daa7d52cf55b905bd20a6bd2cfd133"
+checksum = "a425ecb71515663b2735fd1e65bb638fd134c5ad23857eb197c2f157784476cf"
 dependencies = [
  "elliptic-curve",
 ]
 
 [[package]]
 name = "p384"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aee0d9bdeedaea6cdd47f9281a9f8e1037d3037088b70e2af13c64ce65608ec"
+checksum = "9ae962014118ae1621d13f011e14902223013b1b4151922c3a682a233a967ddb"
 dependencies = [
  "elliptic-curve",
 ]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ and can be easily used for bare-metal or lightweight WebAssembly programming.
 
 ## Minimum Supported Rust Version
 
-All crates in this repository support Rust **1.40** or higher. In future minimum
+All crates in this repository support Rust **1.41** or higher. In future minimum
 supported Rust version can be changed, but it will be done with the minor
 version bump.
 
@@ -44,7 +44,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[rustc-image]: https://img.shields.io/badge/rustc-1.40+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
 
 [//]: # (crates)
 

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -15,26 +15,22 @@ categories    = ["cryptography", "no-std"]
 keywords      = ["crypto", "ecc", "nist", "secp256k1", "signature"]
 
 [dependencies.elliptic-curve]
-version = "0.3"
+version = "0.4"
 default-features = false
 features = ["weierstrass"]
 
-[dependencies.generic-array]
-version = "0.12"
-default-features = false
-
 [dependencies.k256]
-version = "0.2"
+version = "0.3"
 optional = true
 default-features = false
 
 [dependencies.p256]
-version = "0.2"
+version = "0.3"
 optional = true
 default-features = false
 
 [dependencies.p384]
-version = "0.1"
+version = "0.2"
 optional = true
 default-features = false
 

--- a/ecdsa/README.md
+++ b/ecdsa/README.md
@@ -22,9 +22,9 @@ ECDSA implementations, including HSMs or Cloud KMS services.
 
 [Documentation][docs-link]
 
-## Requirements
+## Minimum Supported Rust Version
 
-- Rust **1.40+**
+- Rust **1.41+**
 
 ## License
 
@@ -48,7 +48,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/ecdsa/badge.svg
 [docs-link]: https://docs.rs/ecdsa/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.40+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
 [build-image]: https://github.com/RustCrypto/signatures/workflows/ecdsa/badge.svg?branch=master&event=push
 [build-link]: https://github.com/RustCrypto/signatures/actions?query=workflow%3Aecdsa
 

--- a/ecdsa/src/asn1_signature.rs
+++ b/ecdsa/src/asn1_signature.rs
@@ -1,12 +1,12 @@
 //! ASN.1 DER-encoded ECDSA signatures
 
+use crate::generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
 use crate::{convert::ScalarPair, curve::Curve};
 use core::{
     convert::{TryFrom, TryInto},
     fmt::{self, Debug},
     ops::Add,
 };
-use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
 use signature::Error;
 
 /// Maximum overhead of an ASN.1 DER-encoded ECDSA signature for a given curve:
@@ -23,7 +23,7 @@ use signature::Error;
 /// - 1-byte: ASN.1 `INTEGER` tag (0x02)
 /// - 1-byte: length
 /// - 1-byte: zero to indicate value is positive (`INTEGER` is signed)
-pub type MaxOverhead = generic_array::typenum::U9;
+pub type MaxOverhead = crate::generic_array::typenum::U9;
 
 /// Maximum size of an ASN.1 DER encoded signature for the given elliptic curve.
 pub type MaxSize<ScalarSize> = <<ScalarSize as Add>::Output as Add<MaxOverhead>>::Output;

--- a/ecdsa/src/convert.rs
+++ b/ecdsa/src/convert.rs
@@ -8,12 +8,12 @@
 //! <https://www.bearssl.org/gitweb/?p=BearSSL;a=blob;f=src/ec/ecdsa_atr.c>
 //! <https://www.bearssl.org/gitweb/?p=BearSSL;a=blob;f=src/ec/ecdsa_rta.c>
 
+use crate::generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
 use crate::{
     asn1_signature::{self, Asn1Signature},
     Curve, FixedSignature,
 };
 use core::{marker::PhantomData, ops::Add};
-use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
 use signature::Signature;
 
 /// ASN.1 tags

--- a/ecdsa/src/fixed_signature.rs
+++ b/ecdsa/src/fixed_signature.rs
@@ -1,12 +1,12 @@
 //! Fixed-sized (a.k.a. "raw") ECDSA signatures
 
 use crate::curve::Curve;
+use crate::generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
 use core::{
     convert::{TryFrom, TryInto},
     fmt::{self, Debug},
     ops::Add,
 };
-use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
 use signature::Error;
 
 /// Size of a fixed sized signature for the given elliptic curve.

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -39,12 +39,6 @@
     html_root_url = "https://docs.rs/ecdsa/0.5.0"
 )]
 
-// Re-export the `generic-array` crate
-pub use generic_array;
-
-// Re-export the `signature` crate
-pub use signature;
-
 pub mod asn1_signature;
 mod convert;
 pub mod curve;
@@ -52,8 +46,12 @@ pub mod fixed_signature;
 #[cfg(feature = "test-vectors")]
 pub mod test_vectors;
 
+// Re-export the `signature` crate
+pub use signature;
+
 pub use self::{asn1_signature::Asn1Signature, fixed_signature::FixedSignature};
 pub use elliptic_curve::{
+    self, generic_array,
     weierstrass::{Curve, PublicKey},
     SecretKey,
 };

--- a/ed25519/README.md
+++ b/ed25519/README.md
@@ -21,9 +21,9 @@ Ed25519 implementations, including HSMs or Cloud KMS services.
 
 [Documentation][docs-link]
 
-## Requirements
+## Minimum Supported Rust Version
 
-- Rust **1.40+**
+- Rust **1.41+**
 
 ## License
 
@@ -47,7 +47,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/ed25519/badge.svg
 [docs-link]: https://docs.rs/ed25519/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.40+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
 [build-image]: https://github.com/RustCrypto/signatures/workflows/ed25519/badge.svg?branch=master&event=push
 [build-link]: https://github.com/RustCrypto/signatures/actions?query=workflow%3Aed25519
 

--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -15,7 +15,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust **1.40** or higher.
+//! Rust **1.41** or higher.
 //!
 //! Minimum supported Rust version may be changed in the future, but such
 //! changes will be accompanied with a minor version bump.


### PR DESCRIPTION
Bumps the following crate dependencies, which all now depend on `generic-array` v0.14:

- `elliptic-curve` v0.4.0
- `k256` v0.3.0
- `p256` v0.3.0
- `p384` v0.2.0

Also re-exports `generic-array` from the `elliptic-curve` crate rather than depending on it directly, which simplifies upgrades.