### PR TITLE
ecdsa: bump base64ct, elliptic-curve, and pkcs8; MSRV 1.47+

### DIFF
--- a/.github/workflows/ecdsa.yml
+++ b/.github/workflows/ecdsa.yml
@@ -24,7 +24,7 @@ jobs:
           - thumbv7em-none-eabi
           - wasm32-unknown-unknown
         rust:
-          - 1.46.0 # MSRV
+          - 1.47.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.46.0 # MSRV
+          - 1.47.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "base64ct"
-version = "0.2.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22fb38fd6e62e4ceec8543db40ceb714454ff173451a0f2a6c8952fdf39a2d6c"
+checksum = "d0d27fb6b6f1e43147af148af49d49329413ba781aa0d5e10979831c210173b5"
 
 [[package]]
 name = "bincode"
@@ -151,9 +151,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "203d2ca86d44931f12e9104dcf8f4735a632eb4dd8d8dfe583c87fe41bb8a862"
+checksum = "e96675863dd09400876af3f9348ecfa1090ee8c2f0b1febf369fef01fe271658"
 dependencies = [
  "ff",
  "funty",
@@ -244,24 +244,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "pkcs5"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321f456f11e455766fc424a5a1b86e6d2478a9ba40f12a06c6afc8cef33ec1d1"
-dependencies = [
- "der",
- "spki",
-]
-
-[[package]]
 name = "pkcs8"
-version = "0.5.2"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbe017f30ae5cc01d2d0e24d8d3bcfdd63bc719c6cdc2b97e974fd933d8c7e15"
+checksum = "a9c455331e3393451bdf8d49f022442a6f45870b0442820548e921de155e18a7"
 dependencies = [
  "base64ct",
  "der",
- "pkcs5",
  "spki",
  "zeroize",
 ]

--- a/ecdsa/README.md
+++ b/ecdsa/README.md
@@ -27,7 +27,10 @@ ways:
 
 ## Minimum Supported Rust Version
 
-- Rust **1.46+**
+This crate requires **Rust 1.47** at a minimum.
+
+We may change the MSRV in the future, but it will be accompanied by a minor
+version bump.
 
 ## License
 
@@ -51,7 +54,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/ecdsa/badge.svg
 [docs-link]: https://docs.rs/ecdsa/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.46+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260048-signatures
 [build-image]: https://github.com/RustCrypto/signatures/workflows/ecdsa/badge.svg?branch=master&event=push

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -28,7 +28,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust **1.46+** or higher.
+//! Rust **1.47** or higher.
 //!
 //! Minimum supported Rust version may be changed in the future, but it will be
 //! accompanied with a minor version bump.

--- a/ed25519/README.md
+++ b/ed25519/README.md
@@ -24,7 +24,10 @@ Ed25519 implementations, including HSMs or Cloud KMS services.
 
 ## Minimum Supported Rust Version
 
-- Rust **1.41+**
+This crate requires **Rust 1.41** at a minimum.
+
+We may change the MSRV in the future, but it will be accompanied by a minor
+version bump.
 
 ## License
 


### PR DESCRIPTION
This commit upgrades the following dependencies:

- `base64` v1.0
- `elliptic-curve` v0.9.5
- `pkcs8` v0.5.5