### PR TITLE
ecdsa: rename ScalarBytes to ElementBytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 [[package]]
 name = "elliptic-curve"
 version = "0.5.0-pre"
-source = "git+https://github.com/RustCrypto/traits#920522ae53f03483a27b24bc8e924db9e8aff29c"
+source = "git+https://github.com/RustCrypto/traits#1dd4bc5ebc1f7c16e4a76fa6264b796579b4685e"
 dependencies = [
  "generic-array",
  "rand_core",

--- a/ecdsa/src/asn1.rs
+++ b/ecdsa/src/asn1.rs
@@ -15,7 +15,7 @@ use core::{
     fmt,
     ops::{Add, Range},
 };
-use elliptic_curve::{consts::U9, weierstrass::Curve, ScalarBytes};
+use elliptic_curve::{consts::U9, weierstrass::Curve, ElementBytes};
 
 /// Maximum overhead of an ASN.1 DER-encoded ECDSA signature for a given curve:
 /// 9-bytes.
@@ -93,7 +93,7 @@ where
     }
 
     /// Create an ASN.1 DER encoded signature from the `r` and `s` scalars
-    pub(crate) fn from_scalars(r: &ScalarBytes<C>, s: &ScalarBytes<C>) -> Self {
+    pub(crate) fn from_scalars(r: &ElementBytes<C>, s: &ElementBytes<C>) -> Self {
         let r_len = int_length(r);
         let s_len = int_length(s);
         let scalar_size = C::ElementSize::to_usize();

--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -14,7 +14,7 @@
 use crate::{Signature, SignatureSize};
 use core::borrow::Borrow;
 use elliptic_curve::{
-    generic_array::ArrayLength, ops::Invert, weierstrass::Curve, Arithmetic, ScalarBytes,
+    generic_array::ArrayLength, ops::Invert, weierstrass::Curve, Arithmetic, ElementBytes,
 };
 use signature::Error;
 
@@ -41,7 +41,7 @@ where
     fn try_sign_prehashed<K: Borrow<C::Scalar> + Invert<Output = C::Scalar>>(
         &self,
         ephemeral_scalar: &K,
-        hashed_msg: &ScalarBytes<C>,
+        hashed_msg: &ElementBytes<C>,
     ) -> Result<Signature<C>, Error>;
 }
 
@@ -61,7 +61,7 @@ where
     fn try_sign_recoverable_prehashed<K: Borrow<C::Scalar> + Invert<Output = C::Scalar>>(
         &self,
         ephemeral_scalar: &K,
-        hashed_msg: &ScalarBytes<C>,
+        hashed_msg: &ElementBytes<C>,
     ) -> Result<(Signature<C>, bool), Error>;
 }
 
@@ -74,7 +74,7 @@ where
     fn try_sign_prehashed<K: Borrow<C::Scalar> + Invert<Output = C::Scalar>>(
         &self,
         ephemeral_scalar: &K,
-        hashed_msg: &ScalarBytes<C>,
+        hashed_msg: &ElementBytes<C>,
     ) -> Result<Signature<C>, Error> {
         let (sig, _) = self.try_sign_recoverable_prehashed(ephemeral_scalar, hashed_msg)?;
         Ok(sig)
@@ -100,7 +100,7 @@ where
     /// - `signature`: signature to be verified against the key and message
     fn verify_prehashed(
         &self,
-        hashed_msg: &ScalarBytes<C>,
+        hashed_msg: &ElementBytes<C>,
         signature: &Signature<C>,
     ) -> Result<(), Error>;
 }

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -62,7 +62,7 @@ use core::{
     fmt::{self, Debug},
     ops::Add,
 };
-use elliptic_curve::ScalarBytes;
+use elliptic_curve::ElementBytes;
 use generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
 
 /// Size of a fixed sized signature for the given elliptic curve.
@@ -100,7 +100,7 @@ where
     SignatureSize<C>: ArrayLength<u8>,
 {
     /// Create a [`Signature`] from the serialized `r` and `s` components
-    pub fn from_scalars(r: &ScalarBytes<C>, s: &ScalarBytes<C>) -> Self {
+    pub fn from_scalars(r: &ElementBytes<C>, s: &ElementBytes<C>) -> Self {
         let mut bytes = SignatureBytes::<C>::default();
         let scalar_size = C::ElementSize::to_usize();
         bytes[..scalar_size].copy_from_slice(r.as_slice());
@@ -129,13 +129,13 @@ where
     }
 
     /// Get the `r` component of this signature
-    pub fn r(&self) -> &ScalarBytes<C> {
-        ScalarBytes::<C>::from_slice(&self.bytes[..C::ElementSize::to_usize()])
+    pub fn r(&self) -> &ElementBytes<C> {
+        ElementBytes::<C>::from_slice(&self.bytes[..C::ElementSize::to_usize()])
     }
 
     /// Get the `s` component of this signature
-    pub fn s(&self) -> &ScalarBytes<C> {
-        ScalarBytes::<C>::from_slice(&self.bytes[C::ElementSize::to_usize()..])
+    pub fn s(&self) -> &ElementBytes<C> {
+        ElementBytes::<C>::from_slice(&self.bytes[C::ElementSize::to_usize()..])
     }
 }
 


### PR DESCRIPTION
Per RustCrypto/traits#246