### PR TITLE
ecdsa: make SignPrimitive's ephemeral scalar generic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 [[package]]
 name = "elliptic-curve"
 version = "0.5.0-pre"
-source = "git+https://github.com/RustCrypto/traits#3fd8ac7fa787cfbea275306fab011a592206b1b2"
+source = "git+https://github.com/RustCrypto/traits#f8a916bbcff07aece243db24f17f663d4077baba"
 dependencies = [
  "generic-array",
  "subtle",

--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -12,7 +12,9 @@
 //! FULL PRIVATE KEY RECOVERY!
 
 use crate::{Signature, SignatureSize};
-use elliptic_curve::{generic_array::ArrayLength, weierstrass::Curve, Arithmetic, ScalarBytes};
+use elliptic_curve::{
+    generic_array::ArrayLength, ops::Invert, weierstrass::Curve, Arithmetic, ScalarBytes,
+};
 use signature::Error;
 
 #[cfg(feature = "digest")]
@@ -33,12 +35,10 @@ where
     /// Accepts the following arguments:
     ///
     /// - `ephemeral_scalar`: ECDSA `k` value (MUST BE UNIFORMLY RANDOM!!!)
-    /// - `masking_scalar`: optional blinding factor for sidechannel resistance
     /// - `hashed_msg`: prehashed message to be signed
-    fn try_sign_prehashed(
+    fn try_sign_prehashed<K: Into<C::Scalar> + Invert<Output = C::Scalar>>(
         &self,
-        ephemeral_scalar: &C::Scalar,
-        masking_scalar: Option<&C::Scalar>,
+        ephemeral_scalar: &K,
         hashed_msg: &ScalarBytes<C>,
     ) -> Result<Signature<C>, Error>;
 }


### PR DESCRIPTION
...and remove `masking_scalar`.

This API allows the inversion masking process to be handled outside of the ECDSA implementation itself (potentially generically in a way that can work across elliptic curves).