### PR TITLE
ed25519: updates for `ring-compat` v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,9 +433,9 @@ dependencies = [
 
 [[package]]
 name = "ring-compat"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c10e5a7d9bc5de3d81dc1600f535d163b9330c9e00a96678037593883c6031"
+checksum = "aa5d9fa3ce9ca8fadd287d21da5320dbf6de6a08908acdf95247aeadc2c41964"
 dependencies = [
  "aead",
  "digest",

--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -161,7 +161,7 @@
 //!
 //! ```
 //! use ring_compat::signature::{
-//!     ed25519::{Signature, SigningKey, VerifyKey},
+//!     ed25519::{Signature, SigningKey, VerifyingKey},
 //!     Signer, Verifier
 //! };
 //! #
@@ -222,7 +222,7 @@
 //!
 //! /// `HelloVerifier` defined above instantiated with *ring*
 //! /// as the signature verification provider.
-//! pub type RingHelloVerifier = HelloVerifier<VerifyKey>;
+//! pub type RingHelloVerifier = HelloVerifier<VerifyingKey>;
 //!
 //! let verifier = RingHelloVerifier { verify_key };
 //! assert!(verifier.verify(person, &signature).is_ok());


### PR DESCRIPTION
`VerifyKey` was renamed to `VerifyingKey`