### PR TITLE
ecdsa v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "elliptic-curve",
  "hex-literal",

--- a/ecdsa/CHANGELOG.md
+++ b/ecdsa/CHANGELOG.md
@@ -4,6 +4,50 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.0 (2020-09-11)
+### Added
+- `CheckSignatureBytes` trait ([#151])
+- Add `Signature::r`/`::s` methods which return `NonZeroScalar`values ([#151])
+- `alloc` feature ([#150])
+- Impl `From<&VerifyKey<C>>` for `EncodedPoint<C>` ([#144])
+- Serialization methods for `SigningKey`/`VerifyKey` ([#143])
+- RFC6979-based deterministic signatures ([#133], [#134], [#136])
+
+### Changed
+- Bump `elliptic-curve` crate dependency to v0.6 ([#165])
+- Use `ProjectiveArithmetic` trait ([#164])
+- Rename `ElementBytes` to `FieldBytes` ([#160])
+- Use `ff` and `group` crates to v0.8 ([#156])
+- MSRV 1.44+ ([#156])
+- Remove `rand` feature; make `rand_core` a hard dependency ([#154])
+- Use `impl Into<ElementBytes>` bounds on `Signature::from_scalars` ([#149])
+- Derive `Clone`, `Debug`, `Eq`, and `Ord` on `VerifyKey` ([#148])
+- Renamed `{Signer, Verifier}` => `{SigningKey, VerifyKey}` ([#140])
+- Use newly refactored `sec1::EncodedPoint` ([#131])
+
+### Removed
+- `Generate` trait ([#159])
+- `RecoverableSignPrimitive` ([#146])
+
+[#165]: https://github.com/RustCrypto/signatures/pull/165
+[#164]: https://github.com/RustCrypto/signatures/pull/164
+[#160]: https://github.com/RustCrypto/signatures/pull/160
+[#159]: https://github.com/RustCrypto/signatures/pull/159
+[#156]: https://github.com/RustCrypto/signatures/pull/156
+[#154]: https://github.com/RustCrypto/signatures/pull/154
+[#151]: https://github.com/RustCrypto/signatures/pull/151
+[#150]: https://github.com/RustCrypto/signatures/pull/150
+[#149]: https://github.com/RustCrypto/signatures/pull/149
+[#148]: https://github.com/RustCrypto/signatures/pull/148
+[#146]: https://github.com/RustCrypto/signatures/pull/146
+[#144]: https://github.com/RustCrypto/signatures/pull/144
+[#143]: https://github.com/RustCrypto/signatures/pull/143
+[#140]: https://github.com/RustCrypto/signatures/pull/140
+[#136]: https://github.com/RustCrypto/signatures/pull/136
+[#134]: https://github.com/RustCrypto/signatures/pull/134
+[#133]: https://github.com/RustCrypto/signatures/pull/133
+[#131]: https://github.com/RustCrypto/signatures/pull/131
+
 ## 0.7.2 (2020-08-11)
 ### Added
 - Conditional `PrehashSignature` impl for `asn1::Signature` ([#128])

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ecdsa"
-version       = "0.7.2" # Also update html_root_url in lib.rs when bumping this
+version       = "0.8.0" # Also update html_root_url in lib.rs when bumping this
 description   = """
 Signature and elliptic curve types providing interoperable support for the
 Elliptic Curve Digital Signature Algorithm (ECDSA)

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -9,6 +9,9 @@
 //! - Generic implementation of ECDSA usable with the following crates:
 //!   - [`k256`] (secp256k1)
 //!   - [`p256`] (NIST P-256)
+//! - ECDSA signature types alone which can be used to provide interoperability
+//!   between other crates that provide an ECDSA implementation:
+//!   - [`p384`] NIST P-384
 //! - Other crates which provide their own complete implementations of ECDSA can
 //!   also leverage the types from this crate to export ECDSA functionality in a
 //!   generic, interoperable way by leveraging the [`Signature`] type with the
@@ -17,6 +20,7 @@
 //! [1]: https://csrc.nist.gov/publications/detail/fips/186/4/final
 //! [`k256`]: https://docs.rs/k256
 //! [`p256`]: https://docs.rs/p256
+//! [`p384`]: https://docs.rs/p384
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
@@ -24,7 +28,7 @@
 #![warn(missing_docs, rust_2018_idioms)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png",
-    html_root_url = "https://docs.rs/ecdsa/0.7.2"
+    html_root_url = "https://docs.rs/ecdsa/0.8.0"
 )]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
### Added
- `CheckSignatureBytes` trait ([#151])
- Add `Signature::r`/`::s` methods which return `NonZeroScalar`values ([#151])
- `alloc` feature ([#150])
- Impl `From<&VerifyKey<C>>` for `EncodedPoint<C>` ([#144])
- Serialization methods for `SigningKey`/`VerifyKey` ([#143])
- RFC6979-based deterministic signatures ([#133], [#134], [#136])

### Changed
- Bump `elliptic-curve` crate dependency to v0.6 ([#165])
- Use `ProjectiveArithmetic` trait ([#164])
- Rename `ElementBytes` to `FieldBytes` ([#160])
- Use `ff` and `group` crates to v0.8 ([#156])
- MSRV 1.44+ ([#156])
- Remove `rand` feature; make `rand_core` a hard dependency ([#154])
- Use `impl Into<ElementBytes>` bounds on `Signature::from_scalars` ([#149])
- Derive `Clone`, `Debug`, `Eq`, and `Ord` on `VerifyKey` ([#148])
- Renamed `{Signer, Verifier}` => `{SigningKey, VerifyKey}` ([#140])
- Use newly refactored `sec1::EncodedPoint` ([#131])

### Removed
- `Generate` trait ([#159])
- `RecoverableSignPrimitive` ([#146])

[#165]: https://github.com/RustCrypto/signatures/pull/165
[#164]: https://github.com/RustCrypto/signatures/pull/164
[#160]: https://github.com/RustCrypto/signatures/pull/160
[#159]: https://github.com/RustCrypto/signatures/pull/159
[#156]: https://github.com/RustCrypto/signatures/pull/156
[#154]: https://github.com/RustCrypto/signatures/pull/154
[#151]: https://github.com/RustCrypto/signatures/pull/151
[#150]: https://github.com/RustCrypto/signatures/pull/150
[#149]: https://github.com/RustCrypto/signatures/pull/149
[#148]: https://github.com/RustCrypto/signatures/pull/148
[#146]: https://github.com/RustCrypto/signatures/pull/146
[#140]: https://github.com/RustCrypto/signatures/pull/140
[#144]: https://github.com/RustCrypto/signatures/pull/144
[#143]: https://github.com/RustCrypto/signatures/pull/143
[#136]: https://github.com/RustCrypto/signatures/pull/136
[#134]: https://github.com/RustCrypto/signatures/pull/134
[#133]: https://github.com/RustCrypto/signatures/pull/133
[#131]: https://github.com/RustCrypto/signatures/pull/131