### PR TITLE
ecdsa: rename VerifyKey to VerifyingKey

### DIFF
--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -85,7 +85,7 @@ pub use sign::SigningKey;
 
 #[cfg(feature = "verify")]
 #[cfg_attr(docsrs, doc(cfg(feature = "verify")))]
-pub use verify::VerifyKey;
+pub use verify::VerifyingKey;
 
 #[cfg(feature = "zeroize")]
 #[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]

--- a/ecdsa/src/sign.rs
+++ b/ecdsa/src/sign.rs
@@ -26,7 +26,7 @@ use signature::{
 };
 
 #[cfg(feature = "verify")]
-use {crate::verify::VerifyKey, core::fmt::Debug, elliptic_curve::AffinePoint};
+use {crate::verify::VerifyingKey, core::fmt::Debug, elliptic_curve::AffinePoint};
 
 /// ECDSA signing key
 pub struct SigningKey<C>
@@ -69,14 +69,14 @@ where
             .map_err(|_| Error::new())
     }
 
-    /// Get the [`VerifyKey`] which corresponds to this [`SigningKey`]
+    /// Get the [`VerifyingKey`] which corresponds to this [`SigningKey`]
     #[cfg(feature = "verify")]
     #[cfg_attr(docsrs, doc(cfg(feature = "verify")))]
-    pub fn verify_key(&self) -> VerifyKey<C>
+    pub fn verify_key(&self) -> VerifyingKey<C>
     where
         AffinePoint<C>: Copy + Clone + Debug + Default,
     {
-        VerifyKey {
+        VerifyingKey {
             inner: self.inner.public_key(),
         }
     }
@@ -218,7 +218,7 @@ where
 }
 
 #[cfg(feature = "verify")]
-impl<C> From<&SigningKey<C>> for VerifyKey<C>
+impl<C> From<&SigningKey<C>> for VerifyingKey<C>
 where
     C: Curve + ProjectiveArithmetic,
     FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
@@ -230,7 +230,7 @@ where
     AffinePoint<C>: Copy + Clone + Debug + Default,
     SignatureSize<C>: ArrayLength<u8>,
 {
-    fn from(signing_key: &SigningKey<C>) -> VerifyKey<C> {
+    fn from(signing_key: &SigningKey<C>) -> VerifyingKey<C> {
         signing_key.verify_key()
     }
 }

--- a/ecdsa/src/verify.rs
+++ b/ecdsa/src/verify.rs
@@ -23,7 +23,7 @@ use signature::{digest::Digest, DigestVerifier};
 
 /// ECDSA verify key
 #[derive(Copy, Clone, Debug)]
-pub struct VerifyKey<C>
+pub struct VerifyingKey<C>
 where
     C: Curve + ProjectiveArithmetic,
     FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
@@ -33,7 +33,7 @@ where
     pub(crate) inner: PublicKey<C>,
 }
 
-impl<C> VerifyKey<C>
+impl<C> VerifyingKey<C>
 where
     C: Curve + ProjectiveArithmetic,
     FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
@@ -43,28 +43,28 @@ where
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
-    /// Initialize [`VerifyKey`] from a SEC1-encoded public key.
+    /// Initialize [`VerifyingKey`] from a SEC1-encoded public key.
     pub fn from_sec1_bytes(bytes: &[u8]) -> Result<Self, Error> {
         PublicKey::from_sec1_bytes(bytes)
             .map(|pk| Self { inner: pk })
             .map_err(|_| Error::new())
     }
 
-    /// Initialize [`VerifyKey`] from an [`EncodedPoint`].
+    /// Initialize [`VerifyingKey`] from an [`EncodedPoint`].
     pub fn from_encoded_point(public_key: &EncodedPoint<C>) -> Result<Self, Error> {
         PublicKey::<C>::from_encoded_point(public_key)
             .map(|public_key| Self { inner: public_key })
             .ok_or_else(Error::new)
     }
 
-    /// Serialize this [`VerifyKey`] as a SEC1 [`EncodedPoint`], optionally
+    /// Serialize this [`VerifyingKey`] as a SEC1 [`EncodedPoint`], optionally
     /// applying point compression.
     pub fn to_encoded_point(&self, compress: bool) -> EncodedPoint<C> {
         self.inner.to_encoded_point(compress)
     }
 }
 
