### PR TITLE
ecdsa v0.12.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "der 0.4.0",
  "elliptic-curve 0.10.1",

--- a/ecdsa/CHANGELOG.md
+++ b/ecdsa/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.12.1 (2021-06-09)
+### Added
+- Explicit `Copy` bounds on `VerifyingKey` ([#318])
+
+[#318]: https://github.com/RustCrypto/signatures/pull/318
+
 ## 0.12.0 (2021-06-07)
 ### Changed
 - Bump `der` crate to v0.4 ([#302], [#315])

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ecdsa"
-version = "0.12.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.12.1" # Also update html_root_url in lib.rs when bumping this
 description   = """
 Signature and elliptic curve types providing interoperable support for the
 Elliptic Curve Digital Signature Algorithm (ECDSA)

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -49,7 +49,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/ecdsa/0.12.0"
+    html_root_url = "https://docs.rs/ecdsa/0.12.1"
 )]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
### Added
- Explicit `Copy` bounds on `VerifyingKey` ([#318])

[#318]: https://github.com/RustCrypto/signatures/pull/318