### PR TITLE
ecdsa: use the `sec1` crate release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "const-oid"
 version = "0.6.1"
-source = "git+https://github.com/rustcrypto/formats#85322893dc6038d91027599fcf6b19489acd1f7d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdab415d6744056100f40250a66bc430c1a46f7a02e20bc11c94c79a0f0464df"
 
 [[package]]
 name = "cpufeatures"
@@ -120,7 +121,8 @@ dependencies = [
 [[package]]
 name = "der"
 version = "0.4.3"
-source = "git+https://github.com/rustcrypto/formats#85322893dc6038d91027599fcf6b19489acd1f7d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2adca118c71ecd9ae094d4b68257b3fdfcb711a612b9eec7b5a0d27a5a70a5b4"
 dependencies = [
  "const-oid",
 ]
@@ -484,8 +486,9 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.0.0"
-source = "git+https://github.com/rustcrypto/formats#85322893dc6038d91027599fcf6b19489acd1f7d"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "821f61b502d21d297a599436b55d03fff2340961a13bfd0a2c010380b8435823"
 dependencies = [
  "der 0.4.3",
  "generic-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,4 @@
 members = ["ecdsa", "ed25519"]
 
 [patch.crates-io]
-der = { git = "https://github.com/rustcrypto/formats" }
 elliptic-curve = { git = "https://github.com/RustCrypto/traits.git" }
-sec1 = { git = "https://github.com/rustcrypto/formats" }


### PR DESCRIPTION
Bumps the `elliptic-curve` git hash and removes the patch dependencies