### PR TITLE
Fix compile error in ed25519 example.

### DIFF
--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -56,7 +56,7 @@
 //! }
 //!
 //! pub struct HelloVerifier<V> {
-//!     pub verifier: V
+//!     pub verify_key: V
 //! }
 //!
 //! impl<V> HelloVerifier<V>
@@ -68,7 +68,7 @@
 //!         person: &str,
 //!         signature: &ed25519::Signature
 //!     ) -> Result<(), ed25519::Error> {
-//!         self.verifier.verify(format_message(person).as_bytes(), signature)
+//!         self.verify_key.verify(format_message(person).as_bytes(), signature)
 //!     }
 //! }
 //!


### PR DESCRIPTION
The first portion of the example in `lib.rs` does not match the second portion for `HelloVerifier` member names - and will fail to compile when combined.

This pull-request aligns the member names so the example works when the two halves are put together.