### PR TITLE
ecdsa v0.8.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "elliptic-curve",
  "hex-literal",

--- a/ecdsa/CHANGELOG.md
+++ b/ecdsa/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.3 (2020-09-28)
+### Fixed
+- 32-bit builds for the `dev` feature ([#177])
+
+[#177]: https://github.com/RustCrypto/signatures/pull/177
+
 ## 0.8.2 (2020-09-27)
 ### Added
 - `RecoverableSignPrimitive` ([#174], [#175])

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ecdsa"
-version       = "0.8.2" # Also update html_root_url in lib.rs when bumping this
+version       = "0.8.3" # Also update html_root_url in lib.rs when bumping this
 description   = """
 Signature and elliptic curve types providing interoperable support for the
 Elliptic Curve Digital Signature Algorithm (ECDSA)

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -28,7 +28,7 @@
 #![warn(missing_docs, rust_2018_idioms)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png",
-    html_root_url = "https://docs.rs/ecdsa/0.8.2"
+    html_root_url = "https://docs.rs/ecdsa/0.8.3"
 )]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
### Fixed
- 32-bit builds for the `dev` feature ([#177])

[#177]: https://github.com/RustCrypto/signatures/pull/177