### PR TITLE
ecdsa: Verifier facade (gated under `verifier` feature)

### DIFF
--- a/.github/workflows/ecdsa.yml
+++ b/.github/workflows/ecdsa.yml
@@ -36,6 +36,7 @@ jobs:
           override: true
       - run: cargo build --no-default-features --release --target ${{ matrix.target }}
       - run: cargo build --no-default-features --features signer --release --target ${{ matrix.target }}
+      - run: cargo build --no-default-features --features verifier --release --target ${{ matrix.target }}
 
   test:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 [[package]]
 name = "elliptic-curve"
 version = "0.5.0-pre"
-source = "git+https://github.com/RustCrypto/traits#cb1fdb7ca135d02f9cadf819e036e95d024248f2"
+source = "git+https://github.com/RustCrypto/traits#a65edce5d5ee2f5daec882d68fe00f860674f542"
 dependencies = [
  "generic-array",
  "rand_core",

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -31,6 +31,7 @@ hazmat = []
 rand = ["elliptic-curve/rand_core", "signature/rand-preview"]
 signer = ["digest", "hazmat", "rand", "zeroize"] # TODO(tarcieri): deterministic signing
 std = ["elliptic-curve/std", "signature/std"]
+verifier = ["digest", "hazmat"]
 zeroize = ["elliptic-curve/zeroize"]
 
 [package.metadata.docs.rs]

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -37,6 +37,10 @@ pub mod hazmat;
 #[cfg_attr(docsrs, doc(cfg(feature = "signer")))]
 pub mod signer;
 
+#[cfg(feature = "verifier")]
+#[cfg_attr(docsrs, doc(cfg(feature = "verifier")))]
+pub mod verifier;
+
 // Re-export the `elliptic-curve` crate (and select types)
 pub use elliptic_curve::{
     self, generic_array,
@@ -49,6 +53,9 @@ pub use signature::{self, Error};
 
 #[cfg(feature = "signer")]
 pub use signer::Signer;
+
+#[cfg(feature = "verifier")]
+pub use verifier::Verifier;
 
 use core::{
     convert::TryFrom,

--- a/ecdsa/src/verifier.rs
+++ b/ecdsa/src/verifier.rs
@@ -1,0 +1,71 @@
+//! ECDSA verifier. Generic over elliptic curves.
+//!
+//! Requires an [`elliptic_curve::Arithmetic`] impl on the curve, and a
+//! [`VerifyPrimitive`] impl on its associated `AffinePoint` type.
+
+use crate::{
+    hazmat::{DigestPrimitive, VerifyPrimitive},
+    Error, Signature, SignatureSize,
+};
+use core::ops::Add;
+use elliptic_curve::{
+    consts::U1,
+    generic_array::ArrayLength,
+    weierstrass::{CompressedPointSize, Curve, FromPublicKey, PublicKey, UncompressedPointSize},
+    Arithmetic,
+};
+use signature::{digest::Digest, DigestVerifier};
+
+/// ECDSA verifier
+pub struct Verifier<C: Curve + Arithmetic> {
+    public_key: C::AffinePoint,
+}
+
+impl<C> Verifier<C>
+where
+    C: Curve + Arithmetic,
+    C::AffinePoint: VerifyPrimitive<C> + FromPublicKey<C>,
+    C::ElementSize: Add<U1>,
+    <C::ElementSize as Add>::Output: Add<U1>,
+    CompressedPointSize<C>: ArrayLength<u8>,
+    UncompressedPointSize<C>: ArrayLength<u8>,
+    SignatureSize<C>: ArrayLength<u8>,
+{
+    /// Create a new verifier
+    pub fn new(public_key: &PublicKey<C>) -> Result<Self, Error> {
+        let affine_point = C::AffinePoint::from_public_key(public_key);
+
+        if affine_point.is_some().into() {
+            Ok(Self {
+                public_key: affine_point.unwrap(),
+            })
+        } else {
+            Err(Error::new())
+        }
+    }
+}
+
+impl<C, D> DigestVerifier<D, Signature<C>> for Verifier<C>
+where
+    C: Curve + Arithmetic,
+    D: Digest<OutputSize = C::ElementSize>,
+    C::AffinePoint: VerifyPrimitive<C>,
+    SignatureSize<C>: ArrayLength<u8>,
+{
+    fn verify_digest(&self, digest: D, signature: &Signature<C>) -> Result<(), Error> {
+        self.public_key
+            .verify_prehashed(&digest.finalize(), signature)
+    }
+}
+
+impl<C> signature::Verifier<Signature<C>> for Verifier<C>
+where
+    C: Curve + Arithmetic + DigestPrimitive,
+    C::AffinePoint: VerifyPrimitive<C>,
+    C::Digest: Digest<OutputSize = C::ElementSize>,
+    SignatureSize<C>: ArrayLength<u8>,
+{
+    fn verify(&self, msg: &[u8], signature: &Signature<C>) -> Result<(), Error> {
+        self.verify_digest(C::Digest::new().chain(msg), signature)
+    }
+}


### PR DESCRIPTION
Adds a `ecdsa::verifier::Verifier` facade which handles parsing of `PublicKey` and computing digests of messages, ala the `Signer` facade added in #109.

The implementation is generic over the elliptic curve and digest function, providing a `DigestVerifier` impl, and when the curve type impls `DigestPrimitive`, a `Verifier` impl as well.