### PR TITLE
ecdsa/Cargo.toml: use `all-features = true` on docs.rs

### DIFF
--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -34,5 +34,5 @@ verifier = ["digest", "hazmat"]
 zeroize = ["elliptic-curve/zeroize"]
 
 [package.metadata.docs.rs]
-features = ["digest", "std"]
+all-features = true
 rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
Originally this was trying to hide the `hazmat` module, but several features have been added since then (`rand`, `signer`, `verifier`) which need the `hazmat` module enabled.