### PR TITLE
ecdsa: bump `crypto-bigint` to v0.2.0-pre

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,7 +12,7 @@ dependencies = [
 [[package]]
 name = "base64ct"
 version = "1.0.0"
-source = "git+https://github.com/rustcrypto/utils.git#3fc828a86a31b2b5016dd64e4f3b38a858f9d070"
+source = "git+https://github.com/rustcrypto/utils.git#dd17922cba2798f9a002850acf455cf2d6215483"
 
 [[package]]
 name = "bincode"
@@ -59,7 +59,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "const-oid"
 version = "0.6.0"
-source = "git+https://github.com/rustcrypto/utils.git#3fc828a86a31b2b5016dd64e4f3b38a858f9d070"
+source = "git+https://github.com/rustcrypto/utils.git#dd17922cba2798f9a002850acf455cf2d6215483"
 
 [[package]]
 name = "cpufeatures"
@@ -72,8 +72,8 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.1.0"
-source = "git+https://github.com/rustcrypto/utils.git#3fc828a86a31b2b5016dd64e4f3b38a858f9d070"
+version = "0.2.0-pre"
+source = "git+https://github.com/rustcrypto/utils.git#dd17922cba2798f9a002850acf455cf2d6215483"
 dependencies = [
  "generic-array",
  "subtle",
@@ -114,7 +114,7 @@ dependencies = [
 [[package]]
 name = "der"
 version = "0.4.0-pre"
-source = "git+https://github.com/rustcrypto/utils.git#3fc828a86a31b2b5016dd64e4f3b38a858f9d070"
+source = "git+https://github.com/rustcrypto/utils.git#dd17922cba2798f9a002850acf455cf2d6215483"
 dependencies = [
  "const-oid",
 ]
@@ -200,7 +200,7 @@ dependencies = [
 [[package]]
 name = "elliptic-curve"
 version = "0.10.0-pre"
-source = "git+https://github.com/rustcrypto/traits.git#6dced063c1d943e04ee52e5e53bba5e08b83b450"
+source = "git+https://github.com/rustcrypto/traits.git#23fb60e731179833bf8b0da51dbc51bbd5531dc7"
 dependencies = [
  "crypto-bigint",
  "ff",
@@ -336,7 +336,7 @@ dependencies = [
 [[package]]
 name = "pkcs8"
 version = "0.7.0-pre"
-source = "git+https://github.com/rustcrypto/utils.git#3fc828a86a31b2b5016dd64e4f3b38a858f9d070"
+source = "git+https://github.com/rustcrypto/utils.git#dd17922cba2798f9a002850acf455cf2d6215483"
 dependencies = [
  "base64ct",
  "der 0.4.0-pre",
@@ -486,7 +486,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 [[package]]
 name = "spki"
 version = "0.4.0-pre"
-source = "git+https://github.com/rustcrypto/utils.git#3fc828a86a31b2b5016dd64e4f3b38a858f9d070"
+source = "git+https://github.com/rustcrypto/utils.git#dd17922cba2798f9a002850acf455cf2d6215483"
 dependencies = [
  "der 0.4.0-pre",
 ]

--- a/ecdsa/src/der.rs
+++ b/ecdsa/src/der.rs
@@ -8,7 +8,7 @@ use core::{
 };
 use der::{asn1::UIntBytes, Decodable};
 use elliptic_curve::{
-    bigint::NumBytes,
+    bigint::Encoding as _,
     consts::U9,
     generic_array::{ArrayLength, GenericArray},
     weierstrass::Curve,
@@ -153,7 +153,7 @@ where
             .sequence(|decoder| Ok((UIntBytes::decode(decoder)?, UIntBytes::decode(decoder)?)))
             .map_err(|_| Error::new())?;
 
-        if r.as_bytes().len() > C::UInt::NUM_BYTES || s.as_bytes().len() > C::UInt::NUM_BYTES {
+        if r.as_bytes().len() > C::UInt::BYTE_SIZE || s.as_bytes().len() > C::UInt::BYTE_SIZE {
             return Err(Error::new());
         }
 
@@ -185,9 +185,9 @@ where
 
     fn try_from(sig: Signature<C>) -> Result<super::Signature<C>, Error> {
         let mut bytes = super::SignatureBytes::<C>::default();
-        let r_begin = C::UInt::NUM_BYTES.saturating_sub(sig.r().len());
+        let r_begin = C::UInt::BYTE_SIZE.saturating_sub(sig.r().len());
         let s_begin = bytes.len().saturating_sub(sig.s().len());
-        bytes[r_begin..C::UInt::NUM_BYTES].copy_from_slice(sig.r());
+        bytes[r_begin..C::UInt::BYTE_SIZE].copy_from_slice(sig.r());
         bytes[s_begin..].copy_from_slice(sig.s());
         Self::try_from(bytes.as_slice())
     }

--- a/ecdsa/src/dev.rs
+++ b/ecdsa/src/dev.rs
@@ -2,6 +2,7 @@
 
 use crate::hazmat::FromDigest;
 use elliptic_curve::{
+    bigint::Encoding as _,
     consts::U32,
     dev::{MockCurve, Scalar, ScalarBytes},
     subtle::{ConditionallySelectable, ConstantTimeLess},
@@ -16,7 +17,7 @@ impl FromDigest<MockCurve> for Scalar {
     where
         D: Digest<OutputSize = U32>,
     {
-        let uint = UInt::from_be_bytes(&digest.finalize());
+        let uint = UInt::from_be_bytes(digest.finalize().into());
         let overflow = !uint.ct_lt(&MockCurve::ORDER);
         let scalar = uint.wrapping_add(&UInt::conditional_select(
             &UInt::ZERO,


### PR DESCRIPTION
Incorporates changes from https://github.com/RustCrypto/traits/pull/660 and https://github.com/RustCrypto/utils/pull/488