### PR TITLE
Cargo.lock: bump deps to flat-namespaced `elliptic-curve` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "const-oid"
 version = "0.4.1"
-source = "git+https://github.com/RustCrypto/utils.git#39ef46c61f4658e9dc2a4cd91aa7cda0f8397adc"
+source = "git+https://github.com/RustCrypto/utils.git#b2b5fb554fad25071f4268bc6e8fb3d6def4bc7e"
 
 [[package]]
 name = "cpuid-bool"
@@ -80,7 +80,7 @@ dependencies = [
 [[package]]
 name = "der"
 version = "0.2.0-pre"
-source = "git+https://github.com/RustCrypto/utils.git#39ef46c61f4658e9dc2a4cd91aa7cda0f8397adc"
+source = "git+https://github.com/RustCrypto/utils.git#b2b5fb554fad25071f4268bc6e8fb3d6def4bc7e"
 dependencies = [
  "const-oid",
  "typenum",
@@ -144,7 +144,7 @@ dependencies = [
 [[package]]
 name = "elliptic-curve"
 version = "0.9.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#bb2c4f0b1baec38a03032f0d82239668ce393a6e"
+source = "git+https://github.com/RustCrypto/traits.git#79281260b3dd05b59ded7452a4788be5ab160e46"
 dependencies = [
  "digest",
  "ff",

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -108,11 +108,7 @@ use elliptic_curve::FieldBytes;
 use generic_array::{sequence::Concat, typenum::Unsigned, ArrayLength, GenericArray};
 
 #[cfg(feature = "arithmetic")]
-use elliptic_curve::{
-    ff::PrimeField,
-    scalar::{NonZeroScalar, Scalar},
-    ProjectiveArithmetic,
-};
+use elliptic_curve::{ff::PrimeField, NonZeroScalar, ProjectiveArithmetic, Scalar};
 
 /// Size of a fixed sized signature for the given elliptic curve.
 pub type SignatureSize<C> = <<C as elliptic_curve::Curve>::FieldSize as Add>::Output;

--- a/ecdsa/src/rfc6979.rs
+++ b/ecdsa/src/rfc6979.rs
@@ -8,9 +8,8 @@ use elliptic_curve::{
     ff::PrimeField,
     generic_array::GenericArray,
     ops::Invert,
-    scalar::{NonZeroScalar, Scalar},
     zeroize::{Zeroize, Zeroizing},
-    FieldBytes, FromDigest, ProjectiveArithmetic,
+    FieldBytes, FromDigest, NonZeroScalar, ProjectiveArithmetic, Scalar,
 };
 use hmac::{Hmac, Mac, NewMac};
 

--- a/ecdsa/src/sign.rs
+++ b/ecdsa/src/sign.rs
@@ -10,14 +10,9 @@ use crate::{
     rfc6979, Error, Signature, SignatureSize,
 };
 use elliptic_curve::{
-    ff::PrimeField,
-    generic_array::ArrayLength,
-    ops::Invert,
-    scalar::{NonZeroScalar, Scalar},
-    subtle::ConstantTimeEq,
-    weierstrass::Curve,
-    zeroize::Zeroize,
-    FieldBytes, FromDigest, ProjectiveArithmetic, SecretKey,
+    ff::PrimeField, generic_array::ArrayLength, ops::Invert, subtle::ConstantTimeEq,
+    weierstrass::Curve, zeroize::Zeroize, FieldBytes, FromDigest, NonZeroScalar,
+    ProjectiveArithmetic, Scalar, SecretKey,
 };
 use signature::{
     digest::{BlockInput, Digest, FixedOutput, Reset, Update},

--- a/ecdsa/src/verify.rs
+++ b/ecdsa/src/verify.rs
@@ -12,12 +12,11 @@ use elliptic_curve::{
     consts::U1,
     ff::PrimeField,
     generic_array::ArrayLength,
-    point::{AffinePoint, ProjectivePoint},
     sec1::{
         EncodedPoint, FromEncodedPoint, ToEncodedPoint, UncompressedPointSize, UntaggedPointSize,
     },
     weierstrass::{point, Curve},
-    FieldBytes, FromDigest, ProjectiveArithmetic, PublicKey, Scalar,
+    AffinePoint, FieldBytes, FromDigest, ProjectiveArithmetic, ProjectivePoint, PublicKey, Scalar,
 };
 use signature::{digest::Digest, DigestVerifier};
 


### PR DESCRIPTION
See: https://github.com/RustCrypto/traits/pull/487