### PR TITLE
Allow `signature` v1.4 as a dependency

### DIFF
--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.56"
 [dependencies]
 elliptic-curve = { version = "=0.11.0-pre", default-features = false, features = ["sec1"] }
 hmac = { version = "0.11", optional = true, default-features = false }
-signature = { version = ">= 1.3.1, < 1.4.0", default-features = false, features = ["rand-preview"] }
+signature = { version = ">= 1.3.1, < 1.5.0", default-features = false, features = ["rand-preview"] }
 
 # optional dependencies
 der = { version = "0.5.0-pre.1", optional = true }

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -12,7 +12,7 @@ categories    = ["cryptography", "no-std"]
 keywords      = ["crypto", "curve25519", "ecc", "signature", "signing"]
 
 [dependencies]
-signature = { version = "1.3.1", default-features = false }
+signature = { version = ">=1.3.1, <1.5.0", default-features = false }
 
 # optional dependencies
 pkcs8 = { version = "0.8.0-pre", optional = true }


### PR DESCRIPTION
Expands the range of allowed `signature` crate version to include the 1.4.x series in addition to 1.3.x.