### PR TITLE
ecdsa: rename `SigningKey::new()` to `::from_bytes`

### DIFF
--- a/ecdsa/src/sign.rs
+++ b/ecdsa/src/sign.rs
@@ -71,8 +71,7 @@ where
     }
 
     /// Initialize signing key from a raw scalar serialized as a byte slice.
-    // TODO(tarcieri): PKCS#8 support
-    pub fn new(bytes: &[u8]) -> Result<Self, Error> {
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
         SecretKey::from_bytes(bytes)
             .map(|sk| Self { inner: sk })
             .map_err(|_| Error::new())


### PR DESCRIPTION
More consistent with the rest of the method names in the `elliptic-curve` crate and `VerifyingKey`