### PR TITLE
ecdsa: bound curve implementations on Order trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,12 +152,12 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.9.6"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78fff5a5d53c2e45c2772aa2666904eaf5af581b9fc356b9da42b52bda088e6d"
+checksum = "c1a9176ec191bd6a85fdb3018336d04e8a98e3ca8ae56951d9846b0da94f3dfb"
 dependencies = [
+ "bitvec",
  "ff",
- "funty",
  "generic-array",
  "group",
  "hex-literal",

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -15,7 +15,7 @@ keywords   = ["crypto", "ecc", "nist", "secp256k1", "signature"]
 
 [dependencies]
 der = { version = "0.3", optional = true, features = ["big-uint"] }
-elliptic-curve = { version = "0.9", default-features = false }
+elliptic-curve = { version = "0.9.8", default-features = false }
 hmac = { version = "0.10", optional = true, default-features = false }
 signature = { version = ">= 1.3.0, < 1.4.0", default-features = false, features = ["rand-preview"] }
 

--- a/ecdsa/src/der.rs
+++ b/ecdsa/src/der.rs
@@ -11,6 +11,7 @@ use elliptic_curve::{
     consts::U9,
     generic_array::{typenum::NonZero, ArrayLength, GenericArray},
     weierstrass::Curve,
+    Order,
 };
 
 #[cfg(feature = "alloc")]
@@ -50,7 +51,7 @@ const ENCODING_ERR_MSG: &str = "DER encoding error";
 /// Generic over the scalar size of the elliptic curve.
 pub struct Signature<C>
 where
-    C: Curve,
+    C: Curve + Order,
     C::FieldSize: Add + ArrayLength<u8> + NonZero,
     MaxSize<C>: ArrayLength<u8>,
     <C::FieldSize as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
@@ -67,7 +68,7 @@ where
 
 impl<C> signature::Signature for Signature<C>
 where
-    C: Curve,
+    C: Curve + Order,
     C::FieldSize: Add + ArrayLength<u8> + NonZero,
     MaxSize<C>: ArrayLength<u8>,
     <C::FieldSize as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
@@ -81,7 +82,7 @@ where
 #[allow(clippy::len_without_is_empty)]
 impl<C> Signature<C>
 where
-    C: Curve,
+    C: Curve + Order,
     C::FieldSize: Add + ArrayLength<u8> + NonZero,
     MaxSize<C>: ArrayLength<u8>,
     <C::FieldSize as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
@@ -132,7 +133,7 @@ where
 
 impl<C> AsRef<[u8]> for Signature<C>
 where
-    C: Curve,
+    C: Curve + Order,
     C::FieldSize: Add + ArrayLength<u8> + NonZero,
     MaxSize<C>: ArrayLength<u8>,
     <C::FieldSize as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
@@ -144,7 +145,7 @@ where
 
 impl<C> fmt::Debug for Signature<C>
 where
-    C: Curve,
+    C: Curve + Order,
     C::FieldSize: Add + ArrayLength<u8> + NonZero,
     MaxSize<C>: ArrayLength<u8>,
     <C::FieldSize as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
@@ -159,7 +160,7 @@ where
 
 impl<C> TryFrom<&[u8]> for Signature<C>
 where
-    C: Curve,
+    C: Curve + Order,
     C::FieldSize: Add + ArrayLength<u8> + NonZero,
     MaxSize<C>: ArrayLength<u8>,
     <C::FieldSize as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,

--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -15,7 +15,9 @@
 use {
     crate::SignatureSize,
     core::borrow::Borrow,
-    elliptic_curve::{ff::PrimeField, ops::Invert, FieldBytes, ProjectiveArithmetic, Scalar},
+    elliptic_curve::{
+        ff::PrimeField, ops::Invert, FieldBytes, Order, ProjectiveArithmetic, Scalar,
+    },
     signature::Error,
 };
 
@@ -40,7 +42,7 @@ use crate::{
 #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub trait SignPrimitive<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: Curve + Order + ProjectiveArithmetic,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     SignatureSize<C>: ArrayLength<u8>,
 {
@@ -64,7 +66,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub trait RecoverableSignPrimitive<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: Curve + Order + ProjectiveArithmetic,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     SignatureSize<C>: ArrayLength<u8>,
 {
@@ -84,7 +86,7 @@ where
 #[cfg(feature = "arithmetic")]
 impl<C, T> SignPrimitive<C> for T
 where
-    C: Curve + ProjectiveArithmetic,
+    C: Curve + Order + ProjectiveArithmetic,
     T: RecoverableSignPrimitive<C>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     SignatureSize<C>: ArrayLength<u8>,
@@ -108,7 +110,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub trait VerifyPrimitive<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: Curve + Order + ProjectiveArithmetic,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     SignatureSize<C>: ArrayLength<u8>,
 {
@@ -137,7 +139,7 @@ where
 /// [1]: https://github.com/RustCrypto/traits/tree/master/signature/derive
 #[cfg(feature = "digest")]
 #[cfg_attr(docsrs, doc(cfg(feature = "digest")))]
-pub trait DigestPrimitive: Curve {
+pub trait DigestPrimitive: Curve + Order {
     /// Preferred digest to use when computing ECDSA signatures for this
     /// elliptic curve. This should be a member of the SHA-2 family.
     type Digest: Digest;

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -97,7 +97,7 @@ use core::{
 };
 use elliptic_curve::{
     generic_array::{sequence::Concat, typenum::Unsigned, ArrayLength, GenericArray},
-    FieldBytes,
+    FieldBytes, Order,
 };
 
 #[cfg(feature = "arithmetic")]
@@ -126,7 +126,7 @@ pub type SignatureBytes<C> = GenericArray<u8, SignatureSize<C>>;
 /// ASN.1 DER-encoded signatures also supported via the
 /// [`Signature::from_der`] and [`Signature::to_der`] methods.
 #[derive(Clone, Eq, PartialEq)]
-pub struct Signature<C: Curve + CheckSignatureBytes>
+pub struct Signature<C: Curve + Order + CheckSignatureBytes>
 where
     SignatureSize<C>: ArrayLength<u8>,
 {
@@ -135,7 +135,7 @@ where
 
 impl<C> Signature<C>
 where
-    C: Curve + CheckSignatureBytes,
+    C: Curve + Order + CheckSignatureBytes,
     SignatureSize<C>: ArrayLength<u8>,
 {
     /// Create a [`Signature`] from the serialized `r` and `s` scalar values
@@ -177,7 +177,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 impl<C> Signature<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: Curve + Order + ProjectiveArithmetic,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     <Scalar<C> as PrimeField>::Repr: From<Scalar<C>> + for<'a> From<&'a Scalar<C>>,
     SignatureSize<C>: ArrayLength<u8>,
@@ -221,7 +221,7 @@ where
 
 impl<C> signature::Signature for Signature<C>
 where
-    C: Curve + CheckSignatureBytes,
+    C: Curve + Order + CheckSignatureBytes,
     SignatureSize<C>: ArrayLength<u8>,
 {
     fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
@@ -231,7 +231,7 @@ where
 
 impl<C> AsRef<[u8]> for Signature<C>
 where
-    C: Curve + CheckSignatureBytes,
+    C: Curve + Order + CheckSignatureBytes,
     SignatureSize<C>: ArrayLength<u8>,
 {
     fn as_ref(&self) -> &[u8] {
@@ -241,7 +241,7 @@ where
 
 impl<C> Copy for Signature<C>
 where
-    C: Curve + CheckSignatureBytes,
+    C: Curve + Order + CheckSignatureBytes,
     SignatureSize<C>: ArrayLength<u8>,
     <SignatureSize<C> as ArrayLength<u8>>::ArrayType: Copy,
 {
@@ -249,7 +249,7 @@ where
 
 impl<C> Debug for Signature<C>
 where
-    C: Curve + CheckSignatureBytes,
+    C: Curve + Order + CheckSignatureBytes,
     SignatureSize<C>: ArrayLength<u8>,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -264,7 +264,7 @@ where
 
 impl<C> TryFrom<&[u8]> for Signature<C>
 where
-    C: Curve + CheckSignatureBytes,
+    C: Curve + Order + CheckSignatureBytes,
     SignatureSize<C>: ArrayLength<u8>,
 {
     type Error = Error;
@@ -285,7 +285,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "der")))]
 impl<C> TryFrom<der::Signature<C>> for Signature<C>
 where
-    C: Curve + CheckSignatureBytes,
+    C: Curve + Order + CheckSignatureBytes,
     C::FieldSize: Add + ArrayLength<u8> + NonZero,
     der::MaxSize<C>: ArrayLength<u8>,
     <C::FieldSize as Add>::Output: Add<der::MaxOverhead> + ArrayLength<u8>,

--- a/ecdsa/src/sign.rs
+++ b/ecdsa/src/sign.rs
@@ -8,8 +8,8 @@ use crate::{
 };
 use elliptic_curve::{
     ff::PrimeField, generic_array::ArrayLength, ops::Invert, subtle::ConstantTimeEq,
-    weierstrass::Curve, zeroize::Zeroize, FieldBytes, NonZeroScalar, ProjectiveArithmetic, Scalar,
-    SecretKey,
+    weierstrass::Curve, zeroize::Zeroize, FieldBytes, NonZeroScalar, Order, ProjectiveArithmetic,
+    Scalar, SecretKey,
 };
 use signature::{
     digest::{BlockInput, Digest, FixedOutput, Reset, Update},
@@ -43,7 +43,7 @@ use core::str::FromStr;
 #[cfg_attr(docsrs, doc(cfg(feature = "sign")))]
 pub struct SigningKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: Curve + Order + ProjectiveArithmetic,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>
         + FromDigest<C>
         + Invert<Output = Scalar<C>>
@@ -56,7 +56,7 @@ where
 
 impl<C> SigningKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: Curve + Order + ProjectiveArithmetic,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>
         + FromDigest<C>
         + Invert<Output = Scalar<C>>
@@ -99,7 +99,7 @@ where
 
 impl<C> From<SecretKey<C>> for SigningKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: Curve + Order + ProjectiveArithmetic,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>
         + ConstantTimeEq
         + FromDigest<C>
@@ -115,7 +115,7 @@ where
 
 impl<C, D> DigestSigner<D, Signature<C>> for SigningKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: Curve + Order + ProjectiveArithmetic,
     D: FixedOutput<OutputSize = C::FieldSize> + BlockInput + Clone + Default + Reset + Update,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>
         + FromDigest<C>
@@ -140,7 +140,7 @@ where
 impl<C> signature::Signer<Signature<C>> for SigningKey<C>
 where
     Self: DigestSigner<C::Digest, Signature<C>>,
-    C: Curve + ProjectiveArithmetic + DigestPrimitive,
+    C: Curve + Order + ProjectiveArithmetic + DigestPrimitive,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>
         + FromDigest<C>
         + Invert<Output = Scalar<C>>
@@ -155,7 +155,7 @@ where
 
 impl<C, D> RandomizedDigestSigner<D, Signature<C>> for SigningKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: Curve + Order + ProjectiveArithmetic,
     D: FixedOutput<OutputSize = C::FieldSize> + BlockInput + Clone + Default + Reset + Update,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>
         + FromDigest<C>
@@ -187,7 +187,7 @@ where
 impl<C> RandomizedSigner<Signature<C>> for SigningKey<C>
 where
     Self: RandomizedDigestSigner<C::Digest, Signature<C>>,
-    C: Curve + ProjectiveArithmetic + DigestPrimitive,
+    C: Curve + Order + ProjectiveArithmetic + DigestPrimitive,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>
         + FromDigest<C>
         + Invert<Output = Scalar<C>>
@@ -206,7 +206,7 @@ where
 
 impl<C> From<NonZeroScalar<C>> for SigningKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: Curve + Order + ProjectiveArithmetic,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>
         + FromDigest<C>
         + Invert<Output = Scalar<C>>
@@ -224,7 +224,7 @@ where
 #[cfg(feature = "verify")]
 impl<C> From<&SigningKey<C>> for VerifyingKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: Curve + Order + ProjectiveArithmetic,
     AffinePoint<C>: Copy + Clone + Debug + Default,
     ProjectivePoint<C>: From<AffinePoint<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>
@@ -243,7 +243,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
 impl<C> FromPrivateKey for SigningKey<C>
 where
-    C: Curve + AlgorithmParameters + ProjectiveArithmetic,
+    C: Curve + AlgorithmParameters + Order + ProjectiveArithmetic,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>
@@ -266,7 +266,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl<C> FromStr for SigningKey<C>
 where
-    C: Curve + AlgorithmParameters + ProjectiveArithmetic,
+    C: Curve + AlgorithmParameters + Order + ProjectiveArithmetic,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>

--- a/ecdsa/src/verify.rs
+++ b/ecdsa/src/verify.rs
@@ -13,7 +13,7 @@ use elliptic_curve::{
         EncodedPoint, FromEncodedPoint, ToEncodedPoint, UncompressedPointSize, UntaggedPointSize,
     },
     weierstrass::{Curve, PointCompression},
-    AffinePoint, FieldBytes, ProjectiveArithmetic, ProjectivePoint, PublicKey, Scalar,
+    AffinePoint, FieldBytes, Order, ProjectiveArithmetic, ProjectivePoint, PublicKey, Scalar,
 };
 use signature::{digest::Digest, DigestVerifier};
 
@@ -34,7 +34,7 @@ use core::str::FromStr;
 #[derive(Copy, Clone, Debug)]
 pub struct VerifyingKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: Curve + Order + ProjectiveArithmetic,
     AffinePoint<C>: Copy + Clone + Debug,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
 {
@@ -43,7 +43,7 @@ where
 
 impl<C> VerifyingKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: Curve + Order + ProjectiveArithmetic,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
@@ -73,7 +73,7 @@ where
 
 impl<C, D> DigestVerifier<D, Signature<C>> for VerifyingKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: Curve + Order + ProjectiveArithmetic,
     D: Digest<OutputSize = C::FieldSize>,
     AffinePoint<C>: Copy + Clone + Debug + VerifyPrimitive<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
@@ -89,7 +89,7 @@ where
 
 impl<C> signature::Verifier<Signature<C>> for VerifyingKey<C>
 where
-    C: Curve + ProjectiveArithmetic + DigestPrimitive,
+    C: Curve + Order + ProjectiveArithmetic + DigestPrimitive,
     C::Digest: Digest<OutputSize = C::FieldSize>,
     AffinePoint<C>: Copy + Clone + Debug + VerifyPrimitive<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
@@ -103,7 +103,7 @@ where
 
 impl<C> From<&VerifyingKey<C>> for EncodedPoint<C>
 where
-    C: Curve + ProjectiveArithmetic + PointCompression,
+    C: Curve + Order + ProjectiveArithmetic + PointCompression,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
@@ -117,7 +117,7 @@ where
 
 impl<C> From<PublicKey<C>> for VerifyingKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: Curve + Order + ProjectiveArithmetic,
     AffinePoint<C>: Copy + Clone + Debug,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
 {
@@ -128,7 +128,7 @@ where
 
 impl<C> From<&PublicKey<C>> for VerifyingKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: Curve + Order + ProjectiveArithmetic,
     AffinePoint<C>: Copy + Clone + Debug,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
 {
@@ -139,7 +139,7 @@ where
 
 impl<C> From<VerifyingKey<C>> for PublicKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: Curve + Order + ProjectiveArithmetic,
     AffinePoint<C>: Copy + Clone + Debug,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
 {
@@ -150,7 +150,7 @@ where
 
 impl<C> From<&VerifyingKey<C>> for PublicKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: Curve + Order + ProjectiveArithmetic,
     AffinePoint<C>: Copy + Clone + Debug,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
 {
@@ -161,7 +161,7 @@ where
 
 impl<C> Eq for VerifyingKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: Curve + Order + ProjectiveArithmetic,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
@@ -172,7 +172,7 @@ where
 
 impl<C> PartialEq for VerifyingKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: Curve + Order + ProjectiveArithmetic,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
@@ -188,7 +188,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
 impl<C> FromPublicKey for VerifyingKey<C>
 where
-    C: Curve + AlgorithmParameters + ProjectiveArithmetic + PointCompression,
+    C: Curve + AlgorithmParameters + Order + ProjectiveArithmetic + PointCompression,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
@@ -204,7 +204,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl<C> FromStr for VerifyingKey<C>
 where
-    C: Curve + AlgorithmParameters + ProjectiveArithmetic + PointCompression,
+    C: Curve + AlgorithmParameters + Order + ProjectiveArithmetic + PointCompression,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,


### PR DESCRIPTION
The longer-term goal of this change is to eliminate the `CheckSignatureBytes` trait by having a generic implementation which uses the `Order::ORDER` constant.

For now, just ensure that the curve's order is defined.