### PR TITLE
ecdsa: switch from `ScalarBytes<C>` to `ScalarCore<C>`

### DIFF
--- a/.github/workflows/ecdsa.yml
+++ b/.github/workflows/ecdsa.yml
@@ -45,8 +45,7 @@ jobs:
       - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features pem
       - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features sign
       - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features verify
-      - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features zeroize
-      - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features arithmetic,dev,digest,hazmat,pkcs8,pem,sign,verify,zeroize
+      - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features arithmetic,dev,digest,hazmat,pkcs8,pem,sign,verify
 
   test:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,8 +77,7 @@ dependencies = [
 [[package]]
 name = "crypto-bigint"
 version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8658c15c5d921ddf980f7fe25b1e82f4b7a4083b2c4985fea4922edb8e43e07d"
+source = "git+https://github.com/RustCrypto/utils.git#8fa1b4fb22789fb5afd51bc1fad08ebf95789965"
 dependencies = [
  "generic-array",
  "rand_core 0.6.3",
@@ -209,7 +208,7 @@ dependencies = [
 [[package]]
 name = "elliptic-curve"
 version = "0.11.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#cadefe34305026330e43e41fb4d18e9fe0d56c2c"
+source = "git+https://github.com/RustCrypto/traits.git#c7c63d39dbd9c9d5fc0dfd32e3ac0d58535dc500"
 dependencies = [
  "crypto-bigint",
  "ff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,4 +2,5 @@
 members = ["ecdsa", "ed25519"]
 
 [patch.crates-io]
+crypto-bigint = { git = "https://github.com/RustCrypto/utils.git" }
 elliptic-curve = { git = "https://github.com/RustCrypto/traits.git" }

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -30,15 +30,14 @@ sha2 = { version = "0.9", default-features = false }
 default = ["digest"]
 alloc = []
 arithmetic = ["elliptic-curve/arithmetic"]
-dev = ["arithmetic", "digest", "elliptic-curve/dev", "hazmat", "zeroize"]
+dev = ["arithmetic", "digest", "elliptic-curve/dev", "hazmat"]
 digest = ["signature/digest-preview"]
 hazmat = []
 pkcs8 = ["elliptic-curve/pkcs8", "der"]
 pem = ["elliptic-curve/pem", "pkcs8"]
-sign = ["arithmetic", "digest", "hazmat", "hmac", "zeroize"]
+sign = ["arithmetic", "digest", "hazmat", "hmac"]
 std = ["alloc", "elliptic-curve/std", "signature/std"]
 verify = ["arithmetic", "digest", "hazmat"]
-zeroize = ["elliptic-curve/zeroize"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/ecdsa/src/dev.rs
+++ b/ecdsa/src/dev.rs
@@ -2,9 +2,10 @@
 
 use crate::hazmat::FromDigest;
 use elliptic_curve::{
-    bigint::Encoding as _,
+    bigint::{ArrayEncoding, Encoding},
     consts::U32,
-    dev::{MockCurve, Scalar, ScalarBytes},
+    dev::{MockCurve, Scalar},
+    group::ff::PrimeField,
     subtle::{ConditionallySelectable, ConstantTimeLess},
     Curve,
 };
@@ -25,8 +26,7 @@ impl FromDigest<MockCurve> for Scalar {
             overflow,
         ));
 
-        // TODO(tarcieri): simpler conversion
-        ScalarBytes::from_uint(&scalar).unwrap().into_scalar()
+        Self::from_repr(scalar.to_be_byte_array()).unwrap()
     }
 }
 

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -99,7 +99,7 @@ use core::{
 use elliptic_curve::{
     bigint::Encoding as _,
     generic_array::{sequence::Concat, ArrayLength, GenericArray},
-    FieldBytes, FieldSize, ScalarBytes,
+    FieldBytes, FieldSize, ScalarCore,
 };
 
 #[cfg(feature = "arithmetic")]
@@ -277,7 +277,7 @@ where
                 return Err(Error::new());
             }
 
-            if ScalarBytes::<C>::new(GenericArray::clone_from_slice(scalar))
+            if ScalarCore::<C>::from_bytes_be(GenericArray::clone_from_slice(scalar))
                 .is_none()
                 .into()
             {

--- a/ecdsa/src/sign.rs
+++ b/ecdsa/src/sign.rs
@@ -70,7 +70,7 @@ where
 
     /// Initialize signing key from a raw scalar serialized as a byte slice.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
-        let inner = SecretKey::from_bytes(bytes)
+        let inner = SecretKey::from_bytes_be(bytes)
             .map(|sk| sk.to_secret_scalar())
             .map_err(|_| Error::new())?;
 


### PR DESCRIPTION
Corresponding changes for RustCrypto/traits#732