### PR TITLE
ed25519 v1.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bincode",
  "ed25519-dalek",

--- a/ed25519/CHANGELOG.md
+++ b/ed25519/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.1.1 (2021-04-30)
+### Changed
+- Updates for `ring-compat` v0.2.1 ([#291])
+
+[#291]: https://github.com/RustCrypto/signatures/pull/291
+
 ## 1.1.0 (2021-04-30)
 ### Changed
 - Bump `ring-compat` to v0.2; MSRV 1.47+ ([#289])

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ed25519"
-version       = "1.1.0"
+version       = "1.1.1"
 authors       = ["RustCrypto Developers"]
 license       = "Apache-2.0 OR MIT"
 description   = "Edwards Digital Signature Algorithm (EdDSA) over Curve25519 (as specified in RFC 8032)"

--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -249,7 +249,7 @@
 #![no_std]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png",
-    html_root_url = "https://docs.rs/ed25519/1.0.3"
+    html_root_url = "https://docs.rs/ed25519/1.1.1"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Changed
- Updates for `ring-compat` v0.2.1 ([#291])

[#291]: https://github.com/RustCrypto/signatures/pull/291