### PR TITLE
ecdsa: add hazmat::RecoverableSignPrimitive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 [[package]]
 name = "elliptic-curve"
 version = "0.5.0-pre"
-source = "git+https://github.com/RustCrypto/traits#a65edce5d5ee2f5daec882d68fe00f860674f542"
+source = "git+https://github.com/RustCrypto/traits#920522ae53f03483a27b24bc8e924db9e8aff29c"
 dependencies = [
  "generic-array",
  "rand_core",


### PR DESCRIPTION
Trait for signature algorithm implementations that support public key recovery, with a blanket impl for `SignPrimitive`.