### PR TITLE
ecdsa: bump `elliptic-curve` crate dependency to v0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,7 +12,8 @@ dependencies = [
 [[package]]
 name = "base64ct"
 version = "1.0.0"
-source = "git+https://github.com/rustcrypto/utils.git#dd17922cba2798f9a002850acf455cf2d6215483"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0d27fb6b6f1e43147af148af49d49329413ba781aa0d5e10979831c210173b5"
 
 [[package]]
 name = "bincode"
@@ -59,7 +60,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "const-oid"
 version = "0.6.0"
-source = "git+https://github.com/rustcrypto/utils.git#dd17922cba2798f9a002850acf455cf2d6215483"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c32f031ea41b4291d695026c023b95d59db2d8a2c7640800ed56bc8f510f22"
 
 [[package]]
 name = "cpufeatures"
@@ -72,8 +74,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.0-pre"
-source = "git+https://github.com/rustcrypto/utils.git#dd17922cba2798f9a002850acf455cf2d6215483"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "281d926f72b42bf3ba840b88cd53e39f36be9f66e34c8df3fb336372b3753d41"
 dependencies = [
  "generic-array",
  "subtle",
@@ -113,8 +116,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.4.0-pre"
-source = "git+https://github.com/rustcrypto/utils.git#dd17922cba2798f9a002850acf455cf2d6215483"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f215f706081a44cb702c71c39a52c05da637822e9c1645a50b7202689e982d"
 dependencies = [
  "const-oid",
 ]
@@ -143,8 +147,8 @@ dependencies = [
 name = "ecdsa"
 version = "0.12.0-pre"
 dependencies = [
- "der 0.4.0-pre",
- "elliptic-curve 0.10.0-pre",
+ "der 0.4.0",
+ "elliptic-curve 0.10.0",
  "hex-literal",
  "hmac",
  "sha2",
@@ -199,8 +203,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.10.0-pre"
-source = "git+https://github.com/rustcrypto/traits.git#23fb60e731179833bf8b0da51dbc51bbd5531dc7"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade912ac38a947c8bff6d07bcf0ef97327027837963b0452e6f2a9e78b734ebf"
 dependencies = [
  "crypto-bigint",
  "ff",
@@ -335,11 +340,12 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.7.0-pre"
-source = "git+https://github.com/rustcrypto/utils.git#dd17922cba2798f9a002850acf455cf2d6215483"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d156817ae0125e8aa5067710b0db24f0984830614f99875a70aa5e3b74db69"
 dependencies = [
  "base64ct",
- "der 0.4.0-pre",
+ "der 0.4.0",
  "spki",
  "zeroize",
 ]
@@ -485,10 +491,11 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spki"
-version = "0.4.0-pre"
-source = "git+https://github.com/rustcrypto/utils.git#dd17922cba2798f9a002850acf455cf2d6215483"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "987637c5ae6b3121aba9d513f869bd2bff11c4cc086c22473befd6649c0bd521"
 dependencies = [
- "der 0.4.0-pre",
+ "der 0.4.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,2 @@
 [workspace]
 members = ["ecdsa", "ed25519"]
-
-[patch.crates-io]
-crypto-bigint = { git = "https://github.com/rustcrypto/utils.git" }
-der = { git = "https://github.com/rustcrypto/utils.git" }
-elliptic-curve = { git = "https://github.com/rustcrypto/traits.git" }
-pkcs8 = { git = "https://github.com/rustcrypto/utils.git" }

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -14,15 +14,15 @@ categories = ["cryptography", "no-std"]
 keywords   = ["crypto", "ecc", "nist", "secp256k1", "signature"]
 
 [dependencies]
-elliptic-curve = { version = "=0.10.0-pre", default-features = false }
+elliptic-curve = { version = "0.10", default-features = false }
 hmac = { version = "0.11", optional = true, default-features = false }
 signature = { version = ">= 1.3.0, < 1.4.0", default-features = false, features = ["rand-preview"] }
 
-# optional dependenciescd
-der = { version = "=0.4.0-pre", optional = true }
+# optional dependencies
+der = { version = "0.4", optional = true }
 
 [dev-dependencies]
-elliptic-curve = { version = "=0.10.0-pre", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.10", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 sha2 = { version = "0.9", default-features = false }
 


### PR DESCRIPTION
Also bumps: `der` => v0.4

Changelog: https://github.com/RustCrypto/traits/pull/663