### PR TITLE
ecdsa: use newly refactored sec1::EncodedPoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,8 +45,7 @@ dependencies = [
 [[package]]
 name = "elliptic-curve"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9abe4578ed343c7a2c9d617cd2b1895ba0a87a6a4dee97bde156d65f608c7b2d"
+source = "git+https://github.com/RustCrypto/traits#61464f528779d2231df69039a4d9a954d4091ad3"
 dependencies = [
  "generic-array",
  "rand_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,5 @@
 [workspace]
 members = ["ecdsa", "ed25519"]
+
+[patch.crates-io]
+elliptic-curve = { git = "https://github.com/RustCrypto/traits" }

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -13,14 +13,9 @@ readme        = "README.md"
 categories    = ["cryptography", "no-std"]
 keywords      = ["crypto", "ecc", "nist", "secp256k1", "signature"]
 
-[dependencies.elliptic-curve]
-version = "0.5"
-default-features = false
-features = ["weierstrass"]
-
-[dependencies.signature]
-version = ">= 1.2.2, < 1.3.0"
-default-features = false
+[dependencies]
+elliptic-curve = { version = "0.5", default-features = false, features = ["weierstrass"] }
+signature = { version = ">= 1.2.2, < 1.3.0", default-features = false }
 
 [features]
 default = ["digest", "std"]

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -46,11 +46,7 @@ pub mod signer;
 pub mod verifier;
 
 // Re-export the `elliptic-curve` crate (and select types)
-pub use elliptic_curve::{
-    self, generic_array,
-    weierstrass::{Curve, PublicKey},
-    SecretKey,
-};
+pub use elliptic_curve::{self, generic_array, sec1::EncodedPoint, weierstrass::Curve, SecretKey};
 
 // Re-export the `signature` crate (and select types)
 pub use signature::{self, Error};

--- a/ecdsa/src/verifier.rs
+++ b/ecdsa/src/verifier.rs
@@ -11,11 +11,8 @@ use core::ops::Add;
 use elliptic_curve::{
     consts::U1,
     generic_array::ArrayLength,
-    weierstrass::{
-        point::{CompressedPointSize, UncompressedPointSize},
-        public_key::{FromPublicKey, PublicKey},
-        Curve,
-    },
+    sec1::{EncodedPoint, FromEncodedPoint, UncompressedPointSize, UntaggedPointSize},
+    weierstrass::Curve,
     Arithmetic,
 };
 use signature::{digest::Digest, DigestVerifier};
@@ -28,16 +25,14 @@ pub struct Verifier<C: Curve + Arithmetic> {
 impl<C> Verifier<C>
 where
     C: Curve + Arithmetic,
-    C::AffinePoint: VerifyPrimitive<C> + FromPublicKey<C>,
-    C::ElementSize: Add<U1>,
-    <C::ElementSize as Add>::Output: Add<U1>,
-    CompressedPointSize<C>: ArrayLength<u8>,
+    C::AffinePoint: VerifyPrimitive<C> + FromEncodedPoint<C>,
+    UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
     SignatureSize<C>: ArrayLength<u8>,
 {
     /// Create a new verifier
-    pub fn new(public_key: &PublicKey<C>) -> Result<Self, Error> {
-        let affine_point = C::AffinePoint::from_public_key(public_key);
+    pub fn new(public_key: &EncodedPoint<C>) -> Result<Self, Error> {
+        let affine_point = C::AffinePoint::from_encoded_point(public_key);
 
         if affine_point.is_some().into() {
             Ok(Self {


### PR DESCRIPTION
Uses the new `sec1::EncodedPoint` type introduced in RustCrypto/traits#264