### PR TITLE
ecdsa: remove PrimeField bounds; leverage ScalarArithmetic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,7 +200,7 @@ dependencies = [
 [[package]]
 name = "elliptic-curve"
 version = "0.10.0-pre"
-source = "git+https://github.com/rustcrypto/traits.git#618645970a3c6d98d016edc129bba32c843883ef"
+source = "git+https://github.com/rustcrypto/traits.git#840a60393296983bf941f38758d086b95d33d622"
 dependencies = [
  "crypto-bigint",
  "ff",

--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -15,9 +15,7 @@
 use {
     crate::SignatureSize,
     core::borrow::Borrow,
-    elliptic_curve::{
-        group::ff::PrimeField, ops::Invert, FieldBytes, ProjectiveArithmetic, Scalar,
-    },
+    elliptic_curve::{ops::Invert, ProjectiveArithmetic, Scalar},
     signature::Error,
 };
 
@@ -43,7 +41,6 @@ use crate::{
 pub trait SignPrimitive<C>
 where
     C: Curve + ProjectiveArithmetic,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     SignatureSize<C>: ArrayLength<u8>,
 {
     /// Try to sign the prehashed message.
@@ -67,7 +64,6 @@ where
 pub trait RecoverableSignPrimitive<C>
 where
     C: Curve + ProjectiveArithmetic,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     SignatureSize<C>: ArrayLength<u8>,
 {
     /// Try to sign the prehashed message.
@@ -88,7 +84,6 @@ impl<C, T> SignPrimitive<C> for T
 where
     C: Curve + ProjectiveArithmetic,
     T: RecoverableSignPrimitive<C>,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     SignatureSize<C>: ArrayLength<u8>,
 {
     fn try_sign_prehashed<K: Borrow<Scalar<C>> + Invert<Output = Scalar<C>>>(
@@ -111,7 +106,6 @@ where
 pub trait VerifyPrimitive<C>
 where
     C: Curve + ProjectiveArithmetic,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     SignatureSize<C>: ArrayLength<u8>,
 {
     /// Verify the prehashed message against the provided signature

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -178,7 +178,6 @@ where
 impl<C> Signature<C>
 where
     C: Curve + ProjectiveArithmetic,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     <Scalar<C> as PrimeField>::Repr: From<Scalar<C>> + for<'a> From<&'a Scalar<C>>,
     SignatureSize<C>: ArrayLength<u8>,
 {

--- a/ecdsa/src/rfc6979.rs
+++ b/ecdsa/src/rfc6979.rs
@@ -25,8 +25,7 @@ pub fn generate_k<C, D>(
 where
     C: Curve + ProjectiveArithmetic,
     D: FixedOutput<OutputSize = FieldSize<C>> + BlockInput + Clone + Default + Reset + Update,
-    Scalar<C>:
-        PrimeField<Repr = FieldBytes<C>> + FromDigest<C> + Invert<Output = Scalar<C>> + Zeroize,
+    Scalar<C>: FromDigest<C> + Invert<Output = Scalar<C>> + Zeroize,
 {
     let mut x = secret_scalar.to_repr();
     let h1 = Scalar::<C>::from_digest(msg_digest).to_repr();

--- a/ecdsa/src/sign.rs
+++ b/ecdsa/src/sign.rs
@@ -44,11 +44,7 @@ use core::str::FromStr;
 pub struct SigningKey<C>
 where
     C: Curve + ProjectiveArithmetic,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>
-        + FromDigest<C>
-        + Invert<Output = Scalar<C>>
-        + SignPrimitive<C>
-        + Zeroize,
+    Scalar<C>: FromDigest<C> + Invert<Output = Scalar<C>> + SignPrimitive<C> + Zeroize,
     SignatureSize<C>: ArrayLength<u8>,
 {
     inner: NonZeroScalar<C>,
@@ -57,11 +53,7 @@ where
 impl<C> SigningKey<C>
 where
     C: Curve + ProjectiveArithmetic,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>
-        + FromDigest<C>
-        + Invert<Output = Scalar<C>>
-        + SignPrimitive<C>
-        + Zeroize,
+    Scalar<C>: FromDigest<C> + Invert<Output = Scalar<C>> + SignPrimitive<C> + Zeroize,
     SignatureSize<C>: ArrayLength<u8>,
 {
     /// Generate a cryptographically random [`SigningKey`].
@@ -102,11 +94,7 @@ where
 impl<C> From<SecretKey<C>> for SigningKey<C>
 where
     C: Curve + ProjectiveArithmetic,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>
-        + FromDigest<C>
-        + Invert<Output = Scalar<C>>
-        + SignPrimitive<C>
-        + Zeroize,
+    Scalar<C>: FromDigest<C> + Invert<Output = Scalar<C>> + SignPrimitive<C> + Zeroize,
     SignatureSize<C>: ArrayLength<u8>,
 {
     fn from(secret_key: SecretKey<C>) -> Self {
@@ -117,11 +105,7 @@ where
 impl<C> From<&SecretKey<C>> for SigningKey<C>
 where
     C: Curve + ProjectiveArithmetic,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>
-        + FromDigest<C>
-        + Invert<Output = Scalar<C>>
-        + SignPrimitive<C>
-        + Zeroize,
+    Scalar<C>: FromDigest<C> + Invert<Output = Scalar<C>> + SignPrimitive<C> + Zeroize,
     SignatureSize<C>: ArrayLength<u8>,
 {
     fn from(secret_key: &SecretKey<C>) -> Self {
@@ -135,11 +119,7 @@ impl<C, D> DigestSigner<D, Signature<C>> for SigningKey<C>
 where
     C: Curve + ProjectiveArithmetic,
     D: FixedOutput<OutputSize = FieldSize<C>> + BlockInput + Clone + Default + Reset + Update,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>
-        + FromDigest<C>
-        + Invert<Output = Scalar<C>>
-        + SignPrimitive<C>
-        + Zeroize,
+    Scalar<C>: FromDigest<C> + Invert<Output = Scalar<C>> + SignPrimitive<C> + Zeroize,
     SignatureSize<C>: ArrayLength<u8>,
 {
     /// Sign message prehash using a deterministic ephemeral scalar (`k`)
@@ -156,11 +136,7 @@ impl<C> signature::Signer<Signature<C>> for SigningKey<C>
 where
     Self: DigestSigner<C::Digest, Signature<C>>,
     C: Curve + ProjectiveArithmetic + DigestPrimitive,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>
-        + FromDigest<C>
-        + Invert<Output = Scalar<C>>
-        + SignPrimitive<C>
-        + Zeroize,
+    Scalar<C>: FromDigest<C> + Invert<Output = Scalar<C>> + SignPrimitive<C> + Zeroize,
     SignatureSize<C>: ArrayLength<u8>,
 {
     fn try_sign(&self, msg: &[u8]) -> Result<Signature<C>, signature::Error> {
@@ -172,11 +148,7 @@ impl<C, D> RandomizedDigestSigner<D, Signature<C>> for SigningKey<C>
 where
     C: Curve + ProjectiveArithmetic,
     D: FixedOutput<OutputSize = FieldSize<C>> + BlockInput + Clone + Default + Reset + Update,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>
-        + FromDigest<C>
-        + Invert<Output = Scalar<C>>
-        + SignPrimitive<C>
-        + Zeroize,
+    Scalar<C>: FromDigest<C> + Invert<Output = Scalar<C>> + SignPrimitive<C> + Zeroize,
     SignatureSize<C>: ArrayLength<u8>,
 {
     /// Sign message prehash using an ephemeral scalar (`k`) derived according
@@ -200,11 +172,7 @@ impl<C> RandomizedSigner<Signature<C>> for SigningKey<C>
 where
     Self: RandomizedDigestSigner<C::Digest, Signature<C>>,
     C: Curve + ProjectiveArithmetic + DigestPrimitive,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>
-        + FromDigest<C>
-        + Invert<Output = Scalar<C>>
-        + SignPrimitive<C>
-        + Zeroize,
+    Scalar<C>: FromDigest<C> + Invert<Output = Scalar<C>> + SignPrimitive<C> + Zeroize,
     SignatureSize<C>: ArrayLength<u8>,
 {
     fn try_sign_with_rng(
@@ -219,11 +187,7 @@ where
 impl<C> From<NonZeroScalar<C>> for SigningKey<C>
 where
     C: Curve + ProjectiveArithmetic,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>
-        + FromDigest<C>
-        + Invert<Output = Scalar<C>>
-        + SignPrimitive<C>
-        + Zeroize,
+    Scalar<C>: FromDigest<C> + Invert<Output = Scalar<C>> + SignPrimitive<C> + Zeroize,
     SignatureSize<C>: ArrayLength<u8>,
 {
     fn from(secret_scalar: NonZeroScalar<C>) -> Self {
@@ -239,11 +203,7 @@ where
     C: Curve + ProjectiveArithmetic,
     AffinePoint<C>: Copy + Clone + Debug + Default,
     ProjectivePoint<C>: From<AffinePoint<C>>,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>
-        + FromDigest<C>
-        + Invert<Output = Scalar<C>>
-        + SignPrimitive<C>
-        + Zeroize,
+    Scalar<C>: FromDigest<C> + Invert<Output = Scalar<C>> + SignPrimitive<C> + Zeroize,
     SignatureSize<C>: ArrayLength<u8>,
 {
     fn from(signing_key: &SigningKey<C>) -> VerifyingKey<C> {
@@ -258,11 +218,7 @@ where
     C: Curve + AlgorithmParameters + ProjectiveArithmetic,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>
-        + FromDigest<C>
-        + Invert<Output = Scalar<C>>
-        + SignPrimitive<C>
-        + Zeroize,
+    Scalar<C>: FromDigest<C> + Invert<Output = Scalar<C>> + SignPrimitive<C> + Zeroize,
     SignatureSize<C>: ArrayLength<u8>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
@@ -281,11 +237,7 @@ where
     C: Curve + AlgorithmParameters + ProjectiveArithmetic,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>
-        + FromDigest<C>
-        + Invert<Output = Scalar<C>>
-        + SignPrimitive<C>
-        + Zeroize,
+    Scalar<C>: FromDigest<C> + Invert<Output = Scalar<C>> + SignPrimitive<C> + Zeroize,
     SignatureSize<C>: ArrayLength<u8>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,

--- a/ecdsa/src/verify.rs
+++ b/ecdsa/src/verify.rs
@@ -8,12 +8,11 @@ use core::{cmp::Ordering, fmt::Debug, ops::Add};
 use elliptic_curve::{
     consts::U1,
     generic_array::ArrayLength,
-    group::ff::PrimeField,
     sec1::{
         EncodedPoint, FromEncodedPoint, ToEncodedPoint, UncompressedPointSize, UntaggedPointSize,
     },
     weierstrass::{Curve, PointCompression},
-    AffinePoint, FieldBytes, FieldSize, ProjectiveArithmetic, ProjectivePoint, PublicKey, Scalar,
+    AffinePoint, FieldSize, ProjectiveArithmetic, ProjectivePoint, PublicKey, Scalar,
 };
 use signature::{digest::Digest, DigestVerifier};
 
@@ -36,7 +35,6 @@ pub struct VerifyingKey<C>
 where
     C: Curve + ProjectiveArithmetic,
     AffinePoint<C>: Copy + Clone + Debug,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
 {
     pub(crate) inner: PublicKey<C>,
 }
@@ -46,7 +44,6 @@ where
     C: Curve + ProjectiveArithmetic,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
@@ -77,7 +74,7 @@ where
     D: Digest<OutputSize = FieldSize<C>>,
     AffinePoint<C>: Copy + Clone + Debug + VerifyPrimitive<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>> + FromDigest<C>,
+    Scalar<C>: FromDigest<C>,
     SignatureSize<C>: ArrayLength<u8>,
 {
     fn verify_digest(&self, digest: D, signature: &Signature<C>) -> Result<(), Error> {
@@ -93,7 +90,7 @@ where
     C::Digest: Digest<OutputSize = FieldSize<C>>,
     AffinePoint<C>: Copy + Clone + Debug + VerifyPrimitive<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>> + FromDigest<C>,
+    Scalar<C>: FromDigest<C>,
     SignatureSize<C>: ArrayLength<u8>,
 {
     fn verify(&self, msg: &[u8], signature: &Signature<C>) -> Result<(), Error> {
@@ -106,7 +103,6 @@ where
     C: Curve + ProjectiveArithmetic + PointCompression,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
@@ -119,7 +115,6 @@ impl<C> From<PublicKey<C>> for VerifyingKey<C>
 where
     C: Curve + ProjectiveArithmetic,
     AffinePoint<C>: Copy + Clone + Debug,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
 {
     fn from(public_key: PublicKey<C>) -> VerifyingKey<C> {
         VerifyingKey { inner: public_key }
@@ -130,7 +125,6 @@ impl<C> From<&PublicKey<C>> for VerifyingKey<C>
 where
     C: Curve + ProjectiveArithmetic,
     AffinePoint<C>: Copy + Clone + Debug,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
 {
     fn from(public_key: &PublicKey<C>) -> VerifyingKey<C> {
         public_key.clone().into()
@@ -141,7 +135,6 @@ impl<C> From<VerifyingKey<C>> for PublicKey<C>
 where
     C: Curve + ProjectiveArithmetic,
     AffinePoint<C>: Copy + Clone + Debug,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
 {
     fn from(verifying_key: VerifyingKey<C>) -> PublicKey<C> {
         verifying_key.inner
@@ -152,7 +145,6 @@ impl<C> From<&VerifyingKey<C>> for PublicKey<C>
 where
     C: Curve + ProjectiveArithmetic,
     AffinePoint<C>: Copy + Clone + Debug,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
 {
     fn from(verifying_key: &VerifyingKey<C>) -> PublicKey<C> {
         verifying_key.clone().into()
@@ -164,7 +156,6 @@ where
     C: Curve + ProjectiveArithmetic,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
@@ -175,7 +166,6 @@ where
     C: Curve + ProjectiveArithmetic,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
@@ -189,7 +179,6 @@ where
     C: Curve + ProjectiveArithmetic,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
@@ -203,7 +192,6 @@ where
     C: Curve + ProjectiveArithmetic,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
@@ -219,7 +207,6 @@ where
     C: Curve + AlgorithmParameters + ProjectiveArithmetic + PointCompression,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
@@ -235,7 +222,6 @@ where
     C: Curve + AlgorithmParameters + ProjectiveArithmetic + PointCompression,
     AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
     ProjectivePoint<C>: From<AffinePoint<C>>,
-    Scalar<C>: PrimeField<Repr = FieldBytes<C>>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {


### PR DESCRIPTION
The newly introduced `ScalarArithmetic` trait captures these bounds automatically:

https://github.com/RustCrypto/traits/pull/654