### PR TITLE
ecdsa: SignPrimitive bounds and dev macro fixups

### DIFF
--- a/ecdsa/src/dev.rs
+++ b/ecdsa/src/dev.rs
@@ -41,7 +41,7 @@ macro_rules! new_signing_test {
                 let d = Scalar::from_bytes(vector.d.try_into().unwrap()).unwrap();
                 let k = Scalar::from_bytes(vector.k.try_into().unwrap()).unwrap();
                 let sig = d
-                    .try_sign_prehashed(&k, None, GenericArray::from_slice(vector.m))
+                    .try_sign_prehashed(&k, GenericArray::from_slice(vector.m))
                     .unwrap();
 
                 assert_eq!(vector.r, sig.r().as_slice());
@@ -72,7 +72,6 @@ macro_rules! new_verification_test {
                 );
 
                 let result = q.verify_prehashed(GenericArray::from_slice(vector.m), &sig);
-
                 assert!(result.is_ok());
             }
         }
@@ -94,11 +93,10 @@ macro_rules! new_verification_test {
                 let sig = Signature::from_scalars(GenericArray::from_slice(vector.r), &s_tweaked);
 
                 let result = q.verify_prehashed(GenericArray::from_slice(vector.m), &sig);
-
                 assert!(result.is_err());
             }
         }
 
-        // TODO(tarcieri): test invalid q, invalid r, invalid m
+        // TODO(tarcieri): test invalid Q, invalid r, invalid m
     };
 }

--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -36,7 +36,7 @@ where
     ///
     /// - `ephemeral_scalar`: ECDSA `k` value (MUST BE UNIFORMLY RANDOM!!!)
     /// - `hashed_msg`: prehashed message to be signed
-    fn try_sign_prehashed<K: Into<C::Scalar> + Invert<Output = C::Scalar>>(
+    fn try_sign_prehashed<K: AsRef<C::Scalar> + Invert<Output = C::Scalar>>(
         &self,
         ephemeral_scalar: &K,
         hashed_msg: &ScalarBytes<C>,


### PR DESCRIPTION
Changes the `Into` bound on the `K` generic parameter to `SignPrimitive` to an `AsRef<C::Scalar>`. This avoids making unnecessary copies as well as simplifying type inference.

Also fixes the macros in the `dev` module to use the new two parameter `SignPrimitive` interface.