### PR TITLE
ecdsa v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.7.0-pre"
+version = "0.7.0"
 dependencies = [
  "elliptic-curve",
  "signature",

--- a/ecdsa/CHANGELOG.md
+++ b/ecdsa/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (2020-08-10)
+### Added
+- `hazmat` traits: `SignPrimitive`, `RecoverableSignPrimitive`,
+  `VerifyPrimitive`, `DigestPrimitive` ([#96], [#99], [#107], [#111])
+- `dev` module ([#103])
+- `NormalizeLow` trait ([#115], [#118], [#119])
+- `Copy` impl on `Signature` ([#117])
+- `RecoverableSignPrimitive` ([#120])
+
+### Changed
+- Bumped `elliptic-curve` crate to v0.5 release ([#123])
+- Renamed `FixedSignature` to `ecdsa::Signature` ([#98])
+- Renamed `Asn1Signature` to `ecdsa::asn1::Signature` ([#98], [#102])
+
+### Removed
+- Curve-specific types - migrated to `k256`, `p256`, `p384` crates ([#96])
+
+[#96]: https://github.com/RustCrypto/signatures/pull/96
+[#98]: https://github.com/RustCrypto/signatures/pull/98
+[#99]: https://github.com/RustCrypto/signatures/pull/99
+[#102]: https://github.com/RustCrypto/signatures/pull/102
+[#103]: https://github.com/RustCrypto/signatures/pull/103
+[#107]: https://github.com/RustCrypto/signatures/pull/107
+[#111]: https://github.com/RustCrypto/signatures/pull/111
+[#115]: https://github.com/RustCrypto/signatures/pull/115
+[#117]: https://github.com/RustCrypto/signatures/pull/117
+[#118]: https://github.com/RustCrypto/signatures/pull/118
+[#119]: https://github.com/RustCrypto/signatures/pull/119
+[#120]: https://github.com/RustCrypto/signatures/pull/120
+[#123]: https://github.com/RustCrypto/signatures/pull/123
+
 ## 0.6.1 (2020-06-29)
 ### Added
 - `doc_cfg` attributes for https://docs.rs ([#91])

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,13 +1,12 @@
 [package]
 name          = "ecdsa"
-version       = "0.7.0-pre" # Also update html_root_url in lib.rs when bumping this
+version       = "0.7.0" # Also update html_root_url in lib.rs when bumping this
 description   = """
 Signature and elliptic curve types providing interoperable support for the
 Elliptic Curve Digital Signature Algorithm (ECDSA)
 """
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
-documentation = "https://docs.rs/ecdsa"
 repository    = "https://github.com/RustCrypto/signatures"
 edition       = "2018"
 readme        = "README.md"

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -24,7 +24,7 @@
 #![warn(missing_docs, rust_2018_idioms, intra_doc_link_resolution_failure)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png",
-    html_root_url = "https://docs.rs/ecdsa/0.6.1"
+    html_root_url = "https://docs.rs/ecdsa/0.7.0"
 )]
 
 pub mod asn1;


### PR DESCRIPTION
### Added
- `hazmat` traits: `SignPrimitive`, `RecoverableSignPrimitive`, `VerifyPrimitive`, `DigestPrimitive` ([#96], [#99], [#107], [#111])
- `dev` module ([#103])
- `NormalizeLow` trait ([#115], [#118], [#119])
- `Copy` impl on `Signature` ([#117])
- `RecoverableSignPrimitive` ([#120])

### Changed
- Bumped `elliptic-curve` crate to v0.5 release ([#123])
- Renamed `FixedSignature` to `ecdsa::Signature` ([#98])
- Renamed `Asn1Signature` to `ecdsa::asn1::Signature` ([#98], [#102])

### Removed
- Curve-specific types - migrated to `k256`, `p256`, `p384` crates ([#96])

[#96]: https://github.com/RustCrypto/signatures/pull/96
[#98]: https://github.com/RustCrypto/signatures/pull/98
[#99]: https://github.com/RustCrypto/signatures/pull/99
[#102]: https://github.com/RustCrypto/signatures/pull/102
[#103]: https://github.com/RustCrypto/signatures/pull/103
[#107]: https://github.com/RustCrypto/signatures/pull/107
[#111]: https://github.com/RustCrypto/signatures/pull/111
[#115]: https://github.com/RustCrypto/signatures/pull/115
[#117]: https://github.com/RustCrypto/signatures/pull/117
[#118]: https://github.com/RustCrypto/signatures/pull/118
[#119]: https://github.com/RustCrypto/signatures/pull/119
[#120]: https://github.com/RustCrypto/signatures/pull/120
[#123]: https://github.com/RustCrypto/signatures/pull/123