### PR TITLE
Bump `pkcs8` crate; update encoding traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ checksum = "e6b4d9b1225d28d360ec6a231d65af1fd99a2a095154c8040689617290569c5c"
 [[package]]
 name = "base64ct"
 version = "1.1.1"
-source = "git+https://github.com/RustCrypto/formats.git#98d7a2896d671169453f43ee57b43cee17b18b89"
+source = "git+https://github.com/RustCrypto/formats.git#3fb54bd27644e3f8bf8aeced336af77f4ed42813"
 
 [[package]]
 name = "bincode"
@@ -67,7 +67,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "const-oid"
 version = "0.6.2"
-source = "git+https://github.com/RustCrypto/formats.git#98d7a2896d671169453f43ee57b43cee17b18b89"
+source = "git+https://github.com/RustCrypto/formats.git#3fb54bd27644e3f8bf8aeced336af77f4ed42813"
 
 [[package]]
 name = "cpufeatures"
@@ -80,9 +80,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d12477e115c0d570c12a2dfd859f80b55b60ddb5075df210d3af06d133a69f45"
+checksum = "f83bd3bb4314701c568e340cd8cf78c975aa0ca79e03d3f6d1677d5b0c9c0c03"
 dependencies = [
  "generic-array",
  "rand_core 0.6.3",
@@ -122,9 +122,10 @@ checksum = "28e98c534e9c8a0483aa01d6f6913bc063de254311bd267c9cf535e9b70e15b2"
 [[package]]
 name = "der"
 version = "0.5.0-pre.1"
-source = "git+https://github.com/RustCrypto/formats.git#98d7a2896d671169453f43ee57b43cee17b18b89"
+source = "git+https://github.com/RustCrypto/formats.git#3fb54bd27644e3f8bf8aeced336af77f4ed42813"
 dependencies = [
  "const-oid",
+ "pem-rfc7468 0.2.2 (git+https://github.com/RustCrypto/formats.git)",
 ]
 
 [[package]]
@@ -212,7 +213,7 @@ dependencies = [
 [[package]]
 name = "elliptic-curve"
 version = "0.11.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#80ee951080a3544e6550a86923ed49258f8b91ce"
+source = "git+https://github.com/RustCrypto/traits.git#d2639c11cbaa49db6186f99f1a0d90a44be146ad"
 dependencies = [
  "crypto-bigint",
  "der 0.5.0-pre.1",
@@ -314,9 +315,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.103"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
+checksum = "7b2f96d100e1cf1929e7719b7edb3b90ab5298072638fccd77be9ce942ecdfce"
 
 [[package]]
 name = "log"
@@ -371,7 +372,7 @@ dependencies = [
 [[package]]
 name = "pem-rfc7468"
 version = "0.2.2"
-source = "git+https://github.com/RustCrypto/formats.git#98d7a2896d671169453f43ee57b43cee17b18b89"
+source = "git+https://github.com/RustCrypto/formats.git#3fb54bd27644e3f8bf8aeced336af77f4ed42813"
 dependencies = [
  "base64ct 1.1.1 (git+https://github.com/RustCrypto/formats.git)",
 ]
@@ -379,10 +380,9 @@ dependencies = [
 [[package]]
 name = "pkcs8"
 version = "0.8.0-pre"
-source = "git+https://github.com/RustCrypto/formats.git#98d7a2896d671169453f43ee57b43cee17b18b89"
+source = "git+https://github.com/RustCrypto/formats.git#3fb54bd27644e3f8bf8aeced336af77f4ed42813"
 dependencies = [
  "der 0.5.0-pre.1",
- "pem-rfc7468 0.2.2 (git+https://github.com/RustCrypto/formats.git)",
  "spki",
  "zeroize",
 ]
@@ -496,8 +496,8 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.2.0"
-source = "git+https://github.com/RustCrypto/formats.git#98d7a2896d671169453f43ee57b43cee17b18b89"
+version = "0.2.0-pre"
+source = "git+https://github.com/RustCrypto/formats.git#3fb54bd27644e3f8bf8aeced336af77f4ed42813"
 dependencies = [
  "der 0.5.0-pre.1",
  "generic-array",
@@ -552,8 +552,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 [[package]]
 name = "spki"
 version = "0.5.0-pre"
-source = "git+https://github.com/RustCrypto/formats.git#98d7a2896d671169453f43ee57b43cee17b18b89"
+source = "git+https://github.com/RustCrypto/formats.git#3fb54bd27644e3f8bf8aeced336af77f4ed42813"
 dependencies = [
+ "base64ct 1.1.1 (git+https://github.com/RustCrypto/formats.git)",
  "der 0.5.0-pre.1",
 ]
 

--- a/ecdsa/src/sign.rs
+++ b/ecdsa/src/sign.rs
@@ -29,7 +29,7 @@ use {crate::verify::VerifyingKey, elliptic_curve::PublicKey};
 
 #[cfg(feature = "pkcs8")]
 use crate::elliptic_curve::{
-    pkcs8::{self, FromPrivateKey},
+    pkcs8::{self, DecodePrivateKey},
     sec1::{self, FromEncodedPoint, ToEncodedPoint},
     AffinePoint, AlgorithmParameters,
 };
@@ -273,7 +273,7 @@ where
 
 #[cfg(feature = "pkcs8")]
 #[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
-impl<C> FromPrivateKey for SigningKey<C>
+impl<C> DecodePrivateKey for SigningKey<C>
 where
     C: PrimeCurve + AlgorithmParameters + ProjectiveArithmetic,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,

--- a/ecdsa/src/verify.rs
+++ b/ecdsa/src/verify.rs
@@ -15,7 +15,7 @@ use signature::{digest::Digest, DigestVerifier, Verifier};
 
 #[cfg(feature = "pkcs8")]
 use crate::elliptic_curve::{
-    pkcs8::{self, FromPublicKey},
+    pkcs8::{self, DecodePublicKey},
     AlgorithmParameters,
 };
 
@@ -186,13 +186,13 @@ where
 
 #[cfg(feature = "pkcs8")]
 #[cfg_attr(docsrs, doc(cfg(feature = "pkcs8")))]
-impl<C> FromPublicKey for VerifyingKey<C>
+impl<C> DecodePublicKey for VerifyingKey<C>
 where
     C: PrimeCurve + AlgorithmParameters + ProjectiveArithmetic + PointCompression,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     FieldSize<C>: sec1::ModulusSize,
 {
-    fn from_spki(spki: pkcs8::SubjectPublicKeyInfo<'_>) -> pkcs8::Result<Self> {
+    fn from_spki(spki: pkcs8::SubjectPublicKeyInfo<'_>) -> der::Result<Self> {
         PublicKey::from_spki(spki).map(|inner| Self { inner })
     }
 }

--- a/ed25519/src/pkcs8.rs
+++ b/ed25519/src/pkcs8.rs
@@ -3,10 +3,10 @@
 //! Implements Ed25519 PKCS#8 private keys as described in RFC8410 Section 7:
 //! <https://datatracker.ietf.org/doc/html/rfc8410#section-7>
 
-pub use pkcs8::FromPrivateKey;
+pub use pkcs8::DecodePrivateKey;
 
 #[cfg(feature = "alloc")]
-pub use pkcs8::ToPrivateKey;
+pub use pkcs8::EncodePrivateKey;
 
 use core::convert::TryInto;
 
@@ -56,7 +56,7 @@ impl KeypairBytes {
     }
 }
 
-impl FromPrivateKey for KeypairBytes {
+impl DecodePrivateKey for KeypairBytes {
     fn from_pkcs8_private_key_info(private_key: pkcs8::PrivateKeyInfo<'_>) -> pkcs8::Result<Self> {
         private_key.algorithm.assert_algorithm_oid(ALGORITHM_OID)?;
 
@@ -92,7 +92,7 @@ impl FromPrivateKey for KeypairBytes {
 
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-impl ToPrivateKey for KeypairBytes {
+impl EncodePrivateKey for KeypairBytes {
     fn to_pkcs8_der(&self) -> pkcs8::Result<pkcs8::PrivateKeyDocument> {
         let algorithm = pkcs8::AlgorithmIdentifier {
             oid: ALGORITHM_OID,
@@ -106,12 +106,12 @@ impl ToPrivateKey for KeypairBytes {
         private_key[1] = 0x20;
         private_key[2..].copy_from_slice(&self.secret_key);
 
-        Ok(pkcs8::PrivateKeyInfo {
+        pkcs8::PrivateKeyInfo {
             algorithm,
             private_key: &private_key,
             public_key: self.public_key.as_ref().map(AsRef::as_ref),
         }
-        .to_der())
+        .to_der()
     }
 }
 

--- a/ed25519/tests/pkcs8.rs
+++ b/ed25519/tests/pkcs8.rs
@@ -2,11 +2,11 @@
 
 #![cfg(feature = "pkcs8")]
 
-use ed25519::pkcs8::{FromPrivateKey, KeypairBytes};
+use ed25519::pkcs8::{DecodePrivateKey, KeypairBytes};
 use hex_literal::hex;
 
 #[cfg(feature = "alloc")]
-use ed25519::pkcs8::ToPrivateKey;
+use ed25519::pkcs8::EncodePrivateKey;
 
 /// Ed25519 PKCS#8 v1 private key encoded as ASN.1 DER
 const PKCS8_V1_DER: &[u8] = include_bytes!("examples/pkcs8-v1.der");


### PR DESCRIPTION
Updates `pkcs8` and related crates to use the new trait names after they were renamed in RustCrypto/formats#121.