### PR TITLE
ecdsa: use FromDigest trait; RFC6979 fixups

### DIFF
--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -21,7 +21,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]
-#![warn(missing_docs, rust_2018_idioms, intra_doc_link_resolution_failure)]
+#![warn(missing_docs, rust_2018_idioms)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png",
     html_root_url = "https://docs.rs/ecdsa/0.7.2"


### PR DESCRIPTION
- Uses the `FromDigest` trait to automatically convert message digests into a `C::Scalar` value
- Updates `SignPrimitive` and `VerifyPrimitive` to accept a scalar
- Updates the `dev` module accordingly with the above
- Exposes the `ecdsa::signer::rfc6979` module and makes the `generate_k` method `pub`