### PR TITLE
ecdsa: impl `Clone`, `Debug`, `*Eq` for SigningKey

### DIFF
--- a/ecdsa/src/verify.rs
+++ b/ecdsa/src/verify.rs
@@ -14,7 +14,7 @@ use elliptic_curve::{
     weierstrass::{Curve, PointCompression},
     AffinePoint, FieldSize, ProjectiveArithmetic, PublicKey, Scalar,
 };
-use signature::{digest::Digest, DigestVerifier};
+use signature::{digest::Digest, DigestVerifier, Verifier};
 
 #[cfg(feature = "pkcs8")]
 use crate::elliptic_curve::{
@@ -83,7 +83,7 @@ where
     }
 }
 
-impl<C> signature::Verifier<Signature<C>> for VerifyingKey<C>
+impl<C> Verifier<Signature<C>> for VerifyingKey<C>
 where
     C: Curve + ProjectiveArithmetic + DigestPrimitive,
     C::Digest: Digest<OutputSize = FieldSize<C>>,


### PR DESCRIPTION
Adds previously missing trait impls for `SigningKey<C>`.

The `Eq`/`PartialEq` impls use `ConstantTimeEq` internally to compare signing keys in constant-time.

Closes #344