### PR TITLE
ecdsa: use signature::Error in `hazmat` module

### DIFF
--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -12,7 +12,8 @@
 //! FULL PRIVATE KEY RECOVERY!
 
 use crate::{Signature, SignatureSize};
-use elliptic_curve::{generic_array::ArrayLength, weierstrass::Curve, Error, ScalarBytes};
+use elliptic_curve::{generic_array::ArrayLength, weierstrass::Curve, ScalarBytes};
+use signature::Error;
 
 #[cfg(feature = "digest")]
 use signature::{digest::Digest, PrehashSignature};


### PR DESCRIPTION
It previously used `elliptic_curve::Error` instead by mistake