### PR TITLE
ecdsa: bump `elliptic-curve` to v0.9.10; use `ScalarBytes`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "409dd3e6ac38c26a53efe0e4eba2708fdc8d0a3a6469e035a9f2d2f6f0244a0b"
+checksum = "9f3104713f3d121fc649fc3c462f77e0df75ae28421ac1c09be7449982e90940"
 dependencies = [
  "bitvec",
  "ff",

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -15,7 +15,7 @@ keywords   = ["crypto", "ecc", "nist", "secp256k1", "signature"]
 
 [dependencies]
 der = { version = "0.3", optional = true, features = ["big-uint"] }
-elliptic-curve = { version = "0.9.9", default-features = false }
+elliptic-curve = { version = "0.9.10", default-features = false }
 hmac = { version = "0.10", optional = true, default-features = false }
 signature = { version = ">= 1.3.0, < 1.4.0", default-features = false, features = ["rand-preview"] }
 

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -97,7 +97,7 @@ use core::{
 };
 use elliptic_curve::{
     generic_array::{sequence::Concat, typenum::Unsigned, ArrayLength, GenericArray},
-    FieldBytes, Order,
+    FieldBytes, Order, ScalarBytes,
 };
 
 #[cfg(feature = "arithmetic")]
@@ -279,7 +279,10 @@ where
                 return Err(Error::new());
             }
 
-            if !bool::from(C::is_scalar_repr_in_range(GenericArray::from_slice(scalar))) {
+            if ScalarBytes::<C>::new(GenericArray::clone_from_slice(scalar))
+                .is_none()
+                .into()
+            {
                 return Err(Error::new());
             }
         }


### PR DESCRIPTION
Bumps the `elliptic-curve` crate dependency to v0.9.10, and uses the newly added `ScalarBytes` type to `impl TryFrom<&[u8]> for Signature<C>`