### PR TITLE
ecdsa: flatten and simplify public API

### DIFF
--- a/ecdsa/src/der.rs
+++ b/ecdsa/src/der.rs
@@ -1,16 +1,17 @@
 //! Support for ECDSA signatures encoded as ASN.1 DER.
 
-use crate::{
-    generic_array::{typenum::NonZero, ArrayLength, GenericArray},
-    Error,
-};
+use crate::Error;
 use core::{
     convert::{TryFrom, TryInto},
     fmt,
     ops::{Add, Range},
 };
 use der::Decodable;
-use elliptic_curve::{consts::U9, weierstrass::Curve};
+use elliptic_curve::{
+    consts::U9,
+    generic_array::{typenum::NonZero, ArrayLength, GenericArray},
+    weierstrass::Curve,
+};
 
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -71,15 +71,13 @@ pub mod hazmat;
 pub mod rfc6979;
 
 #[cfg(feature = "sign")]
-#[cfg_attr(docsrs, doc(cfg(feature = "sign")))]
-pub mod sign;
+mod sign;
 
 #[cfg(feature = "verify")]
-#[cfg_attr(docsrs, doc(cfg(feature = "verify")))]
-pub mod verify;
+mod verify;
 
 // Re-export the `elliptic-curve` crate (and select types)
-pub use elliptic_curve::{self, generic_array, sec1::EncodedPoint, weierstrass::Curve};
+pub use elliptic_curve::{self, sec1::EncodedPoint, weierstrass::Curve};
 
 // Re-export the `signature` crate (and select types)
 pub use signature::{self, Error};
@@ -92,26 +90,21 @@ pub use sign::SigningKey;
 #[cfg_attr(docsrs, doc(cfg(feature = "verify")))]
 pub use verify::VerifyingKey;
 
-#[cfg(feature = "zeroize")]
-#[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
-pub use elliptic_curve::SecretKey;
-
-#[cfg(feature = "pkcs8")]
-pub use elliptic_curve::pkcs8;
-
 use core::{
     convert::TryFrom,
     fmt::{self, Debug},
     ops::Add,
 };
-use elliptic_curve::FieldBytes;
-use generic_array::{sequence::Concat, typenum::Unsigned, ArrayLength, GenericArray};
+use elliptic_curve::{
+    generic_array::{sequence::Concat, typenum::Unsigned, ArrayLength, GenericArray},
+    FieldBytes,
+};
 
 #[cfg(feature = "arithmetic")]
 use elliptic_curve::{ff::PrimeField, NonZeroScalar, ProjectiveArithmetic, Scalar};
 
 #[cfg(feature = "der")]
-use generic_array::typenum::NonZero;
+use elliptic_curve::generic_array::typenum::NonZero;
 
 /// Size of a fixed sized signature for the given elliptic curve.
 pub type SignatureSize<C> = <<C as elliptic_curve::Curve>::FieldSize as Add>::Output;
@@ -119,12 +112,9 @@ pub type SignatureSize<C> = <<C as elliptic_curve::Curve>::FieldSize as Add>::Ou
 /// Fixed-size byte array containing an ECDSA signature
 pub type SignatureBytes<C> = GenericArray<u8, SignatureSize<C>>;
 
-/// ECDSA signatures (fixed-size).
+/// ECDSA signature (fixed-size). Generic over elliptic curve types.
 ///
-/// Generic over elliptic curve types.
-///
-/// These signatures are serialized as fixed-sized big endian scalar values
-/// with no additional framing:
+/// Serialized as fixed-sized big endian scalar values with no added framing:
 ///
 /// - `r`: field element size for the given curve, big-endian
 /// - `s`: field element size for the given curve, big-endian

--- a/ecdsa/src/sign.rs
+++ b/ecdsa/src/sign.rs
@@ -1,7 +1,4 @@
-//! ECDSA signing key. Generic over elliptic curves.
-//!
-//! Requires an [`elliptic_curve::ProjectiveArithmetic`] impl on the curve, and a
-//! [`SignPrimitive`] impl on its associated `Scalar` type.
+//! ECDSA signing key.
 
 // TODO(tarcieri): support for hardware crypto accelerators
 
@@ -28,20 +25,22 @@ use {
 };
 
 #[cfg(feature = "pkcs8")]
-use crate::{
-    elliptic_curve::{
-        consts::U1,
-        ops::Add,
-        sec1::{FromEncodedPoint, ToEncodedPoint, UncompressedPointSize, UntaggedPointSize},
-        AlgorithmParameters,
-    },
+use crate::elliptic_curve::{
+    consts::U1,
+    ops::Add,
     pkcs8::{self, FromPrivateKey},
+    sec1::{FromEncodedPoint, ToEncodedPoint, UncompressedPointSize, UntaggedPointSize},
+    AlgorithmParameters,
 };
 
 #[cfg(feature = "pem")]
 use core::str::FromStr;
 
-/// ECDSA signing key
+/// ECDSA signing key. Generic over elliptic curves.
+///
+/// Requires an [`elliptic_curve::ProjectiveArithmetic`] impl on the curve, and a
+/// [`SignPrimitive`] impl on its associated `Scalar` type.
+#[cfg_attr(docsrs, doc(cfg(feature = "sign")))]
 pub struct SigningKey<C>
 where
     C: Curve + ProjectiveArithmetic,

--- a/ecdsa/src/verify.rs
+++ b/ecdsa/src/verify.rs
@@ -1,7 +1,4 @@
-//! ECDSA verification key (i.e. public key). Generic over elliptic curves.
-//!
-//! Requires an [`elliptic_curve::ProjectiveArithmetic`] impl on the curve, and a
-//! [`VerifyPrimitive`] impl on its associated `AffinePoint` type.
+//! ECDSA verification key.
 
 use crate::{
     hazmat::{DigestPrimitive, FromDigest, VerifyPrimitive},
@@ -21,15 +18,19 @@ use elliptic_curve::{
 use signature::{digest::Digest, DigestVerifier};
 
 #[cfg(feature = "pkcs8")]
-use crate::{
-    elliptic_curve::AlgorithmParameters,
+use crate::elliptic_curve::{
     pkcs8::{self, FromPublicKey},
+    AlgorithmParameters,
 };
 
 #[cfg(feature = "pem")]
 use core::str::FromStr;
 
-/// ECDSA verify key
+/// ECDSA verification key (i.e. public key). Generic over elliptic curves.
+///
+/// Requires an [`elliptic_curve::ProjectiveArithmetic`] impl on the curve, and a
+/// [`VerifyPrimitive`] impl on its associated `AffinePoint` type.
+#[cfg_attr(docsrs, doc(cfg(feature = "verify")))]
 #[derive(Copy, Clone, Debug)]
 pub struct VerifyingKey<C>
 where


### PR DESCRIPTION
Removes superfluous modules from the public API, flattening it down and also removing superfluous re-exports.