### PR TITLE
ecdsa v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "elliptic-curve",
  "k256",

--- a/ecdsa/CHANGELOG.md
+++ b/ecdsa/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2020-06-09)
+### Changed
+- Upgrade to `signature` ~1.1.0; `sha` v0.9 ([#87])
+- Bump all elliptic curve crates; MSRV 1.41+ ([#86])
+
+[#87]: https://github.com/RustCrypto/signatures/pull/87
+[#86]: https://github.com/RustCrypto/signatures/pull/86
+
 ## 0.5.0 (2020-04-18)
 ### Changed
 - Upgrade `signature` crate to v1.0 final release ([#80])

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ecdsa"
-version       = "0.5.0" # Also update html_root_url in lib.rs when bumping this
+version       = "0.6.0" # Also update html_root_url in lib.rs when bumping this
 description   = """
 Signature and elliptic curve types providing interoperable support for the
 Elliptic Curve Digital Signature Algorithm (ECDSA)


### PR DESCRIPTION
### Changed
- Upgrade to `signature` ~1.1.0; `sha` v0.9 ([#87])
- Bump all elliptic curve crates; MSRV 1.41+ ([#86])

[#87]: https://github.com/RustCrypto/signatures/pull/87
[#86]: https://github.com/RustCrypto/signatures/pull/86