### PR TITLE
ed25519: `zeroize` feature + doc improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,6 +190,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "signature",
+ "zeroize",
 ]
 
 [[package]]

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -18,6 +18,7 @@ signature = { version = ">=1.3.1, <1.5.0", default-features = false }
 pkcs8 = { version = "0.8.0-pre", optional = true }
 serde = { version = "1", optional = true, default-features = false }
 serde_bytes_crate = { package = "serde_bytes", version = "0.11", optional = true }
+zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 bincode = "1"

--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -249,6 +249,8 @@
 //!
 //! The following features are presently supported:
 //!
+//! - `pkcs8`: support for decoding/encoding PKCS#8-formatted private keys using the
+//!   [`KeypairBytes`] type.
 //! - `std` *(default)*: Enable `std` support in [`signature`], which currently only affects whether
 //!   [`signature::Error`] implements `std::error::Error`.
 //! - `serde`: Implement `serde::Deserialize` and `serde::Serialize` for [`Signature`]. Signatures


### PR DESCRIPTION
When `pkcs8` + `zeroize` is enabled, uses `zeroize` as part of the `Drop` impl for the `KeypairBytes` type.