### PR TITLE
ed25519: enforce signature invariants

### DIFF
--- a/ed25519/README.md
+++ b/ed25519/README.md
@@ -2,10 +2,10 @@
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
+[![Build Status][build-image]][build-link]
 ![Apache2/MIT licensed][license-image]
 ![Rust Version][rustc-image]
 [![Project Chat][chat-image]][chat-link]
-[![Build Status][build-image]][build-link]
 
 [Edwards Digital Signature Algorithm (EdDSA)][1] over Curve25519 as specified
 in [RFC 8032][2].

--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -332,10 +332,17 @@ impl Signature {
         self.0
     }
 
-    /// Create a new signature from a byte array.
+    /// DEPRECATED: Create a new signature from a byte array.
+    ///
+    /// # Warning
+    ///
+    /// This method will panic if an invalid signature is encountered.
+    ///
+    /// Use [`Signature::from_bytes`] or [`Signature::try_from`] instead for
+    /// a fallible conversion.
     #[deprecated(since = "1.3.0", note = "use ed25519::Signature::from_bytes instead")]
     pub fn new(bytes: [u8; Self::BYTE_SIZE]) -> Self {
-        Self(bytes)
+        Self::from_bytes(&bytes[..]).expect("invalid signature")
     }
 }
 
@@ -351,10 +358,28 @@ impl AsRef<[u8]> for Signature {
     }
 }
 
+impl From<Signature> for [u8; Signature::BYTE_SIZE] {
+    fn from(sig: Signature) -> [u8; Signature::BYTE_SIZE] {
+        sig.0
+    }
+}
+
+impl From<&Signature> for [u8; Signature::BYTE_SIZE] {
+    fn from(sig: &Signature) -> [u8; Signature::BYTE_SIZE] {
+        sig.0
+    }
+}
+
+/// DEPRECATED: use `TryFrom<&[u8]>` instead.
+///
+/// # Warning
+///
+/// This conversion will panic if a signature is invalid.
 // TODO(tarcieri): remove this in the next breaking release
 impl From<[u8; Signature::BYTE_SIZE]> for Signature {
     fn from(bytes: [u8; Signature::BYTE_SIZE]) -> Signature {
-        Signature(bytes)
+        #[allow(deprecated)]
+        Signature::new(bytes)
     }
 }
 


### PR DESCRIPTION
This changes the now-deprecated `Signature::new` method as well as the `From<[u8; 64]>` impl on `Signature` to use `Signature::from_bytes` and panics if the signature is invalid.