### PR TITLE
ecdsa: 2021 edition upgrade; MSRV 1.56+

### DIFF
--- a/.github/workflows/ecdsa.yml
+++ b/.github/workflows/ecdsa.yml
@@ -24,7 +24,7 @@ jobs:
           - thumbv7em-none-eabi
           - wasm32-unknown-unknown
         rust:
-          - 1.55.0 # MSRV
+          - 1.56.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.55.0 # MSRV
+          - 1.56.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/ed25519.yml
+++ b/.github/workflows/ed25519.yml
@@ -24,7 +24,7 @@ jobs:
           - thumbv7em-none-eabi
           - wasm32-unknown-unknown
         toolchain:
-          - 1.55.0 # MSRV
+          - 1.56.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v2
@@ -46,7 +46,7 @@ jobs:
           - macos-latest
           - windows-latest
         toolchain:
-          - 1.55.0 # MSRV
+          - 1.56.0 # MSRV
           - stable
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -13,12 +13,16 @@ jobs:
     name: Security Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - name: Cache cargo bin
-        uses: actions/cache@v1
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+      - uses: actions/cache@v1
         with:
           path: ~/.cargo/bin
-          key: ${{ runner.os }}-cargo-audit-v0.11.2
+          key: ${{ runner.os }}-cargo-audit-v0.15.2
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -34,27 +34,8 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.55.0
+          toolchain: 1.56.0
           components: clippy
           override: true
           profile: minimal
       - run: cargo clippy --all-features -- -D warnings
-
-  codecov:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-      - uses: actions-rs/tarpaulin@v0.1
-        with:
-          version: latest
-          args: --all --all-features -- --test-threads 1
-      - uses: codecov/codecov-action@v1
-      - uses: actions/upload-artifact@v1
-        with:
-          name: code-coverage-report
-          path: cobertura.xml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,8 +19,8 @@ checksum = "e6b4d9b1225d28d360ec6a231d65af1fd99a2a095154c8040689617290569c5c"
 
 [[package]]
 name = "base64ct"
-version = "1.1.1"
-source = "git+https://github.com/RustCrypto/formats.git#3fb54bd27644e3f8bf8aeced336af77f4ed42813"
+version = "1.2.0-pre"
+source = "git+https://github.com/RustCrypto/formats.git#4ec825666bcd552a873596743d9fead3bdc898e5"
 
 [[package]]
 name = "bincode"
@@ -42,9 +42,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.7.1"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9df67f7bf9ef8498769f994239c45613ef0c5899415fb58e9add412d2c1a538"
+checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
 
 [[package]]
 name = "byteorder"
@@ -66,8 +66,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "const-oid"
-version = "0.6.2"
-source = "git+https://github.com/RustCrypto/formats.git#3fb54bd27644e3f8bf8aeced336af77f4ed42813"
+version = "0.7.0-pre"
+source = "git+https://github.com/RustCrypto/formats.git#4ec825666bcd552a873596743d9fead3bdc898e5"
 
 [[package]]
 name = "cpufeatures"
@@ -122,10 +122,10 @@ checksum = "28e98c534e9c8a0483aa01d6f6913bc063de254311bd267c9cf535e9b70e15b2"
 [[package]]
 name = "der"
 version = "0.5.0-pre.1"
-source = "git+https://github.com/RustCrypto/formats.git#3fb54bd27644e3f8bf8aeced336af77f4ed42813"
+source = "git+https://github.com/RustCrypto/formats.git#4ec825666bcd552a873596743d9fead3bdc898e5"
 dependencies = [
  "const-oid",
- "pem-rfc7468 0.2.2 (git+https://github.com/RustCrypto/formats.git)",
+ "pem-rfc7468 0.3.0-pre",
 ]
 
 [[package]]
