### PR TITLE
ecdsa: implement RustCrypto/traits#223 updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 [[package]]
 name = "elliptic-curve"
 version = "0.5.0-pre"
-source = "git+https://github.com/RustCrypto/traits#3e7b861581185d7350db3315cd1a99b4c6d382e4"
+source = "git+https://github.com/RustCrypto/traits#3fd8ac7fa787cfbea275306fab011a592206b1b2"
 dependencies = [
  "generic-array",
  "subtle",

--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -43,7 +43,7 @@ where
         &self,
         ephemeral_scalar: &Self::Scalar,
         masking_scalar: Option<&Self::Scalar>,
-        hashed_msg: &ScalarBytes<C::ScalarSize>,
+        hashed_msg: &ScalarBytes<C>,
     ) -> Result<Signature<C>, Error>;
 }
 
@@ -66,7 +66,7 @@ where
     /// - `signature`: signature to be verified against the key and message
     fn verify_prehashed(
         &self,
-        hashed_msg: &ScalarBytes<C::ScalarSize>,
+        hashed_msg: &ScalarBytes<C>,
         signature: &Signature<C>,
     ) -> Result<(), Error>;
 }
@@ -92,7 +92,7 @@ pub trait DigestPrimitive: Curve {
 #[cfg(feature = "digest")]
 impl<C: DigestPrimitive> PrehashSignature for Signature<C>
 where
-    <C::ScalarSize as core::ops::Add>::Output: ArrayLength<u8>,
+    <C::ElementSize as core::ops::Add>::Output: ArrayLength<u8>,
 {
     type Digest = C::Digest;
 }


### PR DESCRIPTION
Updates usages of the `elliptic-curve` crate API to incorporate the changes from https://github.com/RustCrypto/traits/pull/223