### PR TITLE
ecdsa: replace `FromDigest` trait with `Reduce`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ dependencies = [
 [[package]]
 name = "elliptic-curve"
 version = "0.11.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#5251de66e4f9f74c6659b111cacfb78a70b85e4a"
+source = "git+https://github.com/RustCrypto/traits.git#fea0010f3356186804b42e57a8cb3612b96dab9f"
 dependencies = [
  "crypto-bigint",
  "der 0.4.3",
@@ -492,6 +492,7 @@ checksum = "821f61b502d21d297a599436b55d03fff2340961a13bfd0a2c010380b8435823"
 dependencies = [
  "der 0.4.3",
  "generic-array",
+ "subtle",
  "zeroize",
 ]
 

--- a/ecdsa/src/dev.rs
+++ b/ecdsa/src/dev.rs
@@ -1,35 +1,5 @@
 //! Development-related functionality.
 
-use crate::hazmat::FromDigest;
-use elliptic_curve::{
-    bigint::{ArrayEncoding, Encoding},
-    consts::U32,
-    dev::{MockCurve, Scalar},
-    group::ff::PrimeField,
-    subtle::{ConditionallySelectable, ConstantTimeLess},
-    Curve,
-};
-use signature::digest::Digest;
-
-type UInt = <MockCurve as Curve>::UInt;
-
-impl FromDigest<MockCurve> for Scalar {
-    fn from_digest<D>(digest: D) -> Self
-    where
-        D: Digest<OutputSize = U32>,
-    {
-        let uint = UInt::from_be_bytes(digest.finalize().into());
-        let overflow = !uint.ct_lt(&MockCurve::ORDER);
-        let scalar = uint.wrapping_add(&UInt::conditional_select(
-            &UInt::ZERO,
-            &MockCurve::ORDER,
-            overflow,
-        ));
-
-        Self::from_repr(scalar.to_be_byte_array()).unwrap()
-    }
-}
-
 // TODO(tarcieri): implement full set of tests from ECDSA2VS
 // <https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/dss2/ecdsa2vs.pdf>
 

--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -134,23 +134,6 @@ pub trait DigestPrimitive: PrimeCurve {
     type Digest: Digest;
 }
 
-/// Instantiate this type from the output of a digest.
-///
-/// This trait is intended for use in ECDSA and should perform a conversion
-/// which is compatible with the rules for calculating `h` from `H(M)` set out
-/// in RFC6979 section 2.4. This conversion cannot fail.
-///
-/// This trait may also be useful for other hash-to-scalar or hash-to-curve
-/// use cases.
-#[cfg(feature = "digest")]
-#[cfg_attr(docsrs, doc(cfg(feature = "digest")))]
-pub trait FromDigest<C: PrimeCurve> {
-    /// Instantiate this type from a [`Digest`] instance
-    fn from_digest<D>(digest: D) -> Self
-    where
-        D: Digest<OutputSize = FieldSize<C>>;
-}
-
 #[cfg(feature = "digest")]
 impl<C> PrehashSignature for Signature<C>
 where


### PR DESCRIPTION
Now that we have a trait for expressing modular reductions, it can replace the `FromDigest` trait, with the output of a given digest function passed as an input to a modular reduction.