### PR TITLE
ecdsa v0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
- "elliptic-curve 0.8.0",
+ "elliptic-curve 0.8.1",
  "hex-literal",
  "hmac",
  "sha2",
@@ -182,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4cf86631e1e5cf5fa77372d1d4d7bcaa26eba12d695012e93ef980a50dc5250"
+checksum = "02b76528f382c916bbb94470b4e7ad107a3d01619503f7ffba86c93aea04e215"
 dependencies = [
  "bitvec",
  "digest",

--- a/ecdsa/CHANGELOG.md
+++ b/ecdsa/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.1 (2020-12-16)
+### Fixed
+- Trigger docs.rs rebuild with nightly bugfix ([RustCrypto/traits#412])
+
+[RustCrypto/traits#412]: https://github.com/RustCrypto/traits/pull/412
+
 ## 0.10.0 (2020-12-16)
 ### Changed
 - Bump `elliptic-curve` dependency to v0.8 ([#215])

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ecdsa"
-version = "0.10.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.10.1" # Also update html_root_url in lib.rs when bumping this
 description   = """
 Signature and elliptic curve types providing interoperable support for the
 Elliptic Curve Digital Signature Algorithm (ECDSA)

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -48,7 +48,7 @@
 #![warn(missing_docs, rust_2018_idioms)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png",
-    html_root_url = "https://docs.rs/ecdsa/0.10.0"
+    html_root_url = "https://docs.rs/ecdsa/0.10.1"
 )]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
This is a release solely to trigger a rebuild on docs.rs.

The previous build failed due to a `nightly` regression in the upstream `elliptic-curve` crate:

https://github.com/RustCrypto/traits/pull/412

Crate is otherwise unchanged from the previous release.