### PR TITLE
ecdsa: use signature::Result alias

### DIFF
--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -16,7 +16,7 @@ keywords   = ["crypto", "ecc", "nist", "secp256k1", "signature"]
 [dependencies]
 elliptic-curve = { version = "0.10.4", default-features = false }
 hmac = { version = "0.11", optional = true, default-features = false }
-signature = { version = ">= 1.3.0, < 1.4.0", default-features = false, features = ["rand-preview"] }
+signature = { version = ">= 1.3.1, < 1.4.0", default-features = false, features = ["rand-preview"] }
 
 # optional dependencies
 der = { version = "0.4", optional = true }

--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -13,10 +13,9 @@
 
 #[cfg(feature = "arithmetic")]
 use {
-    crate::SignatureSize,
+    crate::{Result, SignatureSize},
     core::borrow::Borrow,
     elliptic_curve::{ops::Invert, ProjectiveArithmetic, Scalar},
-    signature::Error,
 };
 
 #[cfg(feature = "digest")]
@@ -54,7 +53,7 @@ where
         &self,
         ephemeral_scalar: &K,
         hashed_msg: &Scalar<C>,
-    ) -> Result<Signature<C>, Error>;
+    ) -> Result<Signature<C>>;
 }
 
 /// [`SignPrimitive`] for signature implementations that can provide public key
@@ -76,7 +75,7 @@ where
         &self,
         ephemeral_scalar: &K,
         hashed_msg: &Scalar<C>,
-    ) -> Result<(Signature<C>, bool), Error>;
+    ) -> Result<(Signature<C>, bool)>;
 }
 
 #[cfg(feature = "arithmetic")]
@@ -90,7 +89,7 @@ where
         &self,
         ephemeral_scalar: &K,
         hashed_msg: &Scalar<C>,
-    ) -> Result<Signature<C>, Error> {
+    ) -> Result<Signature<C>> {
         self.try_sign_recoverable_prehashed(ephemeral_scalar, hashed_msg)
             .map(|res| res.0)
     }
@@ -114,11 +113,7 @@ where
     ///
     /// - `hashed_msg`: prehashed message to be verified
     /// - `signature`: signature to be verified against the key and message
-    fn verify_prehashed(
-        &self,
-        hashed_msg: &Scalar<C>,
-        signature: &Signature<C>,
-    ) -> Result<(), Error>;
+    fn verify_prehashed(&self, hashed_msg: &Scalar<C>, signature: &Signature<C>) -> Result<()>;
 }
 
 /// Bind a preferred [`Digest`] algorithm to an elliptic curve type.

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -81,7 +81,7 @@ mod verify;
 pub use elliptic_curve::{self, sec1::EncodedPoint, weierstrass::Curve};
 
 // Re-export the `signature` crate (and select types)
-pub use signature::{self, Error};
+pub use signature::{self, Error, Result};
 
 #[cfg(feature = "sign")]
 #[cfg_attr(docsrs, doc(cfg(feature = "sign")))]
