### PR TITLE
ecdsa: bump `elliptic-curve` crate to v0.10.0-pre; MSRV 1.51+

### DIFF
--- a/.github/workflows/ecdsa.yml
+++ b/.github/workflows/ecdsa.yml
@@ -24,7 +24,7 @@ jobs:
           - thumbv7em-none-eabi
           - wasm32-unknown-unknown
         rust:
-          - 1.47.0 # MSRV
+          - 1.51.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.47.0 # MSRV
+          - 1.51.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -38,51 +38,26 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.47.0 # MSRV
+          toolchain: 1.51.0
           components: clippy
       - run: cargo clippy --all-features -- -D warnings
+
 
   codecov:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Cache cargo registry
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
-
-      - name: Cache cargo index
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('Cargo.lock') }}
-
-      - name: Cache cargo build
-        uses: actions/cache@v1
-        with:
-          path: target
-          key: ${{ runner.os }}-coverage-cargo-build-target-${{ hashFiles('Cargo.lock') }}
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+          profile: minimal
           override: true
-
-      - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
+      - uses: actions-rs/tarpaulin@v0.1
         with:
-          version: 'latest'
+          version: latest
           args: --all --all-features -- --test-threads 1
-
-      - name: Upload to codecov.io
-        uses: codecov/codecov-action@v1.0.13
-
-      - name: Archive code coverage results
-        uses: actions/upload-artifact@v1
+      - uses: codecov/codecov-action@v1
+      - uses: actions/upload-artifact@v1
         with:
           name: code-coverage-report
           path: cobertura.xml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aead"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aeaececfd937b9762778f2aca063ad24fdc827c48c07aeae36fb20c03afa11a"
+checksum = "922b33332f54fc0ad13fa3e514601e8d30fb54e1f3eadc36643f6526db645621"
 dependencies = [
  "generic-array",
 ]
@@ -12,8 +12,7 @@ dependencies = [
 [[package]]
 name = "base64ct"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0d27fb6b6f1e43147af148af49d49329413ba781aa0d5e10979831c210173b5"
+source = "git+https://github.com/rustcrypto/utils.git#c1f7fd345e112b2f363a5b8a3ab3d321df4fed7c"
 
 [[package]]
 name = "bincode"
@@ -22,18 +21,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "bitvec"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f682656975d3a682daff957be4ddeb65d6ad656737cd821f2d00685ae466af1"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
 ]
 
 [[package]]
@@ -47,21 +34,21 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.6.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
+checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cc"
-version = "1.0.67"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
 
 [[package]]
 name = "cfg-if"
