### PR TITLE
ecdsa: use new `elliptic_curve::encoding` module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 [[package]]
 name = "elliptic-curve"
 version = "0.5.0-pre"
-source = "git+https://github.com/RustCrypto/traits#1dd4bc5ebc1f7c16e4a76fa6264b796579b4685e"
+source = "git+https://github.com/RustCrypto/traits#1b3dffb7f194176a97730a72d493e5368ac69359"
 dependencies = [
  "generic-array",
  "rand_core",

--- a/ecdsa/src/signer.rs
+++ b/ecdsa/src/signer.rs
@@ -10,12 +10,12 @@ use crate::{
     Error, Signature, SignatureSize,
 };
 use elliptic_curve::{
+    encoding::FromBytes,
     generic_array::ArrayLength,
     ops::Invert,
-    secret_key::{FromSecretKey, SecretKey},
     weierstrass::Curve,
     zeroize::{Zeroize, Zeroizing},
-    Arithmetic,
+    Arithmetic, SecretKey,
 };
 
 #[cfg(feature = "rand")]
@@ -46,7 +46,7 @@ where
 {
     /// Create a new signer
     pub fn new(secret_key: &SecretKey<C>) -> Result<Self, Error> {
-        let scalar = C::Scalar::from_secret_key(secret_key);
+        let scalar = C::Scalar::from_bytes(secret_key.as_bytes());
 
         if scalar.is_some().into() {
             Ok(Self {

--- a/ecdsa/src/verifier.rs
+++ b/ecdsa/src/verifier.rs
@@ -11,7 +11,11 @@ use core::ops::Add;
 use elliptic_curve::{
     consts::U1,
     generic_array::ArrayLength,
-    weierstrass::{CompressedPointSize, Curve, FromPublicKey, PublicKey, UncompressedPointSize},
+    weierstrass::{
+        point::{CompressedPointSize, UncompressedPointSize},
+        public_key::{FromPublicKey, PublicKey},
+        Curve,
+    },
     Arithmetic,
 };
 use signature::{digest::Digest, DigestVerifier};


### PR DESCRIPTION
Uses the new `FromBytes` trait introduced in RustCrypto/traits#247