### PR TITLE
ecdsa v0.10.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "elliptic-curve 0.8.3",
  "hex-literal",

--- a/ecdsa/CHANGELOG.md
+++ b/ecdsa/CHANGELOG.md
@@ -4,13 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.10.1 (2020-12-16)
+## 0.10.2 (2020-12-22)
+### Changed
+- Bump `elliptic-curve` crate to v0.8.3 ([#218])
+- Use the `dev` module from the `elliptic-curve` crate ([#218])
+
+[#218]: https://github.com/RustCrypto/signatures/pull/218
+
+## 0.10.1 (2020-12-16) [YANKED]
 ### Fixed
 - Trigger docs.rs rebuild with nightly bugfix ([RustCrypto/traits#412])
 
 [RustCrypto/traits#412]: https://github.com/RustCrypto/traits/pull/412
 
-## 0.10.0 (2020-12-16)
+## 0.10.0 (2020-12-16) [YANKED]
 ### Changed
 - Bump `elliptic-curve` dependency to v0.8 ([#215])
 

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ecdsa"
-version = "0.10.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.10.2" # Also update html_root_url in lib.rs when bumping this
 description   = """
 Signature and elliptic curve types providing interoperable support for the
 Elliptic Curve Digital Signature Algorithm (ECDSA)
@@ -19,7 +19,7 @@ hmac = { version = "0.10", optional = true, default-features = false }
 signature = { version = ">= 1.2.2, < 1.3.0", default-features = false, features = ["rand-preview"] }
 
 [dev-dependencies]
-elliptic-curve = { version = "0.8.2", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.8.3", default-features = false, features = ["dev"] }
 hex-literal = "0.2"
 sha2 = { version = "0.9", default-features = false }
 

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -48,7 +48,7 @@
 #![warn(missing_docs, rust_2018_idioms)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png",
-    html_root_url = "https://docs.rs/ecdsa/0.10.1"
+    html_root_url = "https://docs.rs/ecdsa/0.10.2"
 )]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
### Changed
- Bump `elliptic-curve` crate to v0.8.3 ([#218])
- Use the `dev` module from the `elliptic-curve` crate ([#218])

[#218]: https://github.com/RustCrypto/signatures/pull/218