### PR TITLE
ecdsa: add explicit `Copy` bounds on `VerifyingKey`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ name = "ecdsa"
 version = "0.12.0"
 dependencies = [
  "der 0.4.0",
- "elliptic-curve 0.10.0",
+ "elliptic-curve 0.10.1",
  "hex-literal",
  "hmac",
  "sha2",
@@ -203,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade912ac38a947c8bff6d07bcf0ef97327027837963b0452e6f2a9e78b734ebf"
+checksum = "b4b6eb4853ca589eb02b325b0cff21e560180907a3640f8bfc8f5969ddd0c6ee"
 dependencies = [
  "crypto-bigint",
  "ff",

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["cryptography", "no-std"]
 keywords   = ["crypto", "ecc", "nist", "secp256k1", "signature"]
 
 [dependencies]
-elliptic-curve = { version = "0.10", default-features = false }
+elliptic-curve = { version = "0.10.1", default-features = false }
 hmac = { version = "0.11", optional = true, default-features = false }
 signature = { version = ">= 1.3.0, < 1.4.0", default-features = false, features = ["rand-preview"] }
 
@@ -22,7 +22,7 @@ signature = { version = ">= 1.3.0, < 1.4.0", default-features = false, features 
 der = { version = "0.4", optional = true }
 
 [dev-dependencies]
-elliptic-curve = { version = "0.10", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.10.1", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 sha2 = { version = "0.9", default-features = false }
 

--- a/ecdsa/src/verify.rs
+++ b/ecdsa/src/verify.rs
@@ -30,7 +30,7 @@ use core::str::FromStr;
 /// Requires an [`elliptic_curve::ProjectiveArithmetic`] impl on the curve, and a
 /// [`VerifyPrimitive`] impl on its associated `AffinePoint` type.
 #[cfg_attr(docsrs, doc(cfg(feature = "verify")))]
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct VerifyingKey<C>
 where
     C: Curve + ProjectiveArithmetic,
@@ -65,6 +65,8 @@ where
         self.inner.to_encoded_point(compress)
     }
 }
+
+impl<C> Copy for VerifyingKey<C> where C: Curve + ProjectiveArithmetic {}
 
 impl<C, D> DigestVerifier<D, Signature<C>> for VerifyingKey<C>
 where


### PR DESCRIPTION
Analogous change to https://github.com/RustCrypto/traits/pull/667