@@ -139,17 +139,14 @@ where
 {
     /// Create a [`Signature`] from the serialized `r` and `s` scalar values
     /// which comprise the signature.
-    pub fn from_scalars(
-        r: impl Into<FieldBytes<C>>,
-        s: impl Into<FieldBytes<C>>,
-    ) -> Result<Self, Error> {
+    pub fn from_scalars(r: impl Into<FieldBytes<C>>, s: impl Into<FieldBytes<C>>) -> Result<Self> {
         Self::try_from(r.into().concat(s.into()).as_slice())
     }
 
     /// Parse a signature from ASN.1 DER
     #[cfg(feature = "der")]
     #[cfg_attr(docsrs, doc(cfg(feature = "der")))]
-    pub fn from_der(bytes: &[u8]) -> Result<Self, Error>
+    pub fn from_der(bytes: &[u8]) -> Result<Self>
     where
         der::MaxSize<C>: ArrayLength<u8>,
         <FieldSize<C> as Add>::Output: Add<der::MaxOverhead> + ArrayLength<u8>,
@@ -195,7 +192,7 @@ where
     /// [BIP 0062: Dealing with Malleability][1].
     ///
     /// [1]: https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki
-    pub fn normalize_s(&mut self) -> Result<bool, Error>
+    pub fn normalize_s(&mut self) -> Result<bool>
     where
         Scalar<C>: NormalizeLow,
     {
@@ -219,7 +216,7 @@ where
     C: Curve,
     SignatureSize<C>: ArrayLength<u8>,
 {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
+    fn from_bytes(bytes: &[u8]) -> Result<Self> {
         Self::try_from(bytes)
     }
 }
@@ -264,7 +261,7 @@ where
 {
     type Error = Error;
 
-    fn try_from(bytes: &[u8]) -> Result<Self, Error> {
+    fn try_from(bytes: &[u8]) -> Result<Self> {
         if bytes.len() != <SignatureSize<C>>::to_usize() {
             return Err(Error::new());
         }

--- a/ecdsa/src/verify.rs
+++ b/ecdsa/src/verify.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     hazmat::{DigestPrimitive, FromDigest, VerifyPrimitive},
-    Error, Signature, SignatureSize,
+    Error, Result, Signature, SignatureSize,
 };
 use core::{cmp::Ordering, convert::TryFrom, fmt::Debug, ops::Add};
 use elliptic_curve::{
@@ -46,14 +46,14 @@ where
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
     /// Initialize [`VerifyingKey`] from a SEC1-encoded public key.
-    pub fn from_sec1_bytes(bytes: &[u8]) -> Result<Self, Error> {
+    pub fn from_sec1_bytes(bytes: &[u8]) -> Result<Self> {
         PublicKey::from_sec1_bytes(bytes)
             .map(|pk| Self { inner: pk })
             .map_err(|_| Error::new())
     }
 
     /// Initialize [`VerifyingKey`] from an [`EncodedPoint`].
-    pub fn from_encoded_point(public_key: &EncodedPoint<C>) -> Result<Self, Error> {
+    pub fn from_encoded_point(public_key: &EncodedPoint<C>) -> Result<Self> {
         PublicKey::<C>::from_encoded_point(public_key)
             .map(|public_key| Self { inner: public_key })
             .ok_or_else(Error::new)
@@ -76,7 +76,7 @@ where
     Scalar<C>: FromDigest<C>,
     SignatureSize<C>: ArrayLength<u8>,
 {
-    fn verify_digest(&self, digest: D, signature: &Signature<C>) -> Result<(), Error> {
+    fn verify_digest(&self, digest: D, signature: &Signature<C>) -> Result<()> {
         self.inner
             .as_affine()
             .verify_prehashed(&Scalar::<C>::from_digest(digest), signature)
@@ -91,7 +91,7 @@ where
     Scalar<C>: FromDigest<C>,
     SignatureSize<C>: ArrayLength<u8>,
 {
-    fn verify(&self, msg: &[u8], signature: &Signature<C>) -> Result<(), Error> {
+    fn verify(&self, msg: &[u8], signature: &Signature<C>) -> Result<()> {
         self.verify_digest(C::Digest::new().chain(msg), signature)
     }
 }
@@ -198,7 +198,7 @@ where
 {
     type Error = Error;
 
-    fn try_from(bytes: &[u8]) -> Result<Self, Error> {
+    fn try_from(bytes: &[u8]) -> Result<Self> {
         Self::from_sec1_bytes(bytes)
     }
 }
@@ -228,7 +228,7 @@ where
 {
     type Err = Error;
 
-    fn from_str(s: &str) -> Result<Self, Error> {
+    fn from_str(s: &str) -> Result<Self> {
         Self::from_public_key_pem(s).map_err(|_| Error::new())
     }
 }


### PR DESCRIPTION
Simplifies the method signatures