### PR TITLE
ecdsa: fix typo

### DIFF
--- a/ecdsa/src/dev.rs
+++ b/ecdsa/src/dev.rs
@@ -171,7 +171,7 @@ macro_rules! new_wycheproof_test {
         #[test]
         fn $name() {
             use blobby::Blob5Iterator;
-            use elliptic_curve::{bignum::NumBytes, generic_array::typenum::Unsigned};
+            use elliptic_curve::{bigint::NumBytes, generic_array::typenum::Unsigned};
 
             // Build a field element but allow for too-short input (left pad with zeros)
             // or too-long input (check excess leftmost bytes are zeros).


### PR DESCRIPTION
`bignum` -> `bigint`