### PR TITLE
ecdsa v0.11.0-pre.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.11.0-pre"
+version = "0.11.0-pre.1"
 dependencies = [
  "der",
  "elliptic-curve",

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ecdsa"
-version = "0.11.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.11.0-pre.1" # Also update html_root_url in lib.rs when bumping this
 description   = """
 Signature and elliptic curve types providing interoperable support for the
 Elliptic Curve Digital Signature Algorithm (ECDSA)

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -48,7 +48,7 @@
 #![warn(missing_docs, rust_2018_idioms)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png",
-    html_root_url = "https://docs.rs/ecdsa/0.10.2"
+    html_root_url = "https://docs.rs/ecdsa/0.11.0-pre.1"
 )]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
`ecdsa` v0.11 is pretty much ready to release aside from updates to `digest` and `hmac`.

This prerelease will allow publishing prereleases of the [RustCrypto/elliptic-curve](https://github.com/RustCrypto/elliptic-curves/) crates with an updated `rand_core` dependency, and then we can bump `digest`/`hmac` for a final release.