@@ -71,17 +58,25 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "const-oid"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af497ba993c3f3c416a0e1e1d84b81c3e0b131c4c67105a391920ba4dfa24d2d"
+version = "0.6.0"
+source = "git+https://github.com/rustcrypto/utils.git#c1f7fd345e112b2f363a5b8a3ab3d321df4fed7c"
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.1"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec1028182c380cc45a2e2c5ec841134f2dfd0f8f5f0a5bcd68004f81b5efdf4"
+checksum = "ed00c67cb5d0a7d64a44f6ad2668db7e7530311dd53ea79bcd4fb022c64911c8"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.1.0"
+source = "git+https://github.com/rustcrypto/utils.git#c1f7fd345e112b2f363a5b8a3ab3d321df4fed7c"
+dependencies = [
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]
@@ -96,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.0.2"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f627126b946c25a4638eec0ea634fc52506dea98db118aae985118ce7c3d723f"
+checksum = "639891fde0dbea823fc3d798a0fdf9d2f9440a42d64a78ab3488b0ca025117b3"
 dependencies = [
  "byteorder",
  "digest",
@@ -113,8 +108,15 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eeb9d92785d1facb50567852ce75d0858630630e7eabea59cf7eb7474051087"
 dependencies = [
- "const-oid",
  "typenum",
+]
+
+[[package]]
+name = "der"
+version = "0.4.0-pre"
+source = "git+https://github.com/rustcrypto/utils.git#c1f7fd345e112b2f363a5b8a3ab3d321df4fed7c"
+dependencies = [
+ "const-oid",
 ]
 
 [[package]]
@@ -128,21 +130,10 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b568b5e72165dd8913ac2aad6a60cb9cb297287615544c523c37f9247b58fc8"
-dependencies = [
- "der",
- "elliptic-curve",
- "signature",
-]
-
-[[package]]
-name = "ecdsa"
 version = "0.11.1"
 dependencies = [
- "der",
- "elliptic-curve",
+ "der 0.4.0-pre",
+ "elliptic-curve 0.10.0-pre",
  "hex-literal",
  "hmac",
  "sha2",
@@ -150,11 +141,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "ed25519"
-version = "1.0.3"
+name = "ecdsa"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c66a534cbb46ab4ea03477eae19d5c22c01da8258030280b7bd9d8433fb6ef"
+checksum = "34d33b390ab82f2e1481e331dbd0530895640179d2128ef9a79cc690b78d1eba"
 dependencies = [
+ "der 0.3.5",
+ "elliptic-curve 0.9.12",
  "signature",
 ]
 
@@ -171,13 +164,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d0860415b12243916284c67a9be413e044ee6668247b99ba26d94b2bc06c8f6"
+dependencies = [
+ "signature",
+]
+
+[[package]]
 name = "ed25519-dalek"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek",
- "ed25519 1.0.3",
+ "ed25519 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand",
  "serde",
  "sha2",
@@ -190,7 +192,17 @@ version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c13e9b0c3c4170dcc2a12783746c4205d98e18957f57854251eea3f9750fe005"
 dependencies = [
- "bitvec",
+ "generic-array",
+ "rand_core 0.6.2",
+ "subtle",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.10.0-pre"
+source = "git+https://github.com/rustcrypto/traits.git#618645970a3c6d98d016edc129bba32c843883ef"
+dependencies = [
+ "crypto-bigint",
  "ff",
  "generic-array",
  "group",
@@ -203,20 +215,13 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a4d941a5b7c2a75222e2d44fcdf634a67133d9db31e177ae5ff6ecda852bfe"
+checksum = "63eec06c61e487eecf0f7e6e6372e596a81922c28d33e645d6983ca6493a1af0"
 dependencies = [
- "bitvec",
  "rand_core 0.6.2",
  "subtle",
 ]
-
-[[package]]
-name = "funty"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "generic-array"
@@ -241,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b3c1e8b4f1ca07e6605ea1be903a5f6956aec5c8a67fd44d56076631675ed8"
+checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
 dependencies = [
  "ff",
  "rand_core 0.6.2",
@@ -268,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.50"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d99f9e3e84b8f67f846ef5b4cbbc3b1c29f6c759fcbce6f01aa0e73d932a24c"
+checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -283,9 +288,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.90"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4aede83fc3617411dc6993bc8c70919750c1c257c6ca6a502aed6e0e2394ae"
+checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
 
 [[package]]
 name = "log"
@@ -310,12 +315,12 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "p256"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cf301f7f053902eaf046d541cd7b454a588b2bdd571f18195b57ae197aed2cb"
+checksum = "2f05f5287453297c4c16af5e2b04df8fd2a3008d70f252729650bc6d7ace5844"
 dependencies = [
- "ecdsa 0.11.0",
- "elliptic-curve",
+ "ecdsa 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "elliptic-curve 0.9.12",
 ]
 
 [[package]]
@@ -324,18 +329,17 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94e3bfd7d8f202c293072de214ad93480b533985bfee4fa4a13cfdd185fab13d"
 dependencies = [
- "ecdsa 0.11.0",
- "elliptic-curve",
+ "ecdsa 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "elliptic-curve 0.9.12",
 ]
 
 [[package]]
 name = "pkcs8"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b813f58dc6e5d1820868a3c3df3a7ae7852aa2d3d18e98f0d6b20ddd01fe25d7"
+version = "0.7.0-pre"
+source = "git+https://github.com/rustcrypto/utils.git#c1f7fd345e112b2f363a5b8a3ab3d321df4fed7c"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.4.0-pre",
  "spki",
  "zeroize",
 ]
@@ -348,9 +352,9 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
  "unicode-xid",
 ]
@@ -363,12 +367,6 @@ checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "radium"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand"
@@ -440,8 +438,8 @@ checksum = "aa5d9fa3ce9ca8fadd287d21da5320dbf6de6a08908acdf95247aeadc2c41964"
 dependencies = [
  "aead",
  "digest",
- "ecdsa 0.11.0",
- "ed25519 1.0.3",
+ "ecdsa 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ed25519 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array",
  "opaque-debug",
  "p256",
@@ -487,11 +485,10 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spki"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dae7e047abc519c96350e9484a96c6bf1492348af912fd3446dd2dc323f6268"
+version = "0.4.0-pre"
+source = "git+https://github.com/rustcrypto/utils.git#c1f7fd345e112b2f363a5b8a3ab3d321df4fed7c"
 dependencies = [
- "der",
+ "der 0.4.0-pre",
 ]
 
 [[package]]
@@ -502,9 +499,9 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
-version = "1.0.67"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6498a9efc342871f91cc2d0d694c674368b4ceb40f62b65a7a08c3792935e702"
+checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -524,12 +521,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
 name = "typenum"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,9 +528,9 @@ checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "untrusted"
@@ -561,9 +552,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83240549659d187488f91f33c0f8547cbfef0b2088bc470c116d1d260ef623d9"
+checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -571,9 +562,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae70622411ca953215ca6d06d3ebeb1e915f0f6613e3b495122878d7ebec7dae"
+checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -586,9 +577,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e734d91443f177bfdb41969de821e15c516931c3c3db3d318fa1b68975d0f6f"
+checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -596,9 +587,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53739ff08c8a68b0fdbcd54c372b8ab800b1449ab3c9d706503bc7dd1621b2c"
+checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -609,15 +600,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a543ae66aa233d14bb765ed9af4a33e81b8b58d1584cf1b47ff8cd0b9e4489"
+checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
 
 [[package]]
 name = "web-sys"
-version = "0.3.50"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a905d57e488fec8861446d3393670fb50d27a262344013181c2cdf9fff5481be"
+checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -646,25 +637,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "wyz"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
-
-[[package]]
 name = "zeroize"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a974bcdd357f0dca4d41677db03436324d45a4c9ed2d0b873a5a360ce41c36"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3f369ddb18862aba61aa49bf31e74d29f0f162dec753063200e1dc084345d16"
+checksum = "a2c1e130bebaeab2f23886bf9acbaca14b092408c452543c857f66399cd6dab1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,8 @@
 [workspace]
 members = ["ecdsa", "ed25519"]
+
+[patch.crates-io]
+crypto-bigint = { git = "https://github.com/rustcrypto/utils.git" }
+der = { git = "https://github.com/rustcrypto/utils.git" }
+elliptic-curve = { git = "https://github.com/rustcrypto/traits.git" }
+pkcs8 = { git = "https://github.com/rustcrypto/utils.git" }

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -14,13 +14,15 @@ categories = ["cryptography", "no-std"]
 keywords   = ["crypto", "ecc", "nist", "secp256k1", "signature"]
 
 [dependencies]
-der = { version = "0.3", optional = true, features = ["big-uint"] }
-elliptic-curve = { version = "0.9.12", default-features = false }
+elliptic-curve = { version = "=0.10.0-pre", default-features = false }
 hmac = { version = "0.11", optional = true, default-features = false }
 signature = { version = ">= 1.3.0, < 1.4.0", default-features = false, features = ["rand-preview"] }
 
+# optional dependenciescd
+der = { version = "=0.4.0-pre", optional = true }
+
 [dev-dependencies]
-elliptic-curve = { version = "0.9", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "=0.10.0-pre", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 sha2 = { version = "0.9", default-features = false }
 

--- a/ecdsa/README.md
+++ b/ecdsa/README.md
@@ -27,7 +27,7 @@ ways:
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.47** at a minimum.
+This crate requires **Rust 1.51** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -54,7 +54,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/ecdsa/badge.svg
 [docs-link]: https://docs.rs/ecdsa/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260048-signatures
 [build-image]: https://github.com/RustCrypto/signatures/workflows/ecdsa/badge.svg?branch=master&event=push

--- a/ecdsa/src/dev.rs
+++ b/ecdsa/src/dev.rs
@@ -1,61 +1,32 @@
 //! Development-related functionality.
 
 use crate::hazmat::FromDigest;
-use core::convert::{TryFrom, TryInto};
 use elliptic_curve::{
     consts::U32,
-    dev::{MockCurve, Scalar, MODULUS},
-    util::{adc64, sbb64},
+    dev::{MockCurve, Scalar, ScalarBytes},
+    subtle::{ConditionallySelectable, ConstantTimeLess},
+    Curve,
 };
 use signature::digest::Digest;
+
+type UInt = <MockCurve as Curve>::UInt;
 
 impl FromDigest<MockCurve> for Scalar {
     fn from_digest<D>(digest: D) -> Self
     where
         D: Digest<OutputSize = U32>,
     {
-        let bytes = digest.finalize();
+        let uint = UInt::from_be_bytes(&digest.finalize());
+        let overflow = !uint.ct_lt(&MockCurve::ORDER);
+        let scalar = uint.wrapping_add(&UInt::conditional_select(
+            &UInt::ZERO,
+            &MockCurve::ORDER,
+            overflow,
+        ));
 
-        sub_inner(
-            u64::from_be_bytes(bytes[24..32].try_into().unwrap()),
-            u64::from_be_bytes(bytes[16..24].try_into().unwrap()),
-            u64::from_be_bytes(bytes[8..16].try_into().unwrap()),
-            u64::from_be_bytes(bytes[0..8].try_into().unwrap()),
-            0,
-            MODULUS[0],
-            MODULUS[1],
-            MODULUS[2],
-            MODULUS[3],
-            0,
-        )
+        // TODO(tarcieri): simpler conversion
+        ScalarBytes::from_uint(&scalar).unwrap().into_scalar()
     }
-}
-
-#[allow(clippy::too_many_arguments)]
-fn sub_inner(
-    l0: u64,
-    l1: u64,
-    l2: u64,
-    l3: u64,
-    l4: u64,
-    r0: u64,
-    r1: u64,
-    r2: u64,
-    r3: u64,
-    r4: u64,
-) -> Scalar {
-    let (w0, borrow) = sbb64(l0, r0, 0);
-    let (w1, borrow) = sbb64(l1, r1, borrow);
-    let (w2, borrow) = sbb64(l2, r2, borrow);
-    let (w3, borrow) = sbb64(l3, r3, borrow);
-    let (_, borrow) = sbb64(l4, r4, borrow);
-
-    let (w0, carry) = adc64(w0, MODULUS[0] & borrow, 0);
-    let (w1, carry) = adc64(w1, MODULUS[1] & borrow, carry);
-    let (w2, carry) = adc64(w2, MODULUS[2] & borrow, carry);
-    let (w3, _) = adc64(w3, MODULUS[3] & borrow, carry);
-
-    Scalar::try_from([w0, w1, w2, w3]).unwrap()
 }
 
 // TODO(tarcieri): implement full set of tests from ECDSA2VS

--- a/ecdsa/src/sign.rs
+++ b/ecdsa/src/sign.rs
@@ -7,9 +7,9 @@ use crate::{
     rfc6979, Error, Signature, SignatureSize,
 };
 use elliptic_curve::{
-    ff::PrimeField, generic_array::ArrayLength, ops::Invert, subtle::ConstantTimeEq,
-    weierstrass::Curve, zeroize::Zeroize, FieldBytes, NonZeroScalar, Order, ProjectiveArithmetic,
-    Scalar, SecretKey,
+    generic_array::ArrayLength, group::ff::PrimeField, ops::Invert, weierstrass::Curve,
+    zeroize::Zeroize, FieldBytes, FieldSize, NonZeroScalar, ProjectiveArithmetic, Scalar,
+    SecretKey,
 };
 use signature::{
     digest::{BlockInput, Digest, FixedOutput, Reset, Update},
@@ -21,7 +21,7 @@ use signature::{
 use {
     crate::verify::VerifyingKey,
     core::fmt::Debug,
-    elliptic_curve::{AffinePoint, ProjectivePoint},
+    elliptic_curve::{AffinePoint, ProjectivePoint, PublicKey},
 };
 
 #[cfg(feature = "pkcs8")]
@@ -43,7 +43,7 @@ use core::str::FromStr;
 #[cfg_attr(docsrs, doc(cfg(feature = "sign")))]
 pub struct SigningKey<C>
 where
-    C: Curve + Order + ProjectiveArithmetic,
+    C: Curve + ProjectiveArithmetic,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>
         + FromDigest<C>
         + Invert<Output = Scalar<C>>
@@ -51,12 +51,12 @@ where
         + Zeroize,
     SignatureSize<C>: ArrayLength<u8>,
 {
-    inner: SecretKey<C>,
+    inner: NonZeroScalar<C>,
 }
 
 impl<C> SigningKey<C>
 where
-    C: Curve + Order + ProjectiveArithmetic,
+    C: Curve + ProjectiveArithmetic,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>
         + FromDigest<C>
         + Invert<Output = Scalar<C>>
@@ -67,15 +67,17 @@ where
     /// Generate a cryptographically random [`SigningKey`].
     pub fn random(rng: impl CryptoRng + RngCore) -> Self {
         Self {
-            inner: SecretKey::random(rng),
+            inner: NonZeroScalar::random(rng),
         }
     }
 
     /// Initialize signing key from a raw scalar serialized as a byte slice.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
-        SecretKey::from_bytes(bytes)
-            .map(|sk| Self { inner: sk })
-            .map_err(|_| Error::new())
+        let sk = SecretKey::from_bytes(bytes).map_err(|_| Error::new())?;
+
+        Ok(Self {
+            inner: sk.to_secret_scalar(),
+        })
     }
 
     /// Get the [`VerifyingKey`] which corresponds to this [`SigningKey`]
@@ -87,21 +89,20 @@ where
         ProjectivePoint<C>: From<AffinePoint<C>>,
     {
         VerifyingKey {
-            inner: self.inner.public_key(),
+            inner: PublicKey::from_secret_scalar(&self.inner),
         }
     }
 
     /// Serialize this [`SigningKey`] as bytes
     pub fn to_bytes(&self) -> FieldBytes<C> {
-        self.inner.to_bytes()
+        self.inner.to_repr()
     }
 }
 
 impl<C> From<SecretKey<C>> for SigningKey<C>
 where
-    C: Curve + Order + ProjectiveArithmetic,
+    C: Curve + ProjectiveArithmetic,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>
-        + ConstantTimeEq
         + FromDigest<C>
         + Invert<Output = Scalar<C>>
         + SignPrimitive<C>
@@ -109,14 +110,31 @@ where
     SignatureSize<C>: ArrayLength<u8>,
 {
     fn from(secret_key: SecretKey<C>) -> Self {
-        Self { inner: secret_key }
+        Self::from(&secret_key)
+    }
+}
+
+impl<C> From<&SecretKey<C>> for SigningKey<C>
+where
+    C: Curve + ProjectiveArithmetic,
+    Scalar<C>: PrimeField<Repr = FieldBytes<C>>
+        + FromDigest<C>
+        + Invert<Output = Scalar<C>>
+        + SignPrimitive<C>
+        + Zeroize,
+    SignatureSize<C>: ArrayLength<u8>,
+{
+    fn from(secret_key: &SecretKey<C>) -> Self {
+        Self {
+            inner: secret_key.to_secret_scalar(),
+        }
     }
 }
 
 impl<C, D> DigestSigner<D, Signature<C>> for SigningKey<C>
 where
-    C: Curve + Order + ProjectiveArithmetic,
-    D: FixedOutput<OutputSize = C::FieldSize> + BlockInput + Clone + Default + Reset + Update,
+    C: Curve + ProjectiveArithmetic,
+    D: FixedOutput<OutputSize = FieldSize<C>> + BlockInput + Clone + Default + Reset + Update,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>
         + FromDigest<C>
         + Invert<Output = Scalar<C>>
@@ -128,19 +146,16 @@ where
     /// computed using the algorithm described in RFC 6979 (Section 3.2):
     /// <https://tools.ietf.org/html/rfc6979#section-3>
     fn try_sign_digest(&self, digest: D) -> Result<Signature<C>, Error> {
-        let k = rfc6979::generate_k(self.inner.secret_scalar(), digest.clone(), &[]);
+        let k = rfc6979::generate_k(&self.inner, digest.clone(), &[]);
         let msg_scalar = Scalar::<C>::from_digest(digest);
-
-        self.inner
-            .secret_scalar()
-            .try_sign_prehashed(&**k, &msg_scalar)
+        self.inner.try_sign_prehashed(&**k, &msg_scalar)
     }
 }
 
 impl<C> signature::Signer<Signature<C>> for SigningKey<C>
 where
     Self: DigestSigner<C::Digest, Signature<C>>,
-    C: Curve + Order + ProjectiveArithmetic + DigestPrimitive,
+    C: Curve + ProjectiveArithmetic + DigestPrimitive,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>
         + FromDigest<C>
         + Invert<Output = Scalar<C>>
@@ -155,8 +170,8 @@ where
 
 impl<C, D> RandomizedDigestSigner<D, Signature<C>> for SigningKey<C>
 where
-    C: Curve + Order + ProjectiveArithmetic,
-    D: FixedOutput<OutputSize = C::FieldSize> + BlockInput + Clone + Default + Reset + Update,
+    C: Curve + ProjectiveArithmetic,
+    D: FixedOutput<OutputSize = FieldSize<C>> + BlockInput + Clone + Default + Reset + Update,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>
         + FromDigest<C>
         + Invert<Output = Scalar<C>>
@@ -175,19 +190,16 @@ where
         let mut added_entropy = FieldBytes::<C>::default();
         rng.fill_bytes(&mut added_entropy);
 
-        let k = rfc6979::generate_k(self.inner.secret_scalar(), digest.clone(), &added_entropy);
+        let k = rfc6979::generate_k(&self.inner, digest.clone(), &added_entropy);
         let msg_scalar = Scalar::<C>::from_digest(digest);
-
-        self.inner
-            .secret_scalar()
-            .try_sign_prehashed(&**k, &msg_scalar)
+        self.inner.try_sign_prehashed(&**k, &msg_scalar)
     }
 }
 
 impl<C> RandomizedSigner<Signature<C>> for SigningKey<C>
 where
     Self: RandomizedDigestSigner<C::Digest, Signature<C>>,
-    C: Curve + Order + ProjectiveArithmetic + DigestPrimitive,
+    C: Curve + ProjectiveArithmetic + DigestPrimitive,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>
         + FromDigest<C>
         + Invert<Output = Scalar<C>>
@@ -206,7 +218,7 @@ where
 
 impl<C> From<NonZeroScalar<C>> for SigningKey<C>
 where
-    C: Curve + Order + ProjectiveArithmetic,
+    C: Curve + ProjectiveArithmetic,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>
         + FromDigest<C>
         + Invert<Output = Scalar<C>>
@@ -216,7 +228,7 @@ where
 {
     fn from(secret_scalar: NonZeroScalar<C>) -> Self {
         Self {
-            inner: SecretKey::new(secret_scalar),
+            inner: secret_scalar,
         }
     }
 }
@@ -224,7 +236,7 @@ where
 #[cfg(feature = "verify")]
 impl<C> From<&SigningKey<C>> for VerifyingKey<C>
 where
-    C: Curve + Order + ProjectiveArithmetic,
+    C: Curve + ProjectiveArithmetic,
     AffinePoint<C>: Copy + Clone + Debug + Default,
     ProjectivePoint<C>: From<AffinePoint<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>
@@ -243,7 +255,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
 impl<C> FromPrivateKey for SigningKey<C>
 where
-    C: Curve + AlgorithmParameters + Order + ProjectiveArithmetic,
+    C: Curve + AlgorithmParameters + ProjectiveArithmetic,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>
@@ -258,7 +270,7 @@ where
     fn from_pkcs8_private_key_info(
         private_key_info: pkcs8::PrivateKeyInfo<'_>,
     ) -> pkcs8::Result<Self> {
-        SecretKey::from_pkcs8_private_key_info(private_key_info).map(|inner| Self { inner })
+        SecretKey::from_pkcs8_private_key_info(private_key_info).map(Into::into)
     }
 }
 
@@ -266,7 +278,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl<C> FromStr for SigningKey<C>
 where
-    C: Curve + AlgorithmParameters + Order + ProjectiveArithmetic,
+    C: Curve + AlgorithmParameters + ProjectiveArithmetic,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>

--- a/ecdsa/src/verify.rs
+++ b/ecdsa/src/verify.rs
@@ -7,13 +7,13 @@ use crate::{
 use core::{cmp::Ordering, fmt::Debug, ops::Add};
 use elliptic_curve::{
     consts::U1,
-    ff::PrimeField,
     generic_array::ArrayLength,
+    group::ff::PrimeField,
     sec1::{
         EncodedPoint, FromEncodedPoint, ToEncodedPoint, UncompressedPointSize, UntaggedPointSize,
     },
     weierstrass::{Curve, PointCompression},
-    AffinePoint, FieldBytes, Order, ProjectiveArithmetic, ProjectivePoint, PublicKey, Scalar,
+    AffinePoint, FieldBytes, FieldSize, ProjectiveArithmetic, ProjectivePoint, PublicKey, Scalar,
 };
 use signature::{digest::Digest, DigestVerifier};
 
@@ -34,7 +34,7 @@ use core::str::FromStr;
 #[derive(Copy, Clone, Debug)]
 pub struct VerifyingKey<C>
 where
-    C: Curve + Order + ProjectiveArithmetic,
+    C: Curve + ProjectiveArithmetic,
     AffinePoint<C>: Copy + Clone + Debug,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
 {
@@ -43,7 +43,7 @@ where
 
 impl<C> VerifyingKey<C>
 where
-    C: Curve + Order + ProjectiveArithmetic,
+    C: Curve + ProjectiveArithmetic,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
@@ -73,8 +73,8 @@ where
 
 impl<C, D> DigestVerifier<D, Signature<C>> for VerifyingKey<C>
 where
-    C: Curve + Order + ProjectiveArithmetic,
-    D: Digest<OutputSize = C::FieldSize>,
+    C: Curve + ProjectiveArithmetic,
+    D: Digest<OutputSize = FieldSize<C>>,
     AffinePoint<C>: Copy + Clone + Debug + VerifyPrimitive<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>> + FromDigest<C>,
@@ -89,8 +89,8 @@ where
 
 impl<C> signature::Verifier<Signature<C>> for VerifyingKey<C>
 where
-    C: Curve + Order + ProjectiveArithmetic + DigestPrimitive,
-    C::Digest: Digest<OutputSize = C::FieldSize>,
+    C: Curve + ProjectiveArithmetic + DigestPrimitive,
+    C::Digest: Digest<OutputSize = FieldSize<C>>,
     AffinePoint<C>: Copy + Clone + Debug + VerifyPrimitive<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>> + FromDigest<C>,
@@ -103,7 +103,7 @@ where
 
 impl<C> From<&VerifyingKey<C>> for EncodedPoint<C>
 where
-    C: Curve + Order + ProjectiveArithmetic + PointCompression,
+    C: Curve + ProjectiveArithmetic + PointCompression,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
@@ -117,7 +117,7 @@ where
 
 impl<C> From<PublicKey<C>> for VerifyingKey<C>
 where
-    C: Curve + Order + ProjectiveArithmetic,
+    C: Curve + ProjectiveArithmetic,
     AffinePoint<C>: Copy + Clone + Debug,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
 {
@@ -128,7 +128,7 @@ where
 
 impl<C> From<&PublicKey<C>> for VerifyingKey<C>
 where
-    C: Curve + Order + ProjectiveArithmetic,
+    C: Curve + ProjectiveArithmetic,
     AffinePoint<C>: Copy + Clone + Debug,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
 {
@@ -139,7 +139,7 @@ where
 
 impl<C> From<VerifyingKey<C>> for PublicKey<C>
 where
-    C: Curve + Order + ProjectiveArithmetic,
+    C: Curve + ProjectiveArithmetic,
     AffinePoint<C>: Copy + Clone + Debug,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
 {
@@ -150,7 +150,7 @@ where
 
 impl<C> From<&VerifyingKey<C>> for PublicKey<C>
 where
-    C: Curve + Order + ProjectiveArithmetic,
+    C: Curve + ProjectiveArithmetic,
     AffinePoint<C>: Copy + Clone + Debug,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
 {
@@ -161,7 +161,7 @@ where
 
 impl<C> Eq for VerifyingKey<C>
 where
-    C: Curve + Order + ProjectiveArithmetic,
+    C: Curve + ProjectiveArithmetic,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
@@ -172,7 +172,7 @@ where
 
 impl<C> PartialEq for VerifyingKey<C>
 where
-    C: Curve + Order + ProjectiveArithmetic,
+    C: Curve + ProjectiveArithmetic,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
@@ -186,7 +186,7 @@ where
 
 impl<C> PartialOrd for VerifyingKey<C>
 where
-    C: Curve + Order + ProjectiveArithmetic,
+    C: Curve + ProjectiveArithmetic,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
@@ -200,7 +200,7 @@ where
 
 impl<C> Ord for VerifyingKey<C>
 where
-    C: Curve + Order + ProjectiveArithmetic,
+    C: Curve + ProjectiveArithmetic,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
@@ -216,7 +216,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
 impl<C> FromPublicKey for VerifyingKey<C>
 where
-    C: Curve + AlgorithmParameters + Order + ProjectiveArithmetic + PointCompression,
+    C: Curve + AlgorithmParameters + ProjectiveArithmetic + PointCompression,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
@@ -232,7 +232,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl<C> FromStr for VerifyingKey<C>
 where
-    C: Curve + AlgorithmParameters + Order + ProjectiveArithmetic + PointCompression,
+    C: Curve + AlgorithmParameters + ProjectiveArithmetic + PointCompression,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
     Scalar<C>: PrimeField<Repr = FieldBytes<C>>,


### PR DESCRIPTION
Sourced via git

Also includes bump to `der` crate v0.4.0-pre