@@ -213,7 +213,7 @@ dependencies = [
 [[package]]
 name = "elliptic-curve"
 version = "0.11.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#d2639c11cbaa49db6186f99f1a0d90a44be146ad"
+source = "git+https://github.com/RustCrypto/traits.git#b168e8c348ce358c6d9bfca66aa142b81d1380d2"
 dependencies = [
  "crypto-bigint",
  "der 0.5.0-pre.1",
@@ -221,7 +221,7 @@ dependencies = [
  "generic-array",
  "group",
  "hex-literal",
- "pem-rfc7468 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pem-rfc7468 0.2.3",
  "pkcs8",
  "rand_core 0.6.3",
  "sec1",
@@ -362,25 +362,25 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e71fb2d401a15271d52aade6d9410fb4ead603a86da5503f92e872e1df790265"
+checksum = "8f22eb0e3c593294a99e9ff4b24cf6b752d43f193aa4415fe5077c159996d497"
 dependencies = [
- "base64ct 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64ct 1.1.1",
 ]
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.2.2"
-source = "git+https://github.com/RustCrypto/formats.git#3fb54bd27644e3f8bf8aeced336af77f4ed42813"
+version = "0.3.0-pre"
+source = "git+https://github.com/RustCrypto/formats.git#4ec825666bcd552a873596743d9fead3bdc898e5"
 dependencies = [
- "base64ct 1.1.1 (git+https://github.com/RustCrypto/formats.git)",
+ "base64ct 1.2.0-pre",
 ]
 
 [[package]]
 name = "pkcs8"
 version = "0.8.0-pre"
-source = "git+https://github.com/RustCrypto/formats.git#3fb54bd27644e3f8bf8aeced336af77f4ed42813"
+source = "git+https://github.com/RustCrypto/formats.git#4ec825666bcd552a873596743d9fead3bdc898e5"
 dependencies = [
  "der 0.5.0-pre.1",
  "spki",
@@ -497,7 +497,7 @@ dependencies = [
 [[package]]
 name = "sec1"
 version = "0.2.0-pre"
-source = "git+https://github.com/RustCrypto/formats.git#3fb54bd27644e3f8bf8aeced336af77f4ed42813"
+source = "git+https://github.com/RustCrypto/formats.git#4ec825666bcd552a873596743d9fead3bdc898e5"
 dependencies = [
  "der 0.5.0-pre.1",
  "generic-array",
@@ -535,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
+checksum = "f2807892cfa58e081aa1f1111391c7a0649d4fa127a4ffbe34bcbfb35a1171a4"
 dependencies = [
  "digest",
  "rand_core 0.6.3",
@@ -552,9 +552,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 [[package]]
 name = "spki"
 version = "0.5.0-pre"
-source = "git+https://github.com/RustCrypto/formats.git#3fb54bd27644e3f8bf8aeced336af77f4ed42813"
+source = "git+https://github.com/RustCrypto/formats.git#4ec825666bcd552a873596743d9fead3bdc898e5"
 dependencies = [
- "base64ct 1.1.1 (git+https://github.com/RustCrypto/formats.git)",
+ "base64ct 1.2.0-pre",
  "der 0.5.0-pre.1",
 ]
 

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,17 +1,18 @@
 [package]
 name    = "ecdsa"
 version = "0.13.0-pre" # Also update html_root_url in lib.rs when bumping this
-description   = """
+description = """
 Signature and elliptic curve types providing interoperable support for the
 Elliptic Curve Digital Signature Algorithm (ECDSA)
 """
-authors    = ["RustCrypto Developers"]
-license    = "Apache-2.0 OR MIT"
+authors = ["RustCrypto Developers"]
+license = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/signatures"
-edition    = "2018"
-readme     = "README.md"
+readme = "README.md"
 categories = ["cryptography", "no-std"]
-keywords   = ["crypto", "ecc", "nist", "secp256k1", "signature"]
+keywords = ["crypto", "ecc", "nist", "secp256k1", "signature"]
+edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 elliptic-curve = { version = "=0.11.0-pre", default-features = false, features = ["sec1"] }

--- a/ecdsa/README.md
+++ b/ecdsa/README.md
@@ -27,7 +27,7 @@ ways:
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.55** at a minimum.
+This crate requires **Rust 1.56** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -54,7 +54,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/ecdsa/badge.svg
 [docs-link]: https://docs.rs/ecdsa/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.55+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260048-signatures
 [build-image]: https://github.com/RustCrypto/signatures/workflows/ecdsa/badge.svg?branch=master&event=push

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -28,7 +28,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust **1.55** or higher.
+//! Rust **1.56** or higher.
 //!
 //! Minimum supported Rust version may be changed in the future, but it will be
 //! accompanied with a minor version bump.

--- a/ed25519/README.md
+++ b/ed25519/README.md
@@ -24,7 +24,7 @@ Ed25519 implementations, including HSMs or Cloud KMS services.
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.55** at a minimum.
+This crate requires **Rust 1.56** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -51,7 +51,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/ed25519/badge.svg
 [docs-link]: https://docs.rs/ed25519/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.55+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260048-signatures
 [build-image]: https://github.com/RustCrypto/signatures/workflows/ed25519/badge.svg?branch=master&event=push

--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -15,7 +15,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Rust **1.55** or higher.
+//! Rust **1.56** or higher.
 //!
 //! Minimum supported Rust version may be changed in the future, but such
 //! changes will be accompanied with a minor version bump.


### PR DESCRIPTION
The `elliptic-curve` crate as well as format parsers including `der`, `sec1`, and `pkcs8` have all been bumped to the 2021 edition:

https://github.com/RustCrypto/traits/pull/795

This commit updates the `ecdsa` crate to the 2021 edition accordingly.