### PR TITLE
ecdsa: add doc_cfg

### DIFF
--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -52,3 +52,4 @@ test-vectors = []
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/ecdsa/src/curve.rs
+++ b/ecdsa/src/curve.rs
@@ -2,17 +2,32 @@
 
 pub use elliptic_curve::weierstrass::{point::*, Curve};
 
+// NIST P-256
+
 #[cfg(feature = "p256")]
+#[cfg_attr(docsrs, doc(cfg(feature = "p256")))]
 pub mod nistp256;
+
 #[cfg(feature = "p256")]
+#[cfg_attr(docsrs, doc(cfg(feature = "p256")))]
 pub use self::nistp256::NistP256;
 
+// NIST P-384
+
 #[cfg(feature = "p384")]
+#[cfg_attr(docsrs, doc(cfg(feature = "p384")))]
 pub mod nistp384;
+
 #[cfg(feature = "p384")]
+#[cfg_attr(docsrs, doc(cfg(feature = "p384")))]
 pub use self::nistp384::NistP384;
 
+// secp256k1 (K-256)
+
 #[cfg(feature = "k256")]
+#[cfg_attr(docsrs, doc(cfg(feature = "k256")))]
 pub mod secp256k1;
+
 #[cfg(feature = "k256")]
+#[cfg_attr(docsrs, doc(cfg(feature = "k256")))]
 pub use self::secp256k1::Secp256k1;

--- a/ecdsa/src/curve/secp256k1/recoverable_signature.rs
+++ b/ecdsa/src/curve/secp256k1/recoverable_signature.rs
@@ -10,17 +10,20 @@ use core::{
     fmt::{self, Debug},
 };
 
+#[cfg(docsrs)]
+use super::PublicKey;
+
 /// Size of an Ethereum-style recoverable signature in bytes
 pub const SIZE: usize = 65;
 
 /// Ethereum-style "recoverable signatures" which allow for the recovery of
 /// the signer's [`PublicKey`] from the signature itself.
 ///
-/// These consist of [`FixedSignature`] followed by a 1-byte [`RecoveryId`]
-/// (65-bytes total):
+/// This format consists of [`FixedSignature`] followed by a 1-byte
+/// [`RecoveryId`] (65-bytes total):
 ///
-/// - `r`: 32-bytes, big endian
-/// - `s`: 32-bytes, big endian
+/// - `r`: 32-byte integer, big endian
+/// - `s`: 32-byte integer, big endian
 /// - `v`: 1-byte [`RecoveryId`]
 #[derive(Copy, Clone)]
 pub struct RecoverableSignature {

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -22,16 +22,11 @@
 //! providers can be plugged in, enabling support for using different
 //! ECDSA implementations, including HSMs or Cloud KMS services.
 //!
-//! ## TODO
-//!
-//! - NIST P-521
-//! - Brainpool
-//! - Const generics(!)
-//!
 //! [1]: https://csrc.nist.gov/publications/detail/fips/186/4/final
 //! [2]: http://docs.rs/elliptic-curve
 
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, intra_doc_link_resolution_failure)]
 #![doc(
@@ -44,6 +39,7 @@ mod convert;
 pub mod curve;
 pub mod fixed_signature;
 #[cfg(feature = "test-vectors")]
+#[cfg_attr(docsrs, doc(cfg(feature = "test-vectors")))]
 pub mod test_vectors;
 
 pub use self::{asn1_signature::Asn1Signature, fixed_signature::FixedSignature};


### PR DESCRIPTION
Uses the nightly-only `doc_cfg` feature to document which modules/types are gated behind cargo features (namely `k256`, `p256`, and `p384`)

This is intended for use with https://docs.rs