### PR TITLE
Split out RFC6979 implementation to its own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,10 +107,12 @@ dependencies = [
 name = "ecdsa"
 version = "0.11.0-pre.1"
 dependencies = [
+ "bitvec",
  "der",
  "elliptic-curve",
  "hex-literal",
  "hmac",
+ "rfc6979",
  "sha2",
  "signature",
 ]
@@ -341,6 +343,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.1.0"
+dependencies = [
+ "hex-literal",
+ "hmac",
+ "sha2",
 ]
 
 [[package]]

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -18,6 +18,8 @@ der = { version = "0.2", optional = true, features = ["big-uint"] }
 elliptic-curve = { version = "0.9", default-features = false }
 hmac = { version = "0.10", optional = true, default-features = false }
 signature = { version = ">= 1.3.0, < 1.4.0", default-features = false, features = ["rand-preview"] }
+rfc6979 = {path = "../rfc6979" }
+bitvec = { version = "0.20.0", default-features = false }
 
 [dev-dependencies]
 elliptic-curve = { version = "0.9", default-features = false, features = ["dev"] }

--- a/ecdsa/src/sign.rs
+++ b/ecdsa/src/sign.rs
@@ -7,7 +7,7 @@
 
 use crate::{
     hazmat::{DigestPrimitive, FromDigest, SignPrimitive},
-    rfc6979, Error, Signature, SignatureSize,
+    Error, Signature, SignatureSize,
 };
 use elliptic_curve::{
     ff::PrimeField, generic_array::ArrayLength, ops::Invert, subtle::ConstantTimeEq,
@@ -129,7 +129,7 @@ where
     /// computed using the algorithm described in RFC 6979 (Section 3.2):
     /// <https://tools.ietf.org/html/rfc6979#section-3>
     fn try_sign_digest(&self, digest: D) -> Result<Signature<C>, Error> {
-        let k = rfc6979::generate_k(self.inner.secret_scalar(), digest.clone(), &[]);
+        let k = crate::rfc6979::generate_k(self.inner.secret_scalar(), digest.clone(), &[]);
         let msg_scalar = Scalar::<C>::from_digest(digest);
 
         self.inner
@@ -176,7 +176,8 @@ where
         let mut added_entropy = FieldBytes::<C>::default();
         rng.fill_bytes(&mut added_entropy);
 
-        let k = rfc6979::generate_k(self.inner.secret_scalar(), digest.clone(), &added_entropy);
+        let k =
+            crate::rfc6979::generate_k(self.inner.secret_scalar(), digest.clone(), &added_entropy);
         let msg_scalar = Scalar::<C>::from_digest(digest);
 
         self.inner

--- a/rfc6979/Cargo.toml
+++ b/rfc6979/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "rfc6979"
+version = "0.1.0"
+authors    = ["RustCrypto Developers"]
+license    = "Apache-2.0 OR MIT"
+repository = "https://github.com/RustCrypto/signatures"
+edition    = "2018"
+description   = """
+Support library for the ecdsa crate which provides deterministic generation
+of k values according to RFC6979
+"""
+readme     = "README.md"
+categories = ["cryptography", "no-std"]
+keywords   = ["crypto", "deterministic", "dsa", "ecdsa", "signature"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+hmac = { version = "0.10", default-features = false }
+
+[dev-dependencies]
+hex-literal = "0.3"
+sha2 = { version = "0.9", default-features = false }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/rfc6979/src/hmac_drbg.rs
+++ b/rfc6979/src/hmac_drbg.rs
@@ -1,0 +1,65 @@
+use hmac::{
+    digest::{generic_array::GenericArray, BlockInput, FixedOutput, Reset, Update},
+    Hmac, Mac, NewMac,
+};
+
+/// Internal implementation of `HMAC_DRBG` as described in NIST SP800-90A:
+/// <https://csrc.nist.gov/publications/detail/sp/800-90a/rev-1/final>
+///
+/// This is a HMAC-based deterministic random bit generator used internally
+/// to compute a deterministic ECDSA ephemeral scalar `k`.
+pub struct HmacDrbg<D>
+where
+    D: BlockInput + FixedOutput + Clone + Default + Reset + Update,
+{
+    /// HMAC key `K` (see RFC 6979 Section 3.2.c)
+    k: Hmac<D>,
+
+    /// Chaining value `V` (see RFC 6979 Section 3.2.c)
+    v: GenericArray<u8, D::OutputSize>,
+}
+
+impl<D> HmacDrbg<D>
+where
+    D: BlockInput + FixedOutput + Clone + Default + Reset + Update,
+{
+    /// Initialize `HMAC_DRBG`
+    pub fn new(entropy_input: &[u8], nonce: &[u8], additional_data: &[u8]) -> Self {
+        let mut k = Hmac::new(&Default::default());
+        let mut v = GenericArray::default();
+
+        for b in &mut v {
+            *b = 0x01;
+        }
+
+        for i in 0..=1 {
+            k.update(&v);
+            k.update(&[i]);
+            k.update(entropy_input);
+            k.update(nonce);
+            k.update(additional_data);
+            k = Hmac::new_varkey(&k.finalize().into_bytes()).unwrap();
+
+            // Steps 3.2.e,g: v = HMAC_k(v)
+            k.update(&v);
+            v = k.finalize_reset().into_bytes();
+        }
+
+        Self { k, v }
+    }
+
+    /// Get the next `HMAC_DRBG` output
+    pub fn generate_into(&mut self, out: &mut [u8]) {
+        for out_chunk in out.chunks_mut(self.v.len()) {
+            self.k.update(&self.v);
+            self.v = self.k.finalize_reset().into_bytes();
+            out_chunk.copy_from_slice(&self.v[..out_chunk.len()]);
+        }
+
+        self.k.update(&self.v);
+        self.k.update(&[0x00]);
+        self.k = Hmac::new_varkey(&self.k.finalize_reset().into_bytes()).unwrap();
+        self.k.update(&self.v);
+        self.v = self.k.finalize_reset().into_bytes();
+    }
+}

--- a/rfc6979/src/lib.rs
+++ b/rfc6979/src/lib.rs
@@ -1,0 +1,87 @@
+//! Support for computing deterministic DSA or ECDSA ephemeral scalar (`k`).
+//!
+//! Implementation of the algorithm described in RFC 6979 (Section 3.2):
+//! <https://tools.ietf.org/html/rfc6979#section-3>
+//!
+//! The generics `I`, `O`, and `T` are merely so checks can be optimized away if all are
+//! fixed-size arrays.
+
+pub use hmac;
+
+use hmac::digest::{BlockInput, FixedOutput, Reset, Update};
+
+pub mod hmac_drbg;
+
+pub struct KGenerator<D, I>
+where
+    D: BlockInput + FixedOutput + Clone + Default + Reset + Update,
+    I: AsRef<[u8]>,
+{
+    modulus: I,
+    rng: hmac_drbg::HmacDrbg<D>,
+}
+
+impl<D, I> KGenerator<D, I>
+where
+    D: BlockInput + FixedOutput + Clone + Default + Reset + Update,
+    I: AsRef<[u8]>,
+{
+    /// The `secret` is the secret part of the DSA private key. `digest` is the hash of the
+    /// message being signed, in general using the same hash algorithm as the one passed to
+    /// `KGenerator` as a generic parameter.
+    ///
+    /// Both should have been truncated to the same number of bits as needed to represent the
+    /// modulus, interpreted as a big-endian number, reduced to being below the modulus by
+    /// subtracting the modulus if it is larger than the modulus, and then encoding as a big
+    /// endian number, padded with leading zero bytes to the same length as the modulus.
+    /// See RFC6979 for details.
+    ///
+    /// The modulus must be in big endian format with no padding (i.e. first byte must not be 0).
+    ///
+    /// This function will panic if these requirements are not met.
+    pub fn new<T: AsRef<[u8]>>(modulus: I, secret: T, digest: T, additional_data: &[u8]) -> Self {
+        let rng = {
+            let modulus = modulus.as_ref();
+            let secret = secret.as_ref();
+            let digest = digest.as_ref();
+            assert!(modulus.len() > 0 && modulus[0] != 0);
+            assert!(secret.len() == modulus.len() && secret < modulus);
+            assert!(digest.len() == modulus.len() && digest < modulus);
+            hmac_drbg::HmacDrbg::new(secret, digest, additional_data)
+        };
+
+        Self { modulus, rng }
+    }
+
+    /// Generate the next number smaller than `modulus` into the passed buffer.
+    /// The buffer must be of the same length as the modulus, or the function will panic.
+    pub fn generate_into<O: AsMut<[u8]>>(&mut self, mut out: O) {
+        let modulus = self.modulus.as_ref();
+        let out = out.as_mut();
+        assert!(out.len() == modulus.len());
+
+        // Many or all reasonable use cases will use all available bits in the modulus and thus
+        // have shift equal to 0. But for classic DSA people generate their own domain params,
+        // and even among older elliptic curves likely to be used with EC-DSA there are oddballs
+        // like P-521.
+        let shift = modulus[0].leading_zeros();
+        loop {
+            self.rng.generate_into(out);
+
+            if shift != 0 {
+                // shift entire buffer right by `shift` bits
+                let mut next_hi = 0;
+                for b in out.iter_mut() {
+                    let hi = next_hi;
+                    let lo = b.wrapping_shr(shift);
+                    next_hi = b.wrapping_shl(8 - shift);
+                    *b = hi | lo;
+                }
+            }
+
+            if &*out < modulus {
+                break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is the deterministic k (nonce) generation used by `ecdsa`. It is being split out because it will also be used in the upcoming `dsa` implementation.

For the currently implemented ECDSA use cases we always have a modulus which has a bit length which is divisible by 8 and equal to the length of the digest function output. This is not guaranteed to be the case for classic DSA, so some missing features had to be implemented.

(This commit contains these changes as well as the move to a separate crate. I can split those changes out again if needed, but I've been testing with the in-progress DSA code as well to make sure the interface is correct and things are working. It would take a bit of extra work and by now I just want to get something up for review.)

One of the changes was to the HMAC DRBG code, to produce output strings of arbitrary length (as defined in its standard). This was not a huge change, just adding a loop.

To properly implement the new aspects of RFC6979 the generation code needs to know the bit length of the modulus. I decided it was probably nicer to just pass the whole modulus, so the code can also check that various values are smaller than the modulus.

The modulus is only available via the `bitvec`-based `PrimeField::char_le_bits` API, and the value of scalars is also available in this way (via `to_le_bits`). So I decided to use it for all Scalar to bytes conversion. I would much prefer an API which properly defines the endianness (and I've posted a discussion of this in an issue on the traits repo), but for now this will do.

This PR depends on https://github.com/RustCrypto/traits/pull/565 (just merged) and https://github.com/RustCrypto/traits/pull/566 (not yet merged), otherwise tests will fail because of unimplemented features on the `MockCurve` used for testing.

The test suite in the `ecdsa` crate is very minimal (and does not exercise the new features needed for DSA) and I've added no dedicated tests for the new crate. However, the new DSA code has many tests based on official test vectors with many combinations of digest and key length, and these do exercise all the features except for moduli with a bit length not divisible by 8.

This is currently at a "ready for review" state and I've tested it fairly well, but I would not be surprised to find something missing a bit of polish.