### PR TITLE
ecdsa: add default generic impl of `VerifyPrimitive::verify_prehashed`

### DIFF
--- a/ecdsa/src/verify.rs
+++ b/ecdsa/src/verify.rs
@@ -74,7 +74,7 @@ where
 {
     fn verify_digest(&self, msg_digest: D, signature: &Signature<C>) -> Result<()> {
         let scalar = Scalar::<C>::from_be_bytes_reduced(msg_digest.finalize());
-        self.inner.as_affine().verify_prehashed(&scalar, signature)
+        self.inner.as_affine().verify_prehashed(scalar, signature)
     }
 }
 


### PR DESCRIPTION
Similar to #396, this adds a generic implementation of ECDSA signature verification by providing a default implementation of the `VerifyPrimitive::verify_prehashed` method.

Downstream crates can choose to override this implementation if they so desire, allowing them to potentially leverage more efficient arithmetic such as Shamir's trick / linear combinations (at least, until such a time as there are traits for these in the `group` crate).

This approach does have a disadvantage that it necessarily adds a `AffineArithmetic<AffinePoint = Self>` bound on the curve, meaning that `VerifyPrimitive` can only be impl'd for a particular curve's affine point type, as opposed to the original design goal of allowing it to be impl'd for a hardware ECDSA accelerator that stores a private scalar.

Either the default impl needs to be replaced with a blanket impl with more restrictive bounds, or a separate trait needs to be added to support hardware accelerators. The latter may indeed make the most sense.