### PR TITLE
Add default impl of `SignPrimitive::try_sign_prehashed`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ dependencies = [
 [[package]]
 name = "elliptic-curve"
 version = "0.11.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#f484ed6326282dc834451ae5a51cda4e60f275bf"
+source = "git+https://github.com/RustCrypto/traits.git#7d813023da0ce6e418e4f7bf3b0dda9914a891cb"
 dependencies = [
  "crypto-bigint 0.3.2",
  "der 0.5.1",

--- a/ecdsa/src/sign.rs
+++ b/ecdsa/src/sign.rs
@@ -178,7 +178,7 @@ where
     fn try_sign_digest(&self, msg_digest: D) -> Result<Signature<C>> {
         let k = rfc6979::generate_k(&self.inner, msg_digest.clone(), &[]);
         let msg_scalar = Scalar::<C>::from_be_bytes_reduced(msg_digest.finalize_fixed());
-        Ok(self.inner.try_sign_prehashed(&**k, &msg_scalar)?.0)
+        Ok(self.inner.try_sign_prehashed(**k, msg_scalar)?.0)
     }
 }
 
@@ -214,7 +214,7 @@ where
 
         let k = rfc6979::generate_k(&self.inner, msg_digest.clone(), &added_entropy);
         let msg_scalar = Scalar::<C>::from_be_bytes_reduced(msg_digest.finalize_fixed());
-        Ok(self.inner.try_sign_prehashed(&**k, &msg_scalar)?.0)
+        Ok(self.inner.try_sign_prehashed(**k, msg_scalar)?.0)
     }
 }
 


### PR DESCRIPTION
Leverages the newly added `AffineXCoordinate` trait from RustCrypto/traits#817 to provide a default generic implementation of the ECDSA signature algorithm.

Downstream crates can choose to override this implementation if they so desire, allowing them to potentially leverage more efficient arithmetic.

This approach does have a disadvantage that it necessarily adds a `ScalarArithmetic<Scalar = Self>` bound on the curve, meaning that `SignPrimitive` can only be impl'd for a particular curve's scalar type, as opposed to the original design goal of allowing it to be impl'd for a hardware ECDSA accelerator that stores a private scalar.

Either the default impl needs to be replaced with a blanket impl with more restrictive bounds, or a separate trait needs to be added to support hardware accelerators. The latter may indeed make the most sense.