### PR TITLE
ecdsa: remove `RecoverableSignPrimitive`

### DIFF
--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -55,7 +55,7 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
-pub mod recovery;
+mod recovery;
 
 #[cfg(feature = "der")]
 #[cfg_attr(docsrs, doc(cfg(feature = "der")))]

--- a/ecdsa/src/sign.rs
+++ b/ecdsa/src/sign.rs
@@ -178,7 +178,7 @@ where
     fn try_sign_digest(&self, msg_digest: D) -> Result<Signature<C>> {
         let k = rfc6979::generate_k(&self.inner, msg_digest.clone(), &[]);
         let msg_scalar = Scalar::<C>::from_be_bytes_reduced(msg_digest.finalize_fixed());
-        self.inner.try_sign_prehashed(&**k, &msg_scalar)
+        Ok(self.inner.try_sign_prehashed(&**k, &msg_scalar)?.0)
     }
 }
 
@@ -214,7 +214,7 @@ where
 
         let k = rfc6979::generate_k(&self.inner, msg_digest.clone(), &added_entropy);
         let msg_scalar = Scalar::<C>::from_be_bytes_reduced(msg_digest.finalize_fixed());
-        self.inner.try_sign_prehashed(&**k, &msg_scalar)
+        Ok(self.inner.try_sign_prehashed(&**k, &msg_scalar)?.0)
     }
 }
 


### PR DESCRIPTION
Consolidates `RecoverableSignPrimitive` into `SignPrimitive`.

These traits were nearly identical. This commit combines them into a single trait that works in all use cases.