### PR TITLE
ecdsa: add CheckSignatureBytes trait + NonZeroScalar components

### DIFF
--- a/ecdsa/src/asn1.rs
+++ b/ecdsa/src/asn1.rs
@@ -15,7 +15,7 @@ use core::{
     fmt,
     ops::{Add, Range},
 };
-use elliptic_curve::{consts::U9, weierstrass::Curve, ElementBytes};
+use elliptic_curve::{consts::U9, weierstrass::Curve};
 
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
@@ -106,8 +106,8 @@ where
         self.as_bytes().to_vec().into_boxed_slice()
     }
 
-    /// Create an ASN.1 DER encoded signature from the `r` and `s` scalars
-    pub(crate) fn from_scalars(r: &ElementBytes<C>, s: &ElementBytes<C>) -> Self {
+    /// Create an ASN.1 DER encoded signature from big endian `r` and `s` scalars
+    pub(crate) fn from_scalar_bytes(r: &[u8], s: &[u8]) -> Self {
         let r_len = int_length(r);
         let s_len = int_length(s);
         let scalar_size = C::FieldSize::to_usize();
@@ -127,11 +127,11 @@ where
         };
 
         // First INTEGER (r)
-        serialize_int(r.as_slice(), &mut bytes[offset..], r_len, scalar_size);
+        serialize_int(r, &mut bytes[offset..], r_len, scalar_size);
         let r_end = offset.checked_add(2).unwrap().checked_add(r_len).unwrap();
 
         // Second INTEGER (s)
-        serialize_int(s.as_slice(), &mut bytes[r_end..], s_len, scalar_size);
+        serialize_int(s, &mut bytes[r_end..], s_len, scalar_size);
         let s_end = r_end.checked_add(2).unwrap().checked_add(s_len).unwrap();
 
         bytes[..s_end]

--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -11,7 +11,7 @@
 //! Failure to use them correctly can lead to catastrophic failures including
 //! FULL PRIVATE KEY RECOVERY!
 
-use crate::{Signature, SignatureSize};
+use crate::{CheckSignatureBytes, Signature, SignatureSize};
 use core::borrow::Borrow;
 use elliptic_curve::{generic_array::ArrayLength, ops::Invert, weierstrass::Curve, Arithmetic};
 use signature::Error;
@@ -86,8 +86,9 @@ pub trait DigestPrimitive: Curve {
 }
 
 #[cfg(feature = "digest")]
-impl<C: DigestPrimitive> PrehashSignature for Signature<C>
+impl<C> PrehashSignature for Signature<C>
 where
+    C: DigestPrimitive + CheckSignatureBytes,
     <C::FieldSize as core::ops::Add>::Output: ArrayLength<u8>,
 {
     type Digest = C::Digest;


### PR DESCRIPTION
Adds a `CheckSignatureBytes` trait with a default impl that ensures neither the `r` nor `s` components of a signature are all-zero.

Includes a blanket impl of `CheckSignatureBytes` for all curves with the `Arithmetic` trait defined (and thus access to `C::Scalar`). This performs a better check that both `r` and `s` do not overflow the curve's order and are non-zero (using `NonZeroScalar`).

Together these allow conditionally defining `ecdsa::Signature::r` and `::s` methods which permit infallible access to `NonZeroScalar<C>`, rather than the previous implementation which returns bytes.

All of the above is a compromise which allows for crates which do not provide a curve arithmetic backend to still assert some checks on the signature values, but also ensure that signatures are well-formed, in-range scalars "automatically" when arithmetic is available.