### PR TITLE
ecdsa::curve::secp256k1::RecoverableSignature

### DIFF
--- a/ecdsa/src/asn1_signature.rs
+++ b/ecdsa/src/asn1_signature.rs
@@ -1,13 +1,16 @@
 //! ASN.1 DER-encoded ECDSA signatures
 
-use crate::generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
-use crate::{convert::ScalarPair, curve::Curve};
+use crate::{
+    convert::ScalarPair,
+    curve::Curve,
+    generic_array::{typenum::Unsigned, ArrayLength, GenericArray},
+    Error,
+};
 use core::{
     convert::{TryFrom, TryInto},
     fmt::{self, Debug},
     ops::Add,
 };
-use signature::Error;
 
 /// Maximum overhead of an ASN.1 DER-encoded ECDSA signature for a given curve:
 /// 9-bytes.
@@ -76,14 +79,14 @@ where
     }
 }
 
-impl<'a, C: Curve> TryFrom<&'a [u8]> for Asn1Signature<C>
+impl<C: Curve> TryFrom<&[u8]> for Asn1Signature<C>
 where
     MaxSize<C::ScalarSize>: ArrayLength<u8>,
     <C::ScalarSize as Add>::Output: ArrayLength<u8> + Add<MaxOverhead>,
 {
     type Error = Error;
 
-    fn try_from(slice: &'a [u8]) -> Result<Self, Error> {
+    fn try_from(slice: &[u8]) -> Result<Self, Error> {
         let length = slice.len();
 
         if <MaxSize<C::ScalarSize>>::to_usize() < length {

--- a/ecdsa/src/curve/secp256k1.rs
+++ b/ecdsa/src/curve/secp256k1.rs
@@ -1,11 +1,14 @@
 //! secp256k1 elliptic curve
 
-pub use k256::{PublicKey, Secp256k1, SecretKey};
+pub mod recoverable_signature;
 
-/// ASN.1 DER encoded secp256k1 ECDSA signature
+pub use k256::{PublicKey, Secp256k1, SecretKey};
+pub use recoverable_signature::{RecoverableSignature, RecoveryId};
+
+/// ASN.1 DER encoded secp256k1 ECDSA signature.
 pub type Asn1Signature = crate::Asn1Signature<Secp256k1>;
 
-/// Fixed-sized (a.k.a. "raw") secp256k1 ECDSA signature
+/// Fixed-sized (a.k.a. "raw") secp256k1 ECDSA signature.
 pub type FixedSignature = crate::FixedSignature<Secp256k1>;
 
 #[cfg(feature = "digest")]

--- a/ecdsa/src/curve/secp256k1/recoverable_signature.rs
+++ b/ecdsa/src/curve/secp256k1/recoverable_signature.rs
@@ -1,0 +1,105 @@
+//! Ethereum-style "recoverable signatures"
+
+use super::FixedSignature;
+use crate::{
+    generic_array::{typenum::U64, GenericArray},
+    Error,
+};
+use core::{
+    convert::{TryFrom, TryInto},
+    fmt::{self, Debug},
+};
+
+/// Size of an Ethereum-style recoverable signature in bytes
+pub const SIZE: usize = 65;
+
+/// Ethereum-style "recoverable signatures" which allow for the recovery of
+/// the signer's [`PublicKey`] from the signature itself.
+///
+/// These consist of [`FixedSignature`] followed by a 1-byte [`RecoveryId`]
+/// (65-bytes total):
+///
+/// - `r`: 32-bytes, big endian
+/// - `s`: 32-bytes, big endian
+/// - `v`: 1-byte [`RecoveryId`]
+#[derive(Copy, Clone)]
+pub struct RecoverableSignature {
+    bytes: [u8; SIZE],
+}
+
+impl RecoverableSignature {
+    /// Get the [`RecoveryId`] for this signature
+    pub fn recovery_id(self) -> RecoveryId {
+        self.bytes[0].try_into().expect("invalid recovery ID")
+    }
+}
+
+impl signature::Signature for RecoverableSignature {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
+        bytes.try_into()
+    }
+}
+
+impl AsRef<[u8]> for RecoverableSignature {
+    fn as_ref(&self) -> &[u8] {
+        &self.bytes[..]
+    }
+}
+
+impl Debug for RecoverableSignature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "RecoverableSignature {{ bytes: {:?}) }}", self.as_ref())
+    }
+}
+
+// TODO(tarcieri): derive `Eq` after const generics are available
+impl Eq for RecoverableSignature {}
+
+// TODO(tarcieri): derive `PartialEq` after const generics are available
+impl PartialEq for RecoverableSignature {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_ref().eq(other.as_ref())
+    }
+}
+
+impl TryFrom<&[u8]> for RecoverableSignature {
+    type Error = Error;
+
+    fn try_from(bytes: &[u8]) -> Result<Self, Error> {
+        if bytes.len() == SIZE && RecoveryId::try_from(bytes[64]).is_ok() {
+            let mut arr = [0u8; SIZE];
+            arr.copy_from_slice(bytes);
+            Ok(Self { bytes: arr })
+        } else {
+            Err(Error::new())
+        }
+    }
+}
+
+impl From<RecoverableSignature> for FixedSignature {
+    fn from(sig: RecoverableSignature) -> FixedSignature {
+        GenericArray::<u8, U64>::clone_from_slice(&sig.bytes[..64]).into()
+    }
+}
+
+/// Identifier used to compute a `PublicKey` from a [`RecoverableSignature`]
+#[derive(Copy, Clone, Debug)]
+pub struct RecoveryId(u8);
+
+impl TryFrom<u8> for RecoveryId {
+    type Error = Error;
+
+    fn try_from(byte: u8) -> Result<Self, Error> {
+        if byte < 4 {
+            Ok(Self(byte))
+        } else {
+            Err(Error::new())
+        }
+    }
+}
+
+impl From<RecoveryId> for u8 {
+    fn from(recovery_id: RecoveryId) -> u8 {
+        recovery_id.0
+    }
+}

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -46,12 +46,14 @@ pub mod fixed_signature;
 #[cfg(feature = "test-vectors")]
 pub mod test_vectors;
 
-// Re-export the `signature` crate
-pub use signature;
-
 pub use self::{asn1_signature::Asn1Signature, fixed_signature::FixedSignature};
+
+// Re-export the `elliptic-curve` crate (and select types)
 pub use elliptic_curve::{
     self, generic_array,
     weierstrass::{Curve, PublicKey},
     SecretKey,
 };
+
+// Re-export the `signature` crate (and select types)
+pub use signature::{self, Error};


### PR DESCRIPTION
Adds a signature type for Ethereum-style recoverable signatures.