### PR TITLE
ecdsa: bump `elliptic-curve` crate dependency to v0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,8 +89,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.5.0"
-source = "git+https://github.com/RustCrypto/traits#bba389743c8156036ccd4bbb73755d8bb22fb796"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9cc9ec2c11b93118b4f8dc0665a3741bc90121d44dc0410f899274c5745454c"
 dependencies = [
  "bitvec",
  "digest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,2 @@
 [workspace]
 members = ["ecdsa", "ed25519"]
-
-[patch.crates-io]
-elliptic-curve = { git = "https://github.com/RustCrypto/traits" }

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -14,7 +14,7 @@ categories    = ["cryptography", "no-std"]
 keywords      = ["crypto", "ecc", "nist", "secp256k1", "signature"]
 
 [dependencies]
-elliptic-curve = { version = "0.5", default-features = false }
+elliptic-curve = { version = "0.6", default-features = false }
 hmac = { version = "0.9", optional = true, default-features = false }
 signature = { version = ">= 1.2.2, < 1.3.0", default-features = false, features = ["rand-preview"] }
 


### PR DESCRIPTION
Release notes: https://github.com/RustCrypto/traits/pull/302