### PR TITLE
ecdsa v0.10.0

### DIFF
--- a/ecdsa/CHANGELOG.md
+++ b/ecdsa/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.0 (2020-12-16)
+### Changed
+- Bump `elliptic-curve` dependency to v0.8 ([#215])
+
+[#215]: https://github.com/RustCrypto/signatures/pull/215
+
 ## 0.9.0 (2020-12-06)
 ### Added
 - PKCS#8 support ([#203])

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
-name          = "ecdsa"
-version       = "0.10.0" # Also update html_root_url in lib.rs when bumping this
+name    = "ecdsa"
+version = "0.10.0" # Also update html_root_url in lib.rs when bumping this
 description   = """
 Signature and elliptic curve types providing interoperable support for the
 Elliptic Curve Digital Signature Algorithm (ECDSA)
 """
-authors       = ["RustCrypto Developers"]
-license       = "Apache-2.0 OR MIT"
-repository    = "https://github.com/RustCrypto/signatures"
-edition       = "2018"
-readme        = "README.md"
-categories    = ["cryptography", "no-std"]
-keywords      = ["crypto", "ecc", "nist", "secp256k1", "signature"]
+authors    = ["RustCrypto Developers"]
+license    = "Apache-2.0 OR MIT"
+repository = "https://github.com/RustCrypto/signatures"
+edition    = "2018"
+readme     = "README.md"
+categories = ["cryptography", "no-std"]
+keywords   = ["crypto", "ecc", "nist", "secp256k1", "signature"]
 
 [dependencies]
 elliptic-curve = { version = "0.8", default-features = false }

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -48,7 +48,7 @@
 #![warn(missing_docs, rust_2018_idioms)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png",
-    html_root_url = "https://docs.rs/ecdsa/0.10.0-pre"
+    html_root_url = "https://docs.rs/ecdsa/0.10.0"
 )]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
### Changed
- Bump `elliptic-curve` dependency to v0.8 ([#215])

[#215]: https://github.com/RustCrypto/signatures/pull/215