### PR TITLE
ed25519 v1.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "bincode",
  "ed25519-dalek",

--- a/ed25519/CHANGES.md
+++ b/ed25519/CHANGES.md
@@ -4,8 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.3 (2020-10-12)
+### Added
+- `ring-compat` usage example ([#187])
+
+[#187]: https://github.com/RustCrypto/signatures/pull/187
+
 ## 1.0.2 (2020-09-11)
-## Added
+### Added
 - `ed25519-dalek` usage example ([#167])
 
 [#167]: https://github.com/RustCrypto/signatures/pull/167

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ed25519"
-version       = "1.0.2"
+version       = "1.0.3"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 description   = "Edwards Digital Signature Algorithm (EdDSA) over Curve25519 (as specified in RFC 8032)"

--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -249,7 +249,7 @@
 #![no_std]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png",
-    html_root_url = "https://docs.rs/ed25519/1.0.2"
+    html_root_url = "https://docs.rs/ed25519/1.0.3"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Added
- `ring-compat` usage example ([#187])

[#187]: https://github.com/RustCrypto/signatures/pull/187