### PR TITLE
ed25519: ignore clippy nit for `Signature::to_bytes()`

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -16,32 +16,29 @@ jobs:
   rustfmt:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout sources
-        uses: actions/checkout@v1
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
           components: rustfmt
-
-      - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
+          override: true
+          profile: minimal
+      - uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
+
   clippy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
-          toolchain: 1.51.0
+          toolchain: 1.51.0 # MSRV
           components: clippy
+          override: true
+          profile: minimal
       - run: cargo clippy --all-features -- -D warnings
-
 
   codecov:
     runs-on: ubuntu-latest

--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -281,6 +281,7 @@ impl Signature {
     }
 
     /// Return the inner byte array
+    #[allow(clippy::wrong_self_convention)] // TODO: fix in next breaking release
     pub fn to_bytes(&self) -> [u8; SIGNATURE_LENGTH] {
         self.0
     }


### PR DESCRIPTION
This crate is 1.0 and fixing this nit would arguably be a breaking change.

This commit ignores it and adds a TODO to fix it eventually.