### PR TITLE
ed25519: fix tarpaulin

### DIFF
--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -177,12 +177,7 @@
     html_root_url = "https://docs.rs/ed25519/1.0.2"
 )]
 #![forbid(unsafe_code)]
-#![warn(
-    missing_docs,
-    rust_2018_idioms,
-    unused_qualifications,
-    intra_doc_link_resolution_failure
-)]
+#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
 #[cfg(feature = "serde")]
 use serde::{de, ser, Deserialize, Serialize};


### PR DESCRIPTION
The presence of the `intra_doc_link_resolution_failure` lint now breaks cargo-tarpaulin:

https://github.com/RustCrypto/signatures/pull/180/checks?check_run_id=1228016160

This PR removes it.