### PR TITLE
ecdsa v0.12.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "der 0.4.0",
  "elliptic-curve 0.10.4",

--- a/ecdsa/CHANGELOG.md
+++ b/ecdsa/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.12.3 (2021-06-17)
+### Added
+- Impl `TryFrom<&[u8]>` for `Verifying<C>` ([#329])
+- Impl `TryFrom<&[u8]>` for `SigningKey<C>` ([#330])
+
+### Changed
+- Use `signature::Result` alias ([#331])
+
+[#329]: https://github.com/RustCrypto/signatures/pull/329
+[#330]: https://github.com/RustCrypto/signatures/pull/330
+[#331]: https://github.com/RustCrypto/signatures/pull/331
+
 ## 0.12.2 (2021-06-18)
 ### Added
 - Zeroization on drop for `SigningKey` ([#321])

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ecdsa"
-version = "0.12.2" # Also update html_root_url in lib.rs when bumping this
+version = "0.12.3" # Also update html_root_url in lib.rs when bumping this
 description   = """
 Signature and elliptic curve types providing interoperable support for the
 Elliptic Curve Digital Signature Algorithm (ECDSA)

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -49,7 +49,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/ecdsa/0.12.2"
+    html_root_url = "https://docs.rs/ecdsa/0.12.3"
 )]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
### Added
- Impl `TryFrom<&[u8]>` for `Verifying<C>` ([#329])
- Impl `TryFrom<&[u8]>` for `SigningKey<C>` ([#330])

### Changed
- Use `signature::Result` alias ([#331])

[#329]: https://github.com/RustCrypto/signatures/pull/329
[#330]: https://github.com/RustCrypto/signatures/pull/330
[#331]: https://github.com/RustCrypto/signatures/pull/331