### PR TITLE
ecdsa: fix test macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.12.4"
+version = "0.13.0-pre"
 dependencies = [
  "der 0.4.1",
  "elliptic-curve 0.11.0-pre",

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ecdsa"
-version = "0.12.4" # Also update html_root_url in lib.rs when bumping this
+version = "0.13.0-pre" # Also update html_root_url in lib.rs when bumping this
 description   = """
 Signature and elliptic curve types providing interoperable support for the
 Elliptic Curve Digital Signature Algorithm (ECDSA)

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -49,7 +49,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/ecdsa/0.12.4"
+    html_root_url = "https://docs.rs/ecdsa/0.13.0-pre"
 )]
 
 #[cfg(feature = "alloc")]

--- a/ecdsa/src/sign.rs
+++ b/ecdsa/src/sign.rs
@@ -26,10 +26,7 @@ use signature::{
 };
 
 #[cfg(feature = "verify")]
-use {
-    crate::verify::VerifyingKey,
-    elliptic_curve::{AffinePoint, PublicKey},
-};
+use {crate::verify::VerifyingKey, elliptic_curve::PublicKey};
 
 #[cfg(feature = "pkcs8")]
 use crate::elliptic_curve::{
@@ -37,7 +34,7 @@ use crate::elliptic_curve::{
     ops::Add,
     pkcs8::{self, FromPrivateKey},
     sec1::{FromEncodedPoint, ToEncodedPoint, UncompressedPointSize, UntaggedPointSize},
-    AlgorithmParameters,
+    AffinePoint, AlgorithmParameters,
 };
 
 #[cfg(feature = "pem")]


### PR DESCRIPTION
Updates the test macros to be compatible with the changes from #352.