### PR TITLE
ecdsa: use `verifying_key` name consistently

### DIFF
--- a/ecdsa/src/dev.rs
+++ b/ecdsa/src/dev.rs
@@ -235,7 +235,7 @@ macro_rules! new_wycheproof_test {
                 let y = element_from_padded_slice::<$curve>(wy);
                 let q_encoded: EncodedPoint<$curve> =
                     EncodedPoint::from_affine_coordinates(&x, &y, /* compress= */ false);
-                let verify_key = ecdsa_core::VerifyingKey::from_encoded_point(&q_encoded).unwrap();
+                let verifying_key = $crate::VerifyingKey::from_encoded_point(&q_encoded).unwrap();
 
                 let sig = match Signature::from_der(sig) {
                     Ok(s) => s,
@@ -243,7 +243,7 @@ macro_rules! new_wycheproof_test {
                     Err(_) => return Some("failed to parse signature ASN.1"),
                 };
 
-                match verify_key.verify(msg, &sig) {
+                match verifying_key.verify(msg, &sig) {
                     Ok(_) if pass => None,
                     Ok(_) => Some("signature verify failed"),
                     Err(_) if !pass => None,

--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -12,23 +12,24 @@
 //! FULL PRIVATE KEY RECOVERY!
 
 #[cfg(feature = "arithmetic")]
-use crate::SignatureSize;
-#[cfg(feature = "arithmetic")]
-use core::borrow::Borrow;
-#[cfg(feature = "arithmetic")]
-use elliptic_curve::{ff::PrimeField, ops::Invert, FieldBytes, ProjectiveArithmetic, Scalar};
-#[cfg(feature = "arithmetic")]
-use signature::Error;
+use {
+    crate::SignatureSize,
+    core::borrow::Borrow,
+    elliptic_curve::{ff::PrimeField, ops::Invert, FieldBytes, ProjectiveArithmetic, Scalar},
+    signature::Error,
+};
 
 #[cfg(feature = "digest")]
-use crate::CheckSignatureBytes;
-#[cfg(feature = "digest")]
-use signature::{digest::Digest, PrehashSignature};
+use crate::{
+    signature::{digest::Digest, PrehashSignature},
+    CheckSignatureBytes,
+};
 
 #[cfg(any(feature = "arithmetic", feature = "digest"))]
-use crate::Signature;
-#[cfg(any(feature = "arithmetic", feature = "digest"))]
-use elliptic_curve::{generic_array::ArrayLength, weierstrass::Curve};
+use crate::{
+    elliptic_curve::{generic_array::ArrayLength, weierstrass::Curve},
+    Signature,
+};
 
 /// Try to sign the given prehashed message using ECDSA.
 ///
@@ -115,7 +116,6 @@ where
     ///
     /// Accepts the following arguments:
     ///
-    /// - `verify_key`: public key to verify the signature against
     /// - `hashed_msg`: prehashed message to be verified
     /// - `signature`: signature to be verified against the key and message
     fn verify_prehashed(

--- a/ecdsa/src/sign.rs
+++ b/ecdsa/src/sign.rs
@@ -81,7 +81,7 @@ where
     /// Get the [`VerifyingKey`] which corresponds to this [`SigningKey`]
     #[cfg(feature = "verify")]
     #[cfg_attr(docsrs, doc(cfg(feature = "verify")))]
-    pub fn verify_key(&self) -> VerifyingKey<C>
+    pub fn verifying_key(&self) -> VerifyingKey<C>
     where
         AffinePoint<C>: Copy + Clone + Debug + Default,
         ProjectivePoint<C>: From<AffinePoint<C>>,
@@ -235,7 +235,7 @@ where
     SignatureSize<C>: ArrayLength<u8>,
 {
     fn from(signing_key: &SigningKey<C>) -> VerifyingKey<C> {
-        signing_key.verify_key()
+        signing_key.verifying_key()
     }
 }
 

--- a/ecdsa/src/verify.rs
+++ b/ecdsa/src/verify.rs
@@ -110,8 +110,8 @@ where
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
-    fn from(verify_key: &VerifyingKey<C>) -> EncodedPoint<C> {
-        verify_key.to_encoded_point(C::COMPRESS_POINTS)
+    fn from(verifying_key: &VerifyingKey<C>) -> EncodedPoint<C> {
+        verifying_key.to_encoded_point(C::COMPRESS_POINTS)
     }
 }
 
@@ -143,8 +143,8 @@ where
     AffinePoint<C>: Copy + Clone + Debug,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
 {
-    fn from(verify_key: VerifyingKey<C>) -> PublicKey<C> {
-        verify_key.inner
+    fn from(verifying_key: VerifyingKey<C>) -> PublicKey<C> {
+        verifying_key.inner
     }
 }
 
@@ -154,8 +154,8 @@ where
     AffinePoint<C>: Copy + Clone + Debug,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
 {
-    fn from(verify_key: &VerifyingKey<C>) -> PublicKey<C> {
-        verify_key.clone().into()
+    fn from(verifying_key: &VerifyingKey<C>) -> PublicKey<C> {
+        verifying_key.clone().into()
     }
 }
 


### PR DESCRIPTION
Previously this key type was named `VerifyKey` and was changed to `VerifyingKey` for more consistency with `SigningKey`.

However, some usages of `verify_key` were not updated. This commit updates those names to be consistent with the type name.