### PR TITLE
feat(ed25519): Add a feature to serialize with serde's bytes type

### DIFF
--- a/.github/workflows/ed25519.yml
+++ b/.github/workflows/ed25519.yml
@@ -101,5 +101,8 @@ jobs:
       - name: Run cargo test --lib
         run: cargo test --lib --release
 
-      - name: Run cargo test --all-features
-        run: cargo test --all-features --release
+      - name: Run cargo test --features serde
+        run: cargo test --features serde --release
+
+      - name: Run cargo test --features serde_as_bytes
+        run: cargo test --features serde_as_bytes --release

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -23,4 +23,5 @@ rand_core = { version = "0.5", features = ["std"] }
 
 [features]
 default = ["std"]
+serde_as_bytes = ["serde"]
 std = ["signature/std"]


### PR DESCRIPTION
An alternative fix for #336 introducing a feature to swap between `*_bytes` and non-`*_bytes` serialization – the two are mutually exclusive!

---

This introduces a new feature, `serde_as_bytes`, that switches the
implementation of (de)serialization to use serde's `*_bytes` methods,
allowing crate consumers to opt-in to this approach which is beneficial
for formats with optimised byte array representations.

This has required a small change to the test workflow, since it's
necessary to test both with and without the `serde_as_bytes` feature.
The features cannot be made mutually exclusive, though logically they
are, without changing the `serde` feature flag, which would be
backwards-incompatible.

Fixes #336.