### PR TITLE
ecdsa: replace CheckSignatureBytes with Order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1a9176ec191bd6a85fdb3018336d04e8a98e3ca8ae56951d9846b0da94f3dfb"
+checksum = "409dd3e6ac38c26a53efe0e4eba2708fdc8d0a3a6469e035a9f2d2f6f0244a0b"
 dependencies = [
  "bitvec",
  "ff",

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -15,7 +15,7 @@ keywords   = ["crypto", "ecc", "nist", "secp256k1", "signature"]
 
 [dependencies]
 der = { version = "0.3", optional = true, features = ["big-uint"] }
-elliptic-curve = { version = "0.9.8", default-features = false }
+elliptic-curve = { version = "0.9.9", default-features = false }
 hmac = { version = "0.10", optional = true, default-features = false }
 signature = { version = ">= 1.3.0, < 1.4.0", default-features = false, features = ["rand-preview"] }
 

--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -22,10 +22,7 @@ use {
 };
 
 #[cfg(feature = "digest")]
-use crate::{
-    signature::{digest::Digest, PrehashSignature},
-    CheckSignatureBytes,
-};
+use crate::signature::{digest::Digest, PrehashSignature};
 
 #[cfg(any(feature = "arithmetic", feature = "digest"))]
 use crate::{
@@ -165,7 +162,7 @@ pub trait FromDigest<C: Curve> {
 #[cfg(feature = "digest")]
 impl<C> PrehashSignature for Signature<C>
 where
-    C: DigestPrimitive + CheckSignatureBytes,
+    C: DigestPrimitive,
     <C::FieldSize as core::ops::Add>::Output: ArrayLength<u8>,
 {
     type Digest = C::Digest;

--- a/ecdsa/tests/lib.rs
+++ b/ecdsa/tests/lib.rs
@@ -1,0 +1,15 @@
+//! Smoke tests which use `MockCurve`
+
+#![cfg(feature = "dev")]
+
+use core::convert::TryFrom;
+use elliptic_curve::dev::MockCurve;
+
+type Signature = ecdsa::Signature<MockCurve>;
+type SignatureBytes = ecdsa::SignatureBytes<MockCurve>;
+
+#[test]
+fn rejects_all_zero_signature() {
+    let all_zero_bytes = SignatureBytes::default();
+    assert!(Signature::try_from(all_zero_bytes.as_ref()).is_err());
+}


### PR DESCRIPTION
Uses a generic implementation for checking that the scalars in a signature are in range which doesn't require a curve arithmetic backend.