### PR TITLE
feat(ed255519): Introduce `serde_bytes` optional dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,7 @@ dependencies = [
  "rand_core 0.5.1",
  "ring-compat",
  "serde",
+ "serde_bytes",
  "signature",
 ]
 
@@ -477,6 +478,15 @@ name = "serde"
 version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "sha2"

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -14,6 +14,7 @@ keywords      = ["crypto", "curve25519", "ecc", "signature", "signing"]
 [dependencies]
 signature = { version = "1", default-features = false }
 serde = { version = "1", optional = true, default-features = false }
+serde_bytes_crate = { package = "serde_bytes", version = "0.11", optional = true }
 
 [dev-dependencies]
 bincode = "1"
@@ -23,4 +24,5 @@ rand_core = { version = "0.5", features = ["std"] }
 
 [features]
 default = ["std"]
+serde_bytes = ["serde", "serde_bytes_crate", "std"]
 std = ["signature/std"]


### PR DESCRIPTION
This allows consumers to opt-in to `serde_bytes` support by setting the
`std`, `serde`, and `serde_bytes` features. This makes it convenient to
optimise (de)serialization for formats with efficient byte array
encodings, e.g.

    #[derive(serde::Deserialize, serde::Serialize)]
    struct MySignature {
        #[serde(with = "serde_bytes")]
        signature: ed25519::Signature,
    }

Without first-class support for `serde_bytes`, consumers would have to
write their own (de)serialization machinery for this common case.