### PR TITLE
ecdsa: remove useless debug assert

### DIFF
--- a/ecdsa/src/der.rs
+++ b/ecdsa/src/der.rs
@@ -177,7 +177,6 @@ where
 
         let r_range = find_scalar_range(input, r.as_bytes())?;
         let s_range = find_scalar_range(input, s.as_bytes())?;
-        debug_assert_eq!(s_range.end, input.len());
 
         if s_range.end != input.len() {
             return Err(Error::new());


### PR DESCRIPTION
This assertion duplicates an error handling check immediately below it.

It's likely a remnant of the retrofitting of the `der` crate for signature parsing.