### PR TITLE
ecdsa v0.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,23 +129,23 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b568b5e72165dd8913ac2aad6a60cb9cb297287615544c523c37f9247b58fc8"
+dependencies = [
+ "der",
+ "elliptic-curve",
+ "signature",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.11.1"
 dependencies = [
  "der",
  "elliptic-curve",
  "hex-literal",
  "hmac",
  "sha2",
- "signature",
-]
-
-[[package]]
-name = "ecdsa"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b568b5e72165dd8913ac2aad6a60cb9cb297287615544c523c37f9247b58fc8"
-dependencies = [
- "der",
- "elliptic-curve",
  "signature",
 ]
 
@@ -314,7 +314,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cf301f7f053902eaf046d541cd7b454a588b2bdd571f18195b57ae197aed2cb"
 dependencies = [
- "ecdsa 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ecdsa 0.11.0",
  "elliptic-curve",
 ]
 
@@ -324,7 +324,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94e3bfd7d8f202c293072de214ad93480b533985bfee4fa4a13cfdd185fab13d"
 dependencies = [
- "ecdsa 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ecdsa 0.11.0",
  "elliptic-curve",
 ]
 
@@ -440,7 +440,7 @@ checksum = "aa5d9fa3ce9ca8fadd287d21da5320dbf6de6a08908acdf95247aeadc2c41964"
 dependencies = [
  "aead",
  "digest",
- "ecdsa 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ecdsa 0.11.0",
  "ed25519 1.0.3",
  "generic-array",
  "opaque-debug",

--- a/ecdsa/CHANGELOG.md
+++ b/ecdsa/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.1 (2021-05-24)
+### Added
+- `Ord` and `PartialOrd` impls on VerifyingKey ([#298], [#299])
+
+### Changed
+- Bump `elliptic-curve` dependency to v0.9.12 ([#299])
+
+[#298]: https://github.com/RustCrypto/signatures/pull/298
+[#299]: https://github.com/RustCrypto/signatures/pull/299
+
 ## 0.11.0 (2021-04-29)
 ### Added
 - `FromDigest` trait ([#238], [#244])

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ecdsa"
-version = "0.11.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.11.1" # Also update html_root_url in lib.rs when bumping this
 description   = """
 Signature and elliptic curve types providing interoperable support for the
 Elliptic Curve Digital Signature Algorithm (ECDSA)

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -48,7 +48,7 @@
 #![warn(missing_docs, rust_2018_idioms)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png",
-    html_root_url = "https://docs.rs/ecdsa/0.11.0"
+    html_root_url = "https://docs.rs/ecdsa/0.11.1"
 )]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
### Added
- `Ord` and `PartialOrd` impls on VerifyingKey ([#298], [#299])

### Changed
- Bump `elliptic-curve` dependency to v0.9.12 ([#299])

[#298]: https://github.com/RustCrypto/signatures/pull/298
[#299]: https://github.com/RustCrypto/signatures/pull/299