### PR TITLE
Revert "ecdsa: explicit Copy impl for VerifyKey (#201)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,7 @@ dependencies = [
 [[package]]
 name = "elliptic-curve"
 version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/traits#ea5106e0cd0f47a5ee11af0d7313f1f1dc0a5a9f"
+source = "git+https://github.com/RustCrypto/traits#fdff330484c9d03f67ba1eda533a24e757f3e204"
 dependencies = [
  "bitvec",
  "digest",

--- a/ecdsa/src/verify.rs
+++ b/ecdsa/src/verify.rs
@@ -22,7 +22,7 @@ use elliptic_curve::{
 use signature::{digest::Digest, DigestVerifier};
 
 /// ECDSA verify key
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct VerifyingKey<C>
 where
     C: Curve + ProjectiveArithmetic,
@@ -155,16 +155,6 @@ where
     fn from(verify_key: &VerifyingKey<C>) -> PublicKey<C> {
         verify_key.clone().into()
     }
-}
-
-impl<C> Copy for VerifyingKey<C>
-where
-    C: Curve + ProjectiveArithmetic,
-    FieldBytes<C>: From<Scalar<C>> + for<'r> From<&'r Scalar<C>>,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
-    AffinePoint<C>: Copy + Clone + Debug,
-    PublicKey<C>: Copy,
-{
 }
 
 impl<C> Eq for VerifyingKey<C>


### PR DESCRIPTION
This reverts commit 91cb79eddef19bede669f5ad79a1a7deb967706e.

Fixed the root cause upstream in the `elliptic-curve` crate:

https://github.com/RustCrypto/traits/pull/379