### PR TITLE
ecdsa: use `PrimeCurve` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,7 +208,7 @@ dependencies = [
 [[package]]
 name = "elliptic-curve"
 version = "0.11.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#c7c63d39dbd9c9d5fc0dfd32e3ac0d58535dc500"
+source = "git+https://github.com/RustCrypto/traits.git#405c176ce5e9d4007f6f87ae7fc89348ffdc930b"
 dependencies = [
  "crypto-bigint",
  "ff",

--- a/ecdsa/src/der.rs
+++ b/ecdsa/src/der.rs
@@ -11,8 +11,7 @@ use elliptic_curve::{
     bigint::Encoding as _,
     consts::U9,
     generic_array::{ArrayLength, GenericArray},
-    weierstrass::Curve,
-    FieldSize,
+    FieldSize, PrimeCurve,
 };
 
 #[cfg(feature = "alloc")]
@@ -45,7 +44,7 @@ type SignatureBytes<C> = GenericArray<u8, MaxSize<C>>;
 /// Generic over the scalar size of the elliptic curve.
 pub struct Signature<C>
 where
-    C: Curve,
+    C: PrimeCurve,
     MaxSize<C>: ArrayLength<u8>,
     <FieldSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
 {
@@ -61,7 +60,7 @@ where
 
 impl<C> signature::Signature for Signature<C>
 where
-    C: Curve,
+    C: PrimeCurve,
     MaxSize<C>: ArrayLength<u8>,
     <FieldSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
 {
@@ -74,7 +73,7 @@ where
 #[allow(clippy::len_without_is_empty)]
 impl<C> Signature<C>
 where
-    C: Curve,
+    C: PrimeCurve,
     MaxSize<C>: ArrayLength<u8>,
     <FieldSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
 {
@@ -117,7 +116,7 @@ where
 
 impl<C> AsRef<[u8]> for Signature<C>
 where
-    C: Curve,
+    C: PrimeCurve,
     MaxSize<C>: ArrayLength<u8>,
     <FieldSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
 {
@@ -128,7 +127,7 @@ where
 
 impl<C> fmt::Debug for Signature<C>
 where
-    C: Curve,
+    C: PrimeCurve,
     MaxSize<C>: ArrayLength<u8>,
     <FieldSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
 {
@@ -142,7 +141,7 @@ where
 
 impl<C> TryFrom<&[u8]> for Signature<C>
 where
-    C: Curve,
+    C: PrimeCurve,
     MaxSize<C>: ArrayLength<u8>,
     <FieldSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
 {
@@ -177,7 +176,7 @@ where
 
 impl<C> TryFrom<Signature<C>> for super::Signature<C>
 where
-    C: Curve,
+    C: PrimeCurve,
     MaxSize<C>: ArrayLength<u8>,
     <FieldSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
 {
@@ -207,7 +206,7 @@ fn find_scalar_range(outer: &[u8], inner: &[u8]) -> Result<Range<usize>> {
 #[cfg(all(feature = "digest", feature = "hazmat"))]
 impl<C> signature::PrehashSignature for Signature<C>
 where
-    C: Curve + crate::hazmat::DigestPrimitive,
+    C: PrimeCurve + crate::hazmat::DigestPrimitive,
     MaxSize<C>: ArrayLength<u8>,
     <FieldSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
 {

--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -26,7 +26,7 @@ use {
 
 #[cfg(any(feature = "arithmetic", feature = "digest"))]
 use crate::{
-    elliptic_curve::{generic_array::ArrayLength, weierstrass::Curve},
+    elliptic_curve::{generic_array::ArrayLength, PrimeCurve},
     Signature,
 };
 
@@ -39,7 +39,7 @@ use crate::{
 #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub trait SignPrimitive<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
     SignatureSize<C>: ArrayLength<u8>,
 {
     /// Try to sign the prehashed message.
@@ -62,7 +62,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub trait RecoverableSignPrimitive<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
     SignatureSize<C>: ArrayLength<u8>,
 {
     /// Try to sign the prehashed message.
@@ -81,7 +81,7 @@ where
 #[cfg(feature = "arithmetic")]
 impl<C, T> SignPrimitive<C> for T
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
     T: RecoverableSignPrimitive<C>,
     SignatureSize<C>: ArrayLength<u8>,
 {
@@ -104,7 +104,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 pub trait VerifyPrimitive<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
     SignatureSize<C>: ArrayLength<u8>,
 {
     /// Verify the prehashed message against the provided signature
@@ -128,7 +128,7 @@ where
 /// [1]: https://github.com/RustCrypto/traits/tree/master/signature/derive
 #[cfg(feature = "digest")]
 #[cfg_attr(docsrs, doc(cfg(feature = "digest")))]
-pub trait DigestPrimitive: Curve {
+pub trait DigestPrimitive: PrimeCurve {
     /// Preferred digest to use when computing ECDSA signatures for this
     /// elliptic curve. This should be a member of the SHA-2 family.
     type Digest: Digest;
@@ -144,7 +144,7 @@ pub trait DigestPrimitive: Curve {
 /// use cases.
 #[cfg(feature = "digest")]
 #[cfg_attr(docsrs, doc(cfg(feature = "digest")))]
-pub trait FromDigest<C: Curve> {
+pub trait FromDigest<C: PrimeCurve> {
     /// Instantiate this type from a [`Digest`] instance
     fn from_digest<D>(digest: D) -> Self
     where

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -78,7 +78,7 @@ mod sign;
 mod verify;
 
 // Re-export the `elliptic-curve` crate (and select types)
-pub use elliptic_curve::{self, sec1::EncodedPoint, weierstrass::Curve};
+pub use elliptic_curve::{self, sec1::EncodedPoint, PrimeCurve};
 
 // Re-export the `signature` crate (and select types)
 pub use signature::{self, Error, Result};
@@ -125,7 +125,7 @@ pub type SignatureBytes<C> = GenericArray<u8, SignatureSize<C>>;
 /// ASN.1 DER-encoded signatures also supported via the
 /// [`Signature::from_der`] and [`Signature::to_der`] methods.
 #[derive(Clone, Eq, PartialEq)]
-pub struct Signature<C: Curve>
+pub struct Signature<C: PrimeCurve>
 where
     SignatureSize<C>: ArrayLength<u8>,
 {
@@ -134,7 +134,7 @@ where
 
 impl<C> Signature<C>
 where
-    C: Curve,
+    C: PrimeCurve,
     SignatureSize<C>: ArrayLength<u8>,
 {
     /// Parse a signature from ASN.1 DER
@@ -181,7 +181,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 impl<C> Signature<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
     SignatureSize<C>: ArrayLength<u8>,
 {
     /// Get the `r` component of this signature
@@ -219,7 +219,7 @@ where
 
 impl<C> signature::Signature for Signature<C>
 where
-    C: Curve,
+    C: PrimeCurve,
     SignatureSize<C>: ArrayLength<u8>,
 {
     fn from_bytes(bytes: &[u8]) -> Result<Self> {
@@ -229,7 +229,7 @@ where
 
 impl<C> AsRef<[u8]> for Signature<C>
 where
-    C: Curve,
+    C: PrimeCurve,
     SignatureSize<C>: ArrayLength<u8>,
 {
     fn as_ref(&self) -> &[u8] {
@@ -239,7 +239,7 @@ where
 
 impl<C> Copy for Signature<C>
 where
-    C: Curve,
+    C: PrimeCurve,
     SignatureSize<C>: ArrayLength<u8>,
     <SignatureSize<C> as ArrayLength<u8>>::ArrayType: Copy,
 {
@@ -247,7 +247,7 @@ where
 
 impl<C> Debug for Signature<C>
 where
-    C: Curve,
+    C: PrimeCurve,
     SignatureSize<C>: ArrayLength<u8>,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -262,7 +262,7 @@ where
 
 impl<C> TryFrom<&[u8]> for Signature<C>
 where
-    C: Curve,
+    C: PrimeCurve,
     SignatureSize<C>: ArrayLength<u8>,
 {
     type Error = Error;

--- a/ecdsa/src/rfc6979.rs
+++ b/ecdsa/src/rfc6979.rs
@@ -8,9 +8,8 @@ use elliptic_curve::{
     generic_array::GenericArray,
     group::ff::PrimeField,
     ops::Invert,
-    weierstrass::Curve,
     zeroize::{Zeroize, Zeroizing},
-    FieldBytes, FieldSize, NonZeroScalar, ProjectiveArithmetic, Scalar,
+    FieldBytes, FieldSize, NonZeroScalar, PrimeCurve, ProjectiveArithmetic, Scalar,
 };
 use hmac::{Hmac, Mac, NewMac};
 use signature::digest::{BlockInput, FixedOutput, Reset, Update};
@@ -23,7 +22,7 @@ pub fn generate_k<C, D>(
     additional_data: &[u8],
 ) -> Zeroizing<NonZeroScalar<C>>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
     D: FixedOutput<OutputSize = FieldSize<C>> + BlockInput + Clone + Default + Reset + Update,
     Scalar<C>: FromDigest<C> + Invert<Output = Scalar<C>> + Zeroize,
 {

--- a/ecdsa/src/sign.rs
+++ b/ecdsa/src/sign.rs
@@ -15,9 +15,8 @@ use elliptic_curve::{
     group::ff::PrimeField,
     ops::Invert,
     subtle::{Choice, ConstantTimeEq},
-    weierstrass::Curve,
     zeroize::Zeroize,
-    FieldBytes, FieldSize, NonZeroScalar, ProjectiveArithmetic, Scalar, SecretKey,
+    FieldBytes, FieldSize, NonZeroScalar, PrimeCurve, ProjectiveArithmetic, Scalar, SecretKey,
 };
 use signature::{
     digest::{BlockInput, Digest, FixedOutput, Reset, Update},
@@ -48,7 +47,7 @@ use core::str::FromStr;
 #[cfg_attr(docsrs, doc(cfg(feature = "sign")))]
 pub struct SigningKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
     Scalar<C>: FromDigest<C> + Invert<Output = Scalar<C>> + SignPrimitive<C> + Zeroize,
     SignatureSize<C>: ArrayLength<u8>,
 {
@@ -57,7 +56,7 @@ where
 
 impl<C> SigningKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
     Scalar<C>: FromDigest<C> + Invert<Output = Scalar<C>> + SignPrimitive<C> + Zeroize,
     SignatureSize<C>: ArrayLength<u8>,
 {
@@ -94,7 +93,7 @@ where
 
 impl<C> ConstantTimeEq for SigningKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
     Scalar<C>: FromDigest<C> + Invert<Output = Scalar<C>> + SignPrimitive<C> + Zeroize,
     SignatureSize<C>: ArrayLength<u8>,
 {
@@ -105,7 +104,7 @@ where
 
 impl<C> Debug for SigningKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
     Scalar<C>: FromDigest<C> + Invert<Output = Scalar<C>> + SignPrimitive<C> + Zeroize,
     SignatureSize<C>: ArrayLength<u8>,
 {
@@ -117,7 +116,7 @@ where
 
 impl<C> Drop for SigningKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
     Scalar<C>: FromDigest<C> + Invert<Output = Scalar<C>> + SignPrimitive<C> + Zeroize,
     SignatureSize<C>: ArrayLength<u8>,
 {
@@ -128,7 +127,7 @@ where
 
 impl<C> Eq for SigningKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
     Scalar<C>: FromDigest<C> + Invert<Output = Scalar<C>> + SignPrimitive<C> + Zeroize,
     SignatureSize<C>: ArrayLength<u8>,
 {
@@ -136,7 +135,7 @@ where
 
 impl<C> PartialEq for SigningKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
     Scalar<C>: FromDigest<C> + Invert<Output = Scalar<C>> + SignPrimitive<C> + Zeroize,
     SignatureSize<C>: ArrayLength<u8>,
 {
@@ -147,7 +146,7 @@ where
 
 impl<C> From<SecretKey<C>> for SigningKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
     Scalar<C>: FromDigest<C> + Invert<Output = Scalar<C>> + SignPrimitive<C> + Zeroize,
     SignatureSize<C>: ArrayLength<u8>,
 {
@@ -158,7 +157,7 @@ where
 
 impl<C> From<&SecretKey<C>> for SigningKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
     Scalar<C>: FromDigest<C> + Invert<Output = Scalar<C>> + SignPrimitive<C> + Zeroize,
     SignatureSize<C>: ArrayLength<u8>,
 {
@@ -171,7 +170,7 @@ where
 
 impl<C, D> DigestSigner<D, Signature<C>> for SigningKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
     D: FixedOutput<OutputSize = FieldSize<C>> + BlockInput + Clone + Default + Reset + Update,
     Scalar<C>: FromDigest<C> + Invert<Output = Scalar<C>> + SignPrimitive<C> + Zeroize,
     SignatureSize<C>: ArrayLength<u8>,
@@ -189,7 +188,7 @@ where
 impl<C> Signer<Signature<C>> for SigningKey<C>
 where
     Self: DigestSigner<C::Digest, Signature<C>>,
-    C: Curve + ProjectiveArithmetic + DigestPrimitive,
+    C: PrimeCurve + ProjectiveArithmetic + DigestPrimitive,
     Scalar<C>: FromDigest<C> + Invert<Output = Scalar<C>> + SignPrimitive<C> + Zeroize,
     SignatureSize<C>: ArrayLength<u8>,
 {
@@ -200,7 +199,7 @@ where
 
 impl<C, D> RandomizedDigestSigner<D, Signature<C>> for SigningKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
     D: FixedOutput<OutputSize = FieldSize<C>> + BlockInput + Clone + Default + Reset + Update,
     Scalar<C>: FromDigest<C> + Invert<Output = Scalar<C>> + SignPrimitive<C> + Zeroize,
     SignatureSize<C>: ArrayLength<u8>,
@@ -225,7 +224,7 @@ where
 impl<C> RandomizedSigner<Signature<C>> for SigningKey<C>
 where
     Self: RandomizedDigestSigner<C::Digest, Signature<C>>,
-    C: Curve + ProjectiveArithmetic + DigestPrimitive,
+    C: PrimeCurve + ProjectiveArithmetic + DigestPrimitive,
     Scalar<C>: FromDigest<C> + Invert<Output = Scalar<C>> + SignPrimitive<C> + Zeroize,
     SignatureSize<C>: ArrayLength<u8>,
 {
@@ -236,7 +235,7 @@ where
 
 impl<C> From<NonZeroScalar<C>> for SigningKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
     Scalar<C>: FromDigest<C> + Invert<Output = Scalar<C>> + SignPrimitive<C> + Zeroize,
     SignatureSize<C>: ArrayLength<u8>,
 {
@@ -249,7 +248,7 @@ where
 
 impl<C> TryFrom<&[u8]> for SigningKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
     Scalar<C>: FromDigest<C> + Invert<Output = Scalar<C>> + SignPrimitive<C> + Zeroize,
     SignatureSize<C>: ArrayLength<u8>,
 {
@@ -263,7 +262,7 @@ where
 #[cfg(feature = "verify")]
 impl<C> From<&SigningKey<C>> for VerifyingKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
 
     Scalar<C>: FromDigest<C> + Invert<Output = Scalar<C>> + SignPrimitive<C> + Zeroize,
     SignatureSize<C>: ArrayLength<u8>,
@@ -277,7 +276,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
 impl<C> FromPrivateKey for SigningKey<C>
 where
-    C: Curve + AlgorithmParameters + ProjectiveArithmetic,
+    C: PrimeCurve + AlgorithmParameters + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     Scalar<C>: FromDigest<C> + Invert<Output = Scalar<C>> + SignPrimitive<C> + Zeroize,
     SignatureSize<C>: ArrayLength<u8>,
@@ -295,7 +294,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl<C> FromStr for SigningKey<C>
 where
-    C: Curve + AlgorithmParameters + ProjectiveArithmetic,
+    C: PrimeCurve + AlgorithmParameters + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     Scalar<C>: FromDigest<C> + Invert<Output = Scalar<C>> + SignPrimitive<C> + Zeroize,
     SignatureSize<C>: ArrayLength<u8>,

--- a/ecdsa/src/verify.rs
+++ b/ecdsa/src/verify.rs
@@ -11,8 +11,7 @@ use elliptic_curve::{
     sec1::{
         EncodedPoint, FromEncodedPoint, ToEncodedPoint, UncompressedPointSize, UntaggedPointSize,
     },
-    weierstrass::{Curve, PointCompression},
-    AffinePoint, FieldSize, ProjectiveArithmetic, PublicKey, Scalar,
+    AffinePoint, FieldSize, PointCompression, PrimeCurve, ProjectiveArithmetic, PublicKey, Scalar,
 };
 use signature::{digest::Digest, DigestVerifier, Verifier};
 
@@ -33,14 +32,14 @@ use core::str::FromStr;
 #[derive(Clone, Debug)]
 pub struct VerifyingKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
 {
     pub(crate) inner: PublicKey<C>,
 }
 
 impl<C> VerifyingKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
@@ -66,11 +65,11 @@ where
     }
 }
 
-impl<C> Copy for VerifyingKey<C> where C: Curve + ProjectiveArithmetic {}
+impl<C> Copy for VerifyingKey<C> where C: PrimeCurve + ProjectiveArithmetic {}
 
 impl<C, D> DigestVerifier<D, Signature<C>> for VerifyingKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
     D: Digest<OutputSize = FieldSize<C>>,
     AffinePoint<C>: VerifyPrimitive<C>,
     Scalar<C>: FromDigest<C>,
@@ -85,7 +84,7 @@ where
 
 impl<C> Verifier<Signature<C>> for VerifyingKey<C>
 where
-    C: Curve + ProjectiveArithmetic + DigestPrimitive,
+    C: PrimeCurve + ProjectiveArithmetic + DigestPrimitive,
     C::Digest: Digest<OutputSize = FieldSize<C>>,
     AffinePoint<C>: VerifyPrimitive<C>,
     Scalar<C>: FromDigest<C>,
@@ -98,7 +97,7 @@ where
 
 impl<C> From<&VerifyingKey<C>> for EncodedPoint<C>
 where
-    C: Curve + ProjectiveArithmetic + PointCompression,
+    C: PrimeCurve + ProjectiveArithmetic + PointCompression,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
@@ -110,7 +109,7 @@ where
 
 impl<C> From<PublicKey<C>> for VerifyingKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
 {
     fn from(public_key: PublicKey<C>) -> VerifyingKey<C> {
         VerifyingKey { inner: public_key }
@@ -119,7 +118,7 @@ where
 
 impl<C> From<&PublicKey<C>> for VerifyingKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
 {
     fn from(public_key: &PublicKey<C>) -> VerifyingKey<C> {
         public_key.clone().into()
@@ -128,7 +127,7 @@ where
 
 impl<C> From<VerifyingKey<C>> for PublicKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
 {
     fn from(verifying_key: VerifyingKey<C>) -> PublicKey<C> {
         verifying_key.inner
@@ -137,7 +136,7 @@ where
 
 impl<C> From<&VerifyingKey<C>> for PublicKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
 {
     fn from(verifying_key: &VerifyingKey<C>) -> PublicKey<C> {
         verifying_key.clone().into()
@@ -146,7 +145,7 @@ where
 
 impl<C> Eq for VerifyingKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
@@ -155,7 +154,7 @@ where
 
 impl<C> PartialEq for VerifyingKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
@@ -167,7 +166,7 @@ where
 
 impl<C> PartialOrd for VerifyingKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
@@ -179,7 +178,7 @@ where
 
 impl<C> Ord for VerifyingKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
@@ -191,7 +190,7 @@ where
 
 impl<C> TryFrom<&[u8]> for VerifyingKey<C>
 where
-    C: Curve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
@@ -207,7 +206,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
 impl<C> FromPublicKey for VerifyingKey<C>
 where
-    C: Curve + AlgorithmParameters + ProjectiveArithmetic + PointCompression,
+    C: PrimeCurve + AlgorithmParameters + ProjectiveArithmetic + PointCompression,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
@@ -221,7 +220,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl<C> FromStr for VerifyingKey<C>
 where
-    C: Curve + AlgorithmParameters + ProjectiveArithmetic + PointCompression,
+    C: PrimeCurve + AlgorithmParameters + ProjectiveArithmetic + PointCompression,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,


### PR DESCRIPTION
Switches from `weierstrass::Curve` to the `PrimeCurve` trait added in RustCrypto/traits#737.