### PR TITLE
ed25519 v1.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,7 +179,7 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.3.0-pre"
+version = "1.3.0"
 dependencies = [
  "bincode",
  "ed25519-dalek",

--- a/ed25519/CHANGELOG.md
+++ b/ed25519/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.3.0 (2021-11-18)
+### Added
+- `Signature::BYTE_SIZE` constant ([#380])
+- PKCS#8 support via `KeypairBytes` type ([#381])
+- `zeroize` feature ([#400])
+- Impl `Display`/`LowerHex`/`UpperHex`/`FromStr` for `Signature` ([#402])
+
+### Changed
+- Deprecate `SIGNATURE_LENGTH` constant in favor of `Signature::BYTE_SIZE` ([#380])
+- Deprecate `Signature::new` in favor of `Signature::from_bytes`/`TryFrom` ([#401])
+- `Signature::new` now panics on invalid signatures ([#403])
+
+[#380]: https://github.com/RustCrypto/signatures/pull/380
+[#381]: https://github.com/RustCrypto/signatures/pull/381
+[#400]: https://github.com/RustCrypto/signatures/pull/400
+[#401]: https://github.com/RustCrypto/signatures/pull/401
+[#402]: https://github.com/RustCrypto/signatures/pull/402
+[#403]: https://github.com/RustCrypto/signatures/pull/403
+
 ## 1.2.0 (2021-07-21)
 ### Added
 - `serde_bytes` optional dependency ([#337])

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -1,21 +1,25 @@
 [package]
-name          = "ed25519"
-version       = "1.3.0-pre"
-authors       = ["RustCrypto Developers"]
-license       = "Apache-2.0 OR MIT"
-description   = "Edwards Digital Signature Algorithm (EdDSA) over Curve25519 (as specified in RFC 8032)"
+name = "ed25519"
+version = "1.3.0"
+authors = ["RustCrypto Developers"]
+license = "Apache-2.0 OR MIT"
+description = """
+Edwards Digital Signature Algorithm (EdDSA) over Curve25519 (as specified in RFC 8032)
+support library providing signature type definitions and PKCS#8 private key
+decoding/encoding support
+"""
 documentation = "https://docs.rs/ed25519"
-repository    = "https://github.com/RustCrypto/signatures"
-edition       = "2018"
-readme        = "README.md"
-categories    = ["cryptography", "no-std"]
-keywords      = ["crypto", "curve25519", "ecc", "signature", "signing"]
+repository = "https://github.com/RustCrypto/signatures/tree/master/ed25519"
+edition = "2018"
+readme = "README.md"
+categories = ["cryptography", "no-std"]
+keywords = ["crypto", "curve25519", "ecc", "signature", "signing"]
 
 [dependencies]
 signature = { version = ">=1.3.1", default-features = false }
 
 # optional dependencies
-pkcs8 = { version = "0.8.0-pre", optional = true }
+pkcs8 = { version = "0.8", optional = true }
 serde = { version = "1", optional = true, default-features = false }
 serde_bytes_crate = { package = "serde_bytes", version = "0.11", optional = true }
 zeroize = { version = "1", optional = true, default-features = false }

--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -272,7 +272,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png",
-    html_root_url = "https://docs.rs/ed25519/1.3.0-pre"
+    html_root_url = "https://docs.rs/ed25519/1.3.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Added
- `Signature::BYTE_SIZE` constant ([#380])
- PKCS#8 support via `KeypairBytes` type ([#381])
- `zeroize` feature ([#400])
- Impl `Display`/`LowerHex`/`UpperHex`/`FromStr` for `Signature` ([#402])

### Changed
- Deprecate `SIGNATURE_LENGTH` constant in favor of `Signature::BYTE_SIZE` ([#380])
- Deprecate `Signature::new` in favor of `Signature::from_bytes`/`TryFrom` ([#401])
- `Signature::new` now panics on invalid signatures ([#403])

[#380]: https://github.com/RustCrypto/signatures/pull/380
[#381]: https://github.com/RustCrypto/signatures/pull/381
[#400]: https://github.com/RustCrypto/signatures/pull/400
[#401]: https://github.com/RustCrypto/signatures/pull/401
[#402]: https://github.com/RustCrypto/signatures/pull/402
[#403]: https://github.com/RustCrypto/signatures/pull/403