### PR TITLE
ecdsa: explicit Copy impl for VerifyKey

### DIFF
--- a/ecdsa/src/verify.rs
+++ b/ecdsa/src/verify.rs
@@ -22,7 +22,7 @@ use elliptic_curve::{
 use signature::{digest::Digest, DigestVerifier};
 
 /// ECDSA verify key
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct VerifyingKey<C>
 where
     C: Curve + ProjectiveArithmetic,
@@ -155,6 +155,16 @@ where
     fn from(verify_key: &VerifyingKey<C>) -> PublicKey<C> {
         verify_key.clone().into()
     }
+}
+
+impl<C> Copy for VerifyingKey<C>
+where
+    C: Curve + ProjectiveArithmetic,
+    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
+    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
+    AffinePoint<C>: Copy + Clone + Debug,
+    PublicKey<C>: Copy,
+{
 }
 
 impl<C> Eq for VerifyingKey<C>


### PR DESCRIPTION
The derived impl does not have the correct bounds