### PR TITLE
ed25519 v1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,15 @@ dependencies = [
 [[package]]
 name = "ed25519"
 version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37c66a534cbb46ab4ea03477eae19d5c22c01da8258030280b7bd9d8433fb6ef"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519"
+version = "1.1.0"
 dependencies = [
  "bincode",
  "ed25519-dalek",
@@ -161,22 +170,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "ed25519"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c66a534cbb46ab4ea03477eae19d5c22c01da8258030280b7bd9d8433fb6ef"
-dependencies = [
- "signature",
-]
-
-[[package]]
 name = "ed25519-dalek"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek",
- "ed25519 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ed25519 1.0.3",
  "rand",
  "serde",
  "sha2",
@@ -440,7 +440,7 @@ dependencies = [
  "aead",
  "digest",
  "ecdsa 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ed25519 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ed25519 1.0.3",
  "generic-array",
  "opaque-debug",
  "p256",

--- a/ed25519/CHANGES.md
+++ b/ed25519/CHANGES.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.1.0 (2021-04-30)
+### Changed
+- Bump `ring-compat` to v0.2; MSRV 1.47+ ([#289])
+
+### Fixed
+- Compile error in example ([#246])
+
+[#246]: https://github.com/RustCrypto/signatures/pull/246
+[#289]: https://github.com/RustCrypto/signatures/pull/289
+
 ## 1.0.3 (2020-10-12)
 ### Added
 - `ring-compat` usage example ([#187])

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ed25519"
-version       = "1.0.3"
+version       = "1.1.0"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 description   = "Edwards Digital Signature Algorithm (EdDSA) over Curve25519 (as specified in RFC 8032)"


### PR DESCRIPTION
### Changed
- Bump `ring-compat` to v0.2; MSRV 1.47+ ([#289])

### Fixed
- Compile error in example ([#246])

[#246]: https://github.com/RustCrypto/signatures/pull/246
[#289]: https://github.com/RustCrypto/signatures/pull/289