### PR TITLE
ecdsa: add DigestPrimitive

### DIFF
--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -30,4 +30,5 @@ hazmat = []
 std = ["elliptic-curve/std", "signature/std"]
 
 [package.metadata.docs.rs]
+features = ["digest", "std"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -26,6 +26,7 @@
 pub mod asn1;
 
 #[cfg(feature = "hazmat")]
+#[cfg_attr(docsrs, doc(cfg(feature = "hazmat")))]
 pub mod hazmat;
 
 // Re-export the `elliptic-curve` crate (and select types)


### PR DESCRIPTION
The `DigestPrimitive` trait, intended to be implemented within a crate which impls `elliptic_curve::weierstrass::Curve`, provides a blanket impl of `PrehashSignature` for `ecdsa::Signature<C: Curve>`.

This is a small hack needed to work around the fact that the ECDSA signature trait now lies in an external crate, so crates which implement a specific curve can no longer impl traits on `ecdsa::Signature`.