### PR TITLE
ecdsa: remove unnecessary bounds on AffinePoint/ProjectivePoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,7 +12,7 @@ dependencies = [
 [[package]]
 name = "base64ct"
 version = "1.0.0"
-source = "git+https://github.com/rustcrypto/utils.git#c1f7fd345e112b2f363a5b8a3ab3d321df4fed7c"
+source = "git+https://github.com/rustcrypto/utils.git#3fc828a86a31b2b5016dd64e4f3b38a858f9d070"
 
 [[package]]
 name = "bincode"
@@ -59,7 +59,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "const-oid"
 version = "0.6.0"
-source = "git+https://github.com/rustcrypto/utils.git#c1f7fd345e112b2f363a5b8a3ab3d321df4fed7c"
+source = "git+https://github.com/rustcrypto/utils.git#3fc828a86a31b2b5016dd64e4f3b38a858f9d070"
 
 [[package]]
 name = "cpufeatures"
@@ -73,7 +73,7 @@ dependencies = [
 [[package]]
 name = "crypto-bigint"
 version = "0.1.0"
-source = "git+https://github.com/rustcrypto/utils.git#c1f7fd345e112b2f363a5b8a3ab3d321df4fed7c"
+source = "git+https://github.com/rustcrypto/utils.git#3fc828a86a31b2b5016dd64e4f3b38a858f9d070"
 dependencies = [
  "generic-array",
  "subtle",
@@ -114,7 +114,7 @@ dependencies = [
 [[package]]
 name = "der"
 version = "0.4.0-pre"
-source = "git+https://github.com/rustcrypto/utils.git#c1f7fd345e112b2f363a5b8a3ab3d321df4fed7c"
+source = "git+https://github.com/rustcrypto/utils.git#3fc828a86a31b2b5016dd64e4f3b38a858f9d070"
 dependencies = [
  "const-oid",
 ]
@@ -200,7 +200,7 @@ dependencies = [
 [[package]]
 name = "elliptic-curve"
 version = "0.10.0-pre"
-source = "git+https://github.com/rustcrypto/traits.git#840a60393296983bf941f38758d086b95d33d622"
+source = "git+https://github.com/rustcrypto/traits.git#6dced063c1d943e04ee52e5e53bba5e08b83b450"
 dependencies = [
  "crypto-bigint",
  "ff",
@@ -336,7 +336,7 @@ dependencies = [
 [[package]]
 name = "pkcs8"
 version = "0.7.0-pre"
-source = "git+https://github.com/rustcrypto/utils.git#c1f7fd345e112b2f363a5b8a3ab3d321df4fed7c"
+source = "git+https://github.com/rustcrypto/utils.git#3fc828a86a31b2b5016dd64e4f3b38a858f9d070"
 dependencies = [
  "base64ct",
  "der 0.4.0-pre",
@@ -486,7 +486,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 [[package]]
 name = "spki"
 version = "0.4.0-pre"
-source = "git+https://github.com/rustcrypto/utils.git#c1f7fd345e112b2f363a5b8a3ab3d321df4fed7c"
+source = "git+https://github.com/rustcrypto/utils.git#3fc828a86a31b2b5016dd64e4f3b38a858f9d070"
 dependencies = [
  "der 0.4.0-pre",
 ]

--- a/ecdsa/src/sign.rs
+++ b/ecdsa/src/sign.rs
@@ -20,8 +20,7 @@ use signature::{
 #[cfg(feature = "verify")]
 use {
     crate::verify::VerifyingKey,
-    core::fmt::Debug,
-    elliptic_curve::{AffinePoint, ProjectivePoint, PublicKey},
+    elliptic_curve::{AffinePoint, PublicKey},
 };
 
 #[cfg(feature = "pkcs8")]
@@ -75,11 +74,7 @@ where
     /// Get the [`VerifyingKey`] which corresponds to this [`SigningKey`]
     #[cfg(feature = "verify")]
     #[cfg_attr(docsrs, doc(cfg(feature = "verify")))]
-    pub fn verifying_key(&self) -> VerifyingKey<C>
-    where
-        AffinePoint<C>: Copy + Clone + Debug + Default,
-        ProjectivePoint<C>: From<AffinePoint<C>>,
-    {
+    pub fn verifying_key(&self) -> VerifyingKey<C> {
         VerifyingKey {
             inner: PublicKey::from_secret_scalar(&self.inner),
         }
@@ -201,8 +196,7 @@ where
 impl<C> From<&SigningKey<C>> for VerifyingKey<C>
 where
     C: Curve + ProjectiveArithmetic,
-    AffinePoint<C>: Copy + Clone + Debug + Default,
-    ProjectivePoint<C>: From<AffinePoint<C>>,
+
     Scalar<C>: FromDigest<C> + Invert<Output = Scalar<C>> + SignPrimitive<C> + Zeroize,
     SignatureSize<C>: ArrayLength<u8>,
 {
@@ -216,8 +210,7 @@ where
 impl<C> FromPrivateKey for SigningKey<C>
 where
     C: Curve + AlgorithmParameters + ProjectiveArithmetic,
-    AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
-    ProjectivePoint<C>: From<AffinePoint<C>>,
+    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     Scalar<C>: FromDigest<C> + Invert<Output = Scalar<C>> + SignPrimitive<C> + Zeroize,
     SignatureSize<C>: ArrayLength<u8>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
@@ -235,8 +228,7 @@ where
 impl<C> FromStr for SigningKey<C>
 where
     C: Curve + AlgorithmParameters + ProjectiveArithmetic,
-    AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
-    ProjectivePoint<C>: From<AffinePoint<C>>,
+    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     Scalar<C>: FromDigest<C> + Invert<Output = Scalar<C>> + SignPrimitive<C> + Zeroize,
     SignatureSize<C>: ArrayLength<u8>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,

--- a/ecdsa/src/verify.rs
+++ b/ecdsa/src/verify.rs
@@ -12,7 +12,7 @@ use elliptic_curve::{
         EncodedPoint, FromEncodedPoint, ToEncodedPoint, UncompressedPointSize, UntaggedPointSize,
     },
     weierstrass::{Curve, PointCompression},
-    AffinePoint, FieldSize, ProjectiveArithmetic, ProjectivePoint, PublicKey, Scalar,
+    AffinePoint, FieldSize, ProjectiveArithmetic, PublicKey, Scalar,
 };
 use signature::{digest::Digest, DigestVerifier};
 
@@ -34,7 +34,6 @@ use core::str::FromStr;
 pub struct VerifyingKey<C>
 where
     C: Curve + ProjectiveArithmetic,
-    AffinePoint<C>: Copy + Clone + Debug,
 {
     pub(crate) inner: PublicKey<C>,
 }
@@ -42,8 +41,7 @@ where
 impl<C> VerifyingKey<C>
 where
     C: Curve + ProjectiveArithmetic,
-    AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
-    ProjectivePoint<C>: From<AffinePoint<C>>,
+    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
@@ -72,8 +70,7 @@ impl<C, D> DigestVerifier<D, Signature<C>> for VerifyingKey<C>
 where
     C: Curve + ProjectiveArithmetic,
     D: Digest<OutputSize = FieldSize<C>>,
-    AffinePoint<C>: Copy + Clone + Debug + VerifyPrimitive<C>,
-    ProjectivePoint<C>: From<AffinePoint<C>>,
+    AffinePoint<C>: VerifyPrimitive<C>,
     Scalar<C>: FromDigest<C>,
     SignatureSize<C>: ArrayLength<u8>,
 {
@@ -88,8 +85,7 @@ impl<C> signature::Verifier<Signature<C>> for VerifyingKey<C>
 where
     C: Curve + ProjectiveArithmetic + DigestPrimitive,
     C::Digest: Digest<OutputSize = FieldSize<C>>,
-    AffinePoint<C>: Copy + Clone + Debug + VerifyPrimitive<C>,
-    ProjectivePoint<C>: From<AffinePoint<C>>,
+    AffinePoint<C>: VerifyPrimitive<C>,
     Scalar<C>: FromDigest<C>,
     SignatureSize<C>: ArrayLength<u8>,
 {
@@ -101,8 +97,7 @@ where
 impl<C> From<&VerifyingKey<C>> for EncodedPoint<C>
 where
     C: Curve + ProjectiveArithmetic + PointCompression,
-    AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
-    ProjectivePoint<C>: From<AffinePoint<C>>,
+    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
@@ -114,7 +109,6 @@ where
 impl<C> From<PublicKey<C>> for VerifyingKey<C>
 where
     C: Curve + ProjectiveArithmetic,
-    AffinePoint<C>: Copy + Clone + Debug,
 {
     fn from(public_key: PublicKey<C>) -> VerifyingKey<C> {
         VerifyingKey { inner: public_key }
@@ -124,7 +118,6 @@ where
 impl<C> From<&PublicKey<C>> for VerifyingKey<C>
 where
     C: Curve + ProjectiveArithmetic,
-    AffinePoint<C>: Copy + Clone + Debug,
 {
     fn from(public_key: &PublicKey<C>) -> VerifyingKey<C> {
         public_key.clone().into()
@@ -134,7 +127,6 @@ where
 impl<C> From<VerifyingKey<C>> for PublicKey<C>
 where
     C: Curve + ProjectiveArithmetic,
-    AffinePoint<C>: Copy + Clone + Debug,
 {
     fn from(verifying_key: VerifyingKey<C>) -> PublicKey<C> {
         verifying_key.inner
@@ -144,7 +136,6 @@ where
 impl<C> From<&VerifyingKey<C>> for PublicKey<C>
 where
     C: Curve + ProjectiveArithmetic,
-    AffinePoint<C>: Copy + Clone + Debug,
 {
     fn from(verifying_key: &VerifyingKey<C>) -> PublicKey<C> {
         verifying_key.clone().into()
@@ -154,8 +145,7 @@ where
 impl<C> Eq for VerifyingKey<C>
 where
     C: Curve + ProjectiveArithmetic,
-    AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
-    ProjectivePoint<C>: From<AffinePoint<C>>,
+    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
@@ -164,8 +154,7 @@ where
 impl<C> PartialEq for VerifyingKey<C>
 where
     C: Curve + ProjectiveArithmetic,
-    AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
-    ProjectivePoint<C>: From<AffinePoint<C>>,
+    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
@@ -177,8 +166,7 @@ where
 impl<C> PartialOrd for VerifyingKey<C>
 where
     C: Curve + ProjectiveArithmetic,
-    AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
-    ProjectivePoint<C>: From<AffinePoint<C>>,
+    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
@@ -190,8 +178,7 @@ where
 impl<C> Ord for VerifyingKey<C>
 where
     C: Curve + ProjectiveArithmetic,
-    AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
-    ProjectivePoint<C>: From<AffinePoint<C>>,
+    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
@@ -205,8 +192,7 @@ where
 impl<C> FromPublicKey for VerifyingKey<C>
 where
     C: Curve + AlgorithmParameters + ProjectiveArithmetic + PointCompression,
-    AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
-    ProjectivePoint<C>: From<AffinePoint<C>>,
+    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
@@ -220,8 +206,7 @@ where
 impl<C> FromStr for VerifyingKey<C>
 where
     C: Curve + AlgorithmParameters + ProjectiveArithmetic + PointCompression,
-    AffinePoint<C>: Copy + Clone + Debug + Default + FromEncodedPoint<C> + ToEncodedPoint<C>,
-    ProjectivePoint<C>: From<AffinePoint<C>>,
+    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {


### PR DESCRIPTION
These bounds are now captured by the `*Arithmetic` traits