### PR TITLE
ecdsa v0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "elliptic-curve",
  "k256",

--- a/ecdsa/CHANGELOG.md
+++ b/ecdsa/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.1 (2020-06-29)
+### Added
+- `doc_cfg` attributes for https://docs.rs ([#91])
+- `ecdsa::curve::secp256k1::RecoverableSignature` ([#90])
+
+[#91]: https://github.com/RustCrypto/signatures/pull/91
+[#90]: https://github.com/RustCrypto/signatures/pull/90
+
 ## 0.6.0 (2020-06-09)
 ### Changed
 - Upgrade to `signature` ~1.1.0; `sha` v0.9 ([#87])

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ecdsa"
-version       = "0.6.0" # Also update html_root_url in lib.rs when bumping this
+version       = "0.6.1" # Also update html_root_url in lib.rs when bumping this
 description   = """
 Signature and elliptic curve types providing interoperable support for the
 Elliptic Curve Digital Signature Algorithm (ECDSA)

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -31,7 +31,7 @@
 #![warn(missing_docs, rust_2018_idioms, intra_doc_link_resolution_failure)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png",
-    html_root_url = "https://docs.rs/ecdsa/0.5.0"
+    html_root_url = "https://docs.rs/ecdsa/0.6.1"
 )]
 
 pub mod asn1_signature;


### PR DESCRIPTION
### Added
- `doc_cfg` attributes for https://docs.rs ([#91])
- `ecdsa::curve::secp256k1::RecoverableSignature` ([#90])

[#91]: https://github.com/RustCrypto/signatures/pull/91
[#90]: https://github.com/RustCrypto/signatures/pull/90