-impl<C, D> DigestVerifier<D, Signature<C>> for VerifyKey<C>
+impl<C, D> DigestVerifier<D, Signature<C>> for VerifyingKey<C>
 where
     C: Curve + ProjectiveArithmetic,
     D: Digest<OutputSize = C::FieldSize>,
@@ -80,7 +80,7 @@ where
     }
 }
 
-impl<C> signature::Verifier<Signature<C>> for VerifyKey<C>
+impl<C> signature::Verifier<Signature<C>> for VerifyingKey<C>
 where
     C: Curve + ProjectiveArithmetic + DigestPrimitive,
     C::Digest: Digest<OutputSize = C::FieldSize>,
@@ -94,7 +94,7 @@ where
     }
 }
 
-impl<C> From<&VerifyKey<C>> for EncodedPoint<C>
+impl<C> From<&VerifyingKey<C>> for EncodedPoint<C>
 where
     C: Curve + ProjectiveArithmetic + point::Compression,
     FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
@@ -104,60 +104,60 @@ where
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
-    fn from(verify_key: &VerifyKey<C>) -> EncodedPoint<C> {
+    fn from(verify_key: &VerifyingKey<C>) -> EncodedPoint<C> {
         verify_key.to_encoded_point(C::COMPRESS_POINTS)
     }
 }
 
-impl<C> From<PublicKey<C>> for VerifyKey<C>
+impl<C> From<PublicKey<C>> for VerifyingKey<C>
 where
     C: Curve + ProjectiveArithmetic,
     FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     AffinePoint<C>: Copy + Clone + Debug,
 {
-    fn from(public_key: PublicKey<C>) -> VerifyKey<C> {
-        VerifyKey { inner: public_key }
+    fn from(public_key: PublicKey<C>) -> VerifyingKey<C> {
+        VerifyingKey { inner: public_key }
     }
 }
 
-impl<C> From<&PublicKey<C>> for VerifyKey<C>
+impl<C> From<&PublicKey<C>> for VerifyingKey<C>
 where
     C: Curve + ProjectiveArithmetic,
     FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     AffinePoint<C>: Copy + Clone + Debug,
 {
-    fn from(public_key: &PublicKey<C>) -> VerifyKey<C> {
+    fn from(public_key: &PublicKey<C>) -> VerifyingKey<C> {
         public_key.clone().into()
     }
 }
 
-impl<C> From<VerifyKey<C>> for PublicKey<C>
+impl<C> From<VerifyingKey<C>> for PublicKey<C>
 where
     C: Curve + ProjectiveArithmetic,
     FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     AffinePoint<C>: Copy + Clone + Debug,
 {
-    fn from(verify_key: VerifyKey<C>) -> PublicKey<C> {
+    fn from(verify_key: VerifyingKey<C>) -> PublicKey<C> {
         verify_key.inner
     }
 }
 
-impl<C> From<&VerifyKey<C>> for PublicKey<C>
+impl<C> From<&VerifyingKey<C>> for PublicKey<C>
 where
     C: Curve + ProjectiveArithmetic,
     FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     AffinePoint<C>: Copy + Clone + Debug,
 {
-    fn from(verify_key: &VerifyKey<C>) -> PublicKey<C> {
+    fn from(verify_key: &VerifyingKey<C>) -> PublicKey<C> {
         verify_key.clone().into()
     }
 }
 
-impl<C> Eq for VerifyKey<C>
+impl<C> Eq for VerifyingKey<C>
 where
     C: Curve + ProjectiveArithmetic,
     FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
@@ -169,7 +169,7 @@ where
 {
 }
 
-impl<C> PartialEq for VerifyKey<C>
+impl<C> PartialEq for VerifyingKey<C>
 where
     C: Curve + ProjectiveArithmetic,
     FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,


### PR DESCRIPTION
Per the discussion in #196, renames `VerifyKey` => `VerifyingKey` for better consistency with `SigningKey`.