### PR TITLE
ecdsa: work around nightly-2020-10-06 breakage

### DIFF
--- a/ecdsa/src/sign.rs
+++ b/ecdsa/src/sign.rs
@@ -86,9 +86,9 @@ where
     where
         AffinePoint<C>: Clone + Debug,
     {
-        VerifyKey {
-            public_key: (C::ProjectivePoint::generator() * &self.secret_scalar).to_affine(),
-        }
+        #[allow(clippy::op_ref)]
+        let public_key = (C::ProjectivePoint::generator() * &*self.secret_scalar).to_affine();
+        VerifyKey { public_key }
     }
 
     /// Serialize this [`SigningKey`] as bytes


### PR DESCRIPTION
The `ecdsa` crate no longer builds on `nightly`, possibly due to:

https://github.com/rust-lang/rust/issues/77638

Unfortunately this means rustdoc builds on https://docs.rs fail!

This commit works around the issue.