### PR TITLE
ecdsa: simplify VerifyKey trait bounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,7 @@ dependencies = [
 [[package]]
 name = "elliptic-curve"
 version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/traits#71f6f53f0ac67ac6ba9dfb46aff7eb20df28bafe"
+source = "git+https://github.com/RustCrypto/traits#ea5106e0cd0f47a5ee11af0d7313f1f1dc0a5a9f"
 dependencies = [
  "bitvec",
  "digest",

--- a/ecdsa/src/sign.rs
+++ b/ecdsa/src/sign.rs
@@ -26,15 +26,7 @@ use signature::{
 };
 
 #[cfg(feature = "verify")]
-use {
-    crate::verify::VerifyKey,
-    core::{fmt::Debug, ops::Add},
-    elliptic_curve::{
-        consts::U1,
-        sec1::{FromEncodedPoint, ToEncodedPoint, UncompressedPointSize, UntaggedPointSize},
-        AffinePoint, ProjectivePoint,
-    },
-};
+use {crate::verify::VerifyKey, core::fmt::Debug, elliptic_curve::AffinePoint};
 
 /// ECDSA signing key
 pub struct SigningKey<C>
@@ -82,10 +74,7 @@ where
     #[cfg_attr(docsrs, doc(cfg(feature = "verify")))]
     pub fn verify_key(&self) -> VerifyKey<C>
     where
-        AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
-        ProjectivePoint<C>: From<AffinePoint<C>>,
-        UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
-        UncompressedPointSize<C>: ArrayLength<u8>,
+        AffinePoint<C>: Copy + Clone + Debug + Default,
     {
         VerifyKey {
             inner: self.inner.public_key(),
@@ -238,10 +227,7 @@ where
         + Invert<Output = Scalar<C>>
         + SignPrimitive<C>
         + Zeroize,
-    AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
-    ProjectivePoint<C>: From<AffinePoint<C>>,
-    UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
-    UncompressedPointSize<C>: ArrayLength<u8>,
+    AffinePoint<C>: Copy + Clone + Debug + Default,
     SignatureSize<C>: ArrayLength<u8>,
 {
     fn from(signing_key: &SigningKey<C>) -> VerifyKey<C> {

--- a/ecdsa/src/verify.rs
+++ b/ecdsa/src/verify.rs
@@ -22,16 +22,13 @@ use elliptic_curve::{
 use signature::{digest::Digest, DigestVerifier};
 
 /// ECDSA verify key
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug)]
 pub struct VerifyKey<C>
 where
     C: Curve + ProjectiveArithmetic,
     FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
-    AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
-    ProjectivePoint<C>: From<AffinePoint<C>>,
-    UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
-    UncompressedPointSize<C>: ArrayLength<u8>,
+    AffinePoint<C>: Copy + Clone + Debug,
 {
     pub(crate) inner: PublicKey<C>,
 }
@@ -40,18 +37,11 @@ impl<C> VerifyKey<C>
 where
     C: Curve + ProjectiveArithmetic,
     FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>> + FromDigest<C>,
-    AffinePoint<C>: Copy
-        + Clone
-        + Debug
-        + Default
-        + FromEncodedPoint<C>
-        + ToEncodedPoint<C>
-        + VerifyPrimitive<C>,
+    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
+    AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
-    SignatureSize<C>: ArrayLength<u8>,
 {
     /// Initialize [`VerifyKey`] from a SEC1-encoded public key.
     pub fn from_sec1_bytes(bytes: &[u8]) -> Result<Self, Error> {
@@ -80,16 +70,7 @@ where
     D: Digest<OutputSize = C::FieldSize>,
     FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>> + FromDigest<C>,
-    AffinePoint<C>: Copy
-        + Clone
-        + Debug
-        + Default
-        + FromEncodedPoint<C>
-        + ToEncodedPoint<C>
-        + VerifyPrimitive<C>,
-    ProjectivePoint<C>: From<AffinePoint<C>>,
-    UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
-    UncompressedPointSize<C>: ArrayLength<u8>,
+    AffinePoint<C>: Copy + Clone + Debug + VerifyPrimitive<C>,
     SignatureSize<C>: ArrayLength<u8>,
 {
     fn verify_digest(&self, digest: D, signature: &Signature<C>) -> Result<(), Error> {
@@ -105,16 +86,7 @@ where
     C::Digest: Digest<OutputSize = C::FieldSize>,
     FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>> + FromDigest<C>,
-    AffinePoint<C>: Copy
-        + Clone
-        + Debug
-        + Default
-        + FromEncodedPoint<C>
-        + ToEncodedPoint<C>
-        + VerifyPrimitive<C>,
-    ProjectivePoint<C>: From<AffinePoint<C>>,
-    UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
-    UncompressedPointSize<C>: ArrayLength<u8>,
+    AffinePoint<C>: Copy + Clone + Debug + VerifyPrimitive<C>,
     SignatureSize<C>: ArrayLength<u8>,
 {
     fn verify(&self, msg: &[u8], signature: &Signature<C>) -> Result<(), Error> {
@@ -126,18 +98,11 @@ impl<C> From<&VerifyKey<C>> for EncodedPoint<C>
 where
     C: Curve + ProjectiveArithmetic + point::Compression,
     FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>> + FromDigest<C>,
-    AffinePoint<C>: Copy
-        + Clone
-        + Debug
-        + Default
-        + FromEncodedPoint<C>
-        + ToEncodedPoint<C>
-        + VerifyPrimitive<C>,
+    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
+    AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
-    SignatureSize<C>: ArrayLength<u8>,
 {
     fn from(verify_key: &VerifyKey<C>) -> EncodedPoint<C> {
         verify_key.to_encoded_point(C::COMPRESS_POINTS)
@@ -146,20 +111,10 @@ where
 
 impl<C> From<PublicKey<C>> for VerifyKey<C>
 where
-    C: Curve + ProjectiveArithmetic + point::Compression,
+    C: Curve + ProjectiveArithmetic,
     FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>> + FromDigest<C>,
-    AffinePoint<C>: Copy
-        + Clone
-        + Debug
-        + Default
-        + VerifyPrimitive<C>
-        + FromEncodedPoint<C>
-        + ToEncodedPoint<C>,
-    ProjectivePoint<C>: From<AffinePoint<C>>,
-    UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
-    UncompressedPointSize<C>: ArrayLength<u8>,
-    SignatureSize<C>: ArrayLength<u8>,
+    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
+    AffinePoint<C>: Copy + Clone + Debug,
 {
     fn from(public_key: PublicKey<C>) -> VerifyKey<C> {
         VerifyKey { inner: public_key }
@@ -168,20 +123,10 @@ where
 
 impl<C> From<&PublicKey<C>> for VerifyKey<C>
 where
-    C: Curve + ProjectiveArithmetic + point::Compression,
+    C: Curve + ProjectiveArithmetic,
     FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>> + FromDigest<C>,
-    AffinePoint<C>: Copy
-        + Clone
-        + Debug
-        + Default
-        + VerifyPrimitive<C>
-        + FromEncodedPoint<C>
-        + ToEncodedPoint<C>,
-    ProjectivePoint<C>: From<AffinePoint<C>>,
-    UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
-    UncompressedPointSize<C>: ArrayLength<u8>,
-    SignatureSize<C>: ArrayLength<u8>,
+    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
+    AffinePoint<C>: Copy + Clone + Debug,
 {
     fn from(public_key: &PublicKey<C>) -> VerifyKey<C> {
         public_key.clone().into()
@@ -190,20 +135,10 @@ where
 
 impl<C> From<VerifyKey<C>> for PublicKey<C>
 where
-    C: Curve + ProjectiveArithmetic + point::Compression,
+    C: Curve + ProjectiveArithmetic,
     FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>> + FromDigest<C>,
-    AffinePoint<C>: Copy
-        + Clone
-        + Debug
-        + Default
-        + VerifyPrimitive<C>
-        + FromEncodedPoint<C>
-        + ToEncodedPoint<C>,
-    ProjectivePoint<C>: From<AffinePoint<C>>,
-    UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
-    UncompressedPointSize<C>: ArrayLength<u8>,
-    SignatureSize<C>: ArrayLength<u8>,
+    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
+    AffinePoint<C>: Copy + Clone + Debug,
 {
     fn from(verify_key: VerifyKey<C>) -> PublicKey<C> {
         verify_key.inner
@@ -212,22 +147,39 @@ where
 
 impl<C> From<&VerifyKey<C>> for PublicKey<C>
 where
-    C: Curve + ProjectiveArithmetic + point::Compression,
+    C: Curve + ProjectiveArithmetic,
     FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>> + FromDigest<C>,
-    AffinePoint<C>: Copy
-        + Clone
-        + Debug
-        + Default
-        + VerifyPrimitive<C>
-        + FromEncodedPoint<C>
-        + ToEncodedPoint<C>,
+    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
+    AffinePoint<C>: Copy + Clone + Debug,
+{
+    fn from(verify_key: &VerifyKey<C>) -> PublicKey<C> {
+        verify_key.clone().into()
+    }
+}
+
+impl<C> Eq for VerifyKey<C>
+where
+    C: Curve + ProjectiveArithmetic,
+    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
+    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
+    AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
-    SignatureSize<C>: ArrayLength<u8>,
 {
-    fn from(verify_key: &VerifyKey<C>) -> PublicKey<C> {
-        verify_key.inner
+}
+
+impl<C> PartialEq for VerifyKey<C>
+where
+    C: Curve + ProjectiveArithmetic,
+    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
+    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
+    AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
+    ProjectivePoint<C>: From<AffinePoint<C>>,
+    UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
+    UncompressedPointSize<C>: ArrayLength<u8>,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.inner.eq(&other.inner)
     }
 }


### PR DESCRIPTION
Uses simpler bounds implemented in RustCrypto/traits#378