### PR TITLE
ed25519: deprecate `Signature::new` in favor of `::from_bytes`

### DIFF
--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -12,7 +12,7 @@ categories    = ["cryptography", "no-std"]
 keywords      = ["crypto", "curve25519", "ecc", "signature", "signing"]
 
 [dependencies]
-signature = { version = ">=1.3.1, <1.5.0", default-features = false }
+signature = { version = ">=1.3.1", default-features = false }
 
 # optional dependencies
 pkcs8 = { version = "0.8.0-pre", optional = true }
@@ -30,6 +30,7 @@ rand_core = { version = "0.5", features = ["std"] }
 [features]
 default = ["std"]
 alloc = ["pkcs8/alloc"]
+pem = ["pkcs8/pem"]
 serde_bytes = ["serde", "serde_bytes_crate", "std"]
 std = ["signature/std"]
 

--- a/ed25519/src/pkcs8.rs
+++ b/ed25519/src/pkcs8.rs
@@ -25,7 +25,11 @@ pub const ALGORITHM_OID: ObjectIdentifier = ObjectIdentifier::new("1.3.101.112")
 
 /// Ed25519 keypair serialized as bytes.
 ///
-/// This type is primarily useful for decoding/encoding PKCS#8 private key files.
+/// This type is primarily useful for decoding/encoding PKCS#8 private key
+/// files (either DER or PEM) encoded using the following traits:
+///
+/// - [`DecodePrivateKey`]: decode DER or PEM encoded PKCS#8 private key.
+/// - [`EncodePrivateKey`]: encode DER or PEM encoded PKCS#8 private key.
 pub struct KeypairBytes {
     /// Ed25519 secret key.
     ///


### PR DESCRIPTION
Adds a `Signature::from_bytes` inherent method which matches the method of the same name on the `Signature` trait, i.e. it returns a `signature::Result`.

This method performs a partial range check on the `s` component of the signature to ensure fit within the order of ~2^(252.5). It won't reject all invalid signatures, but it will detect quite a few of them.

Deprecates the infallible `Signature::new` method, since it can't detect invalid signatures. While the `from_bytes` method isn't perfect, it can be improved in the future, whereas an infallible method can't.