### PR TITLE
ecdsa: update to use new `FromEncodedPoint` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ dependencies = [
 [[package]]
 name = "elliptic-curve"
 version = "0.11.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#fea0010f3356186804b42e57a8cb3612b96dab9f"
+source = "git+https://github.com/RustCrypto/traits.git#148e5da89e85104fe172163093413785fea06c06"
 dependencies = [
  "crypto-bigint",
  "der 0.4.3",

--- a/ecdsa/src/verify.rs
+++ b/ecdsa/src/verify.rs
@@ -50,7 +50,7 @@ where
 
     /// Initialize [`VerifyingKey`] from an [`EncodedPoint`].
     pub fn from_encoded_point(public_key: &EncodedPoint<C>) -> Result<Self> {
-        PublicKey::<C>::from_encoded_point(public_key)
+        Option::from(PublicKey::<C>::from_encoded_point(public_key))
             .map(|public_key| Self { inner: public_key })
             .ok_or_else(Error::new)
     }


### PR DESCRIPTION
See: https://github.com/RustCrypto/traits/pull/782