### PR TITLE
ecdsa: implement secp256k1 low-S normalization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ dependencies = [
 [[package]]
 name = "elliptic-curve"
 version = "0.4.0"
-source = "git+https://github.com/RustCrypto/elliptic-curves#d1a8376b5520646fcb536e1094289bc65391b48d"
+source = "git+https://github.com/RustCrypto/elliptic-curves#fd3516fde64d5d9ef160f1c4392d807ca7ede6ea"
 dependencies = [
  "generic-array",
  "subtle",
@@ -101,7 +101,7 @@ dependencies = [
 [[package]]
 name = "k256"
 version = "0.3.0"
-source = "git+https://github.com/RustCrypto/elliptic-curves#d1a8376b5520646fcb536e1094289bc65391b48d"
+source = "git+https://github.com/RustCrypto/elliptic-curves#fd3516fde64d5d9ef160f1c4392d807ca7ede6ea"
 dependencies = [
  "elliptic-curve",
 ]
@@ -115,7 +115,7 @@ checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 [[package]]
 name = "p256"
 version = "0.3.0"
-source = "git+https://github.com/RustCrypto/elliptic-curves#d1a8376b5520646fcb536e1094289bc65391b48d"
+source = "git+https://github.com/RustCrypto/elliptic-curves#fd3516fde64d5d9ef160f1c4392d807ca7ede6ea"
 dependencies = [
  "elliptic-curve",
 ]
@@ -123,7 +123,7 @@ dependencies = [
 [[package]]
 name = "p384"
 version = "0.2.0"
-source = "git+https://github.com/RustCrypto/elliptic-curves#d1a8376b5520646fcb536e1094289bc65391b48d"
+source = "git+https://github.com/RustCrypto/elliptic-curves#fd3516fde64d5d9ef160f1c4392d807ca7ede6ea"
 dependencies = [
  "elliptic-curve",
 ]

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -46,6 +46,7 @@ default-features = false
 [features]
 default = ["digest", "std", "zeroize"]
 digest = ["signature/digest-preview", "sha2"]
+k256-arithmetic = ["k256/arithmetic"]
 std = ["elliptic-curve/std", "signature/std"]
 zeroize = ["elliptic-curve/zeroize"]
 test-vectors = []

--- a/ecdsa/src/curve/secp256k1.rs
+++ b/ecdsa/src/curve/secp256k1.rs
@@ -1,9 +1,14 @@
 //! secp256k1 elliptic curve
 
+#[cfg(feature = "k256-arithmetic")]
+mod normalize_s;
 pub mod recoverable_signature;
 
 pub use k256::{PublicKey, Secp256k1, SecretKey};
 pub use recoverable_signature::{RecoverableSignature, RecoveryId};
+
+#[cfg(feature = "k256-arithmetic")]
+use normalize_s::ScalarPair;
 
 /// ASN.1 DER encoded secp256k1 ECDSA signature.
 pub type Asn1Signature = crate::Asn1Signature<Secp256k1>;
@@ -19,4 +24,29 @@ impl signature::PrehashSignature for Asn1Signature {
 #[cfg(feature = "digest")]
 impl signature::PrehashSignature for FixedSignature {
     type Digest = sha2::Sha256;
+}
+
+#[cfg(feature = "k256-arithmetic")]
+impl Asn1Signature {
+    /// Normalize signature into "low S" form as described in
+    /// [BIP 0062: Dealing with Malleability][1].
+    ///
+    /// [1]: https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki
+    pub fn normalize_s(&self) -> Result<Self, signature::Error> {
+        // The `Asn1Signature` type should always contain a valid ASN.1 signature
+        let r_and_s = ScalarPair::from_asn1_signature(&self).expect("invalid ASN.1 signature");
+        normalize_s::normalize_s(r_and_s).map(|sig| Self::from(&sig))
+    }
+}
+
+#[cfg(feature = "k256-arithmetic")]
+impl FixedSignature {
+    /// Normalize signature into "low S" form as described in
+    /// [BIP 0062: Dealing with Malleability][1].
+    ///
+    /// [1]: https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki
+    pub fn normalize_s(&self) -> Result<Self, signature::Error> {
+        let r_and_s = ScalarPair::from_fixed_signature(&self);
+        normalize_s::normalize_s(r_and_s)
+    }
 }

--- a/ecdsa/src/curve/secp256k1/normalize_s.rs
+++ b/ecdsa/src/curve/secp256k1/normalize_s.rs
@@ -1,0 +1,94 @@
+//! Support for normalizing the s-component of ECDSA signatures to the lower
+//! half of the modulus as described in the [Low S values in signatures][1]
+//! section of [BIP 0062: Dealing with Malleability][2].
+//!
+//! [1]: https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki#Low_S_values_in_signatures
+//! [2]: https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki
+
+use super::{FixedSignature, Secp256k1};
+use crate::generic_array::GenericArray;
+use k256::{elliptic_curve::subtle::ConditionallySelectable, Scalar};
+use signature::Error;
+
+/// `(r,s)` pair of scalars which comprise a secp256k1 ECDSA signature
+pub(super) type ScalarPair<'a> = crate::convert::ScalarPair<'a, Secp256k1>;
+
+/// Size of a secp256k1 scalar
+const SCALAR_SIZE: usize = 32;
+
+/// Normalize the `s` component of the given [`ScalarPair`] to the lower half
+/// of the modulus.
+pub(super) fn normalize_s(r_and_s: ScalarPair<'_>) -> Result<FixedSignature, Error> {
+    let mut s_bytes = [0u8; SCALAR_SIZE];
+    r_and_s.write_s(&mut s_bytes);
+
+    let s_option = Scalar::from_bytes(s_bytes);
+
+    // Not constant time, but we're operating on public values
+    let s = if s_option.is_some().into() {
+        s_option.unwrap()
+    } else {
+        return Err(Error::new());
+    };
+
+    // Negate `s` if it's within the upper half of the modulus
+    let s_neg = -s;
+    let low_s = Scalar::conditional_select(&s, &s_neg, s.is_high());
+
+    let mut bytes = GenericArray::default();
+    r_and_s.write_r(&mut bytes[..SCALAR_SIZE]);
+    bytes[SCALAR_SIZE..].copy_from_slice(&low_s.to_bytes());
+
+    Ok(FixedSignature::from(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use signature::Signature;
+
+    #[test]
+    fn already_normalized() {
+        #[rustfmt::skip]
+        let sig = FixedSignature::from_bytes(&[
+            1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ]).unwrap();
+
+        let sig_normalized = sig.normalize_s().unwrap();
+        assert_eq!(sig, sig_normalized);
+    }
+
+    // Test vectors generated using rust-secp256k1
+    #[test]
+    fn not_normalized() {
+        #[rustfmt::skip]
+        let sig_hi = FixedSignature::from_bytes(&[
+            0x20, 0xc0, 0x1a, 0x91, 0x0e, 0xbb, 0x26, 0x10,
+            0xaf, 0x2d, 0x76, 0x3f, 0xa0, 0x9b, 0x3b, 0x30,
+            0x92, 0x3c, 0x8e, 0x40, 0x8b, 0x11, 0xdf, 0x2c,
+            0x61, 0xad, 0x76, 0xd9, 0x70, 0xa2, 0xf1, 0xbc,
+            0xee, 0x2f, 0x11, 0xef, 0x8c, 0xb0, 0x0a, 0x49,
+            0x61, 0x7d, 0x13, 0x57, 0xf4, 0xd5, 0x56, 0x41,
+            0x09, 0x0a, 0x48, 0xf2, 0x01, 0xe9, 0xb9, 0x59,
+            0xc4, 0x8f, 0x6f, 0x6b, 0xec, 0x6f, 0x93, 0x8f,
+        ]).unwrap();
+
+        #[rustfmt::skip]
+        let sig_lo = FixedSignature::from_bytes(&[
+            0x20, 0xc0, 0x1a, 0x91, 0x0e, 0xbb, 0x26, 0x10,
+            0xaf, 0x2d, 0x76, 0x3f, 0xa0, 0x9b, 0x3b, 0x30,
+            0x92, 0x3c, 0x8e, 0x40, 0x8b, 0x11, 0xdf, 0x2c,
+            0x61, 0xad, 0x76, 0xd9, 0x70, 0xa2, 0xf1, 0xbc,
+            0x11, 0xd0, 0xee, 0x10, 0x73, 0x4f, 0xf5, 0xb6,
+            0x9e, 0x82, 0xec, 0xa8, 0x0b, 0x2a, 0xa9, 0xbd,
+            0xb1, 0xa4, 0x93, 0xf4, 0xad, 0x5e, 0xe6, 0xe1,
+            0xfb, 0x42, 0xef, 0x20, 0xe3, 0xc6, 0xad, 0xb2,
+        ]).unwrap();
+
+        let sig_normalized = sig_hi.normalize_s().unwrap();
+        assert_eq!(sig_lo, sig_normalized);
+    }
+}


### PR DESCRIPTION
Adds `normalize_s` method to `secp256k1::{Asn1Signature, FixedSignature}` when the (new) `k256-arithmetic` feature is enabled.

This normalizes the s-component of ECDSA signatures in order to make them non-malleable as described in [BIP 0062: Dealing with Malleability](https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki).