### PR TITLE
Use released RustCrypto/formats crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,14 +13,9 @@ dependencies = [
 
 [[package]]
 name = "base64ct"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b4d9b1225d28d360ec6a231d65af1fd99a2a095154c8040689617290569c5c"
-
-[[package]]
-name = "base64ct"
 version = "1.2.0"
-source = "git+https://github.com/RustCrypto/formats.git#43d3ca3f8bca8d7f0a779489885d21a77b0f64a5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "392c772b012d685a640cdad68a5a21f4a45e696f85a2c2c907aab2fe49a91e19"
 
 [[package]]
 name = "bincode"
@@ -67,7 +62,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "const-oid"
 version = "0.7.0"
-source = "git+https://github.com/RustCrypto/formats.git#43d3ca3f8bca8d7f0a779489885d21a77b0f64a5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d355758f44afa81c21e66e1301d47cbffbbcde4b405cbe46b8b19f213abf9f60"
 
 [[package]]
 name = "cpufeatures"
@@ -132,8 +128,9 @@ checksum = "28e98c534e9c8a0483aa01d6f6913bc063de254311bd267c9cf535e9b70e15b2"
 
 [[package]]
 name = "der"
-version = "0.5.0"
-source = "git+https://github.com/RustCrypto/formats.git#43d3ca3f8bca8d7f0a779489885d21a77b0f64a5"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
 dependencies = [
  "const-oid",
  "pem-rfc7468 0.3.0",
@@ -163,7 +160,7 @@ dependencies = [
 name = "ecdsa"
 version = "0.13.0-pre"
 dependencies = [
- "der 0.5.0",
+ "der 0.5.1",
  "elliptic-curve 0.11.0-pre",
  "hex-literal",
  "hmac",
@@ -224,15 +221,15 @@ dependencies = [
 [[package]]
 name = "elliptic-curve"
 version = "0.11.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#0d6f582e941ce60d5876288664e3fccfc29cbe8d"
+source = "git+https://github.com/RustCrypto/traits.git#3502b5b35966e690eaf504e8e60542d7b7a22eff"
 dependencies = [
  "crypto-bigint 0.3.0",
- "der 0.5.0",
+ "der 0.5.1",
  "ff",
  "generic-array",
  "group",
  "hex-literal",
- "pem-rfc7468 0.2.4",
+ "pem-rfc7468 0.2.3",
  "rand_core 0.6.3",
  "sec1",
  "subtle",
@@ -372,27 +369,29 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.2.4"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84e93a3b1cc0510b03020f33f21e62acdde3dcaef432edc95bea377fbd4c2cd4"
+checksum = "8f22eb0e3c593294a99e9ff4b24cf6b752d43f193aa4415fe5077c159996d497"
 dependencies = [
- "base64ct 1.1.1",
+ "base64ct",
 ]
 
 [[package]]
 name = "pem-rfc7468"
 version = "0.3.0"
-source = "git+https://github.com/RustCrypto/formats.git#43d3ca3f8bca8d7f0a779489885d21a77b0f64a5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1254538022fc9aaf1db9f36f315f7a622dc4d46bedc42f8f8220ee23f932ee"
 dependencies = [
- "base64ct 1.2.0",
+ "base64ct",
 ]
 
 [[package]]
 name = "pkcs8"
-version = "0.8.0-pre"
-source = "git+https://github.com/RustCrypto/formats.git#43d3ca3f8bca8d7f0a779489885d21a77b0f64a5"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
 dependencies = [
- "der 0.5.0",
+ "der 0.5.1",
  "spki",
  "zeroize",
 ]
@@ -506,10 +505,11 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.2.0-pre"
-source = "git+https://github.com/RustCrypto/formats.git#43d3ca3f8bca8d7f0a779489885d21a77b0f64a5"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2503adcd8c83e7081b3f9a3173f328f4d6cd50e116aaa324389b46f2d771d595"
 dependencies = [
- "der 0.5.0",
+ "der 0.5.1",
  "generic-array",
  "pkcs8",
  "subtle",
@@ -562,11 +562,12 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spki"
-version = "0.5.0"
-source = "git+https://github.com/RustCrypto/formats.git#43d3ca3f8bca8d7f0a779489885d21a77b0f64a5"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707c346225adc965b02243d87a3951bb6f8cbd039947cd99430ee2b2fdad09a3"
 dependencies = [
- "base64ct 1.2.0",
- "der 0.5.0",
+ "base64ct",
+ "der 0.5.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,4 @@ resolver = "2"
 members = ["ecdsa", "ed25519"]
 
 [patch.crates-io]
-der = { git = "https://github.com/RustCrypto/formats.git" }
 elliptic-curve = { git = "https://github.com/RustCrypto/traits.git" }
-pkcs8 = { git = "https://github.com/RustCrypto/formats.git" }
-sec1 = { git = "https://github.com/RustCrypto/formats.git" }


### PR DESCRIPTION
Removes the git-based dependencies