### PR TITLE
ecdsa: Bump `elliptic-curve` crate to v0.5 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,8 +44,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.5.0-pre"
-source = "git+https://github.com/RustCrypto/traits#048fb8f85a9b4cbbb29a2302a9a3fc596526fdcf"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9abe4578ed343c7a2c9d617cd2b1895ba0a87a6a4dee97bde156d65f608c7b2d"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -55,9 +56,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60fb4bb6bba52f78a471264d9a3b7d026cc0af47b22cd2cffbc0b787ca003e63"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
  "version_check",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,2 @@
 [workspace]
 members = ["ecdsa", "ed25519"]
-
-[patch.crates-io]
-elliptic-curve = { git = "https://github.com/RustCrypto/traits" }

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -15,7 +15,7 @@ categories    = ["cryptography", "no-std"]
 keywords      = ["crypto", "ecc", "nist", "secp256k1", "signature"]
 
 [dependencies.elliptic-curve]
-version = "= 0.5.0-pre"
+version = "0.5"
 default-features = false
 features = ["weierstrass"]
 
@@ -28,7 +28,7 @@ default = ["digest", "std"]
 dev = []
 digest = ["signature/digest-preview"]
 hazmat = []
-rand = ["elliptic-curve/rand_core", "signature/rand-preview"]
+rand = ["elliptic-curve/rand", "signature/rand-preview"]
 signer = ["digest", "hazmat", "rand", "zeroize"] # TODO(tarcieri): deterministic signing
 std = ["elliptic-curve/std", "signature/std"]
 verifier = ["digest", "hazmat"]

--- a/ecdsa/src/asn1.rs
+++ b/ecdsa/src/asn1.rs
@@ -328,7 +328,9 @@ mod tests {
         type ElementSize = U32;
     }
 
-    impl elliptic_curve::weierstrass::Curve for ExampleCurve {}
+    impl elliptic_curve::weierstrass::Curve for ExampleCurve {
+        const COMPRESS_POINTS: bool = false;
+    }
 
     type Signature = crate::Signature<ExampleCurve>;
 


### PR DESCRIPTION
Release notes: https://github.com/RustCrypto/traits/pull/254