### PR TITLE
ecdsa: fix `serde` feature combos; improve CI

### DIFF
--- a/.github/workflows/ecdsa.yml
+++ b/.github/workflows/ecdsa.yml
@@ -43,9 +43,10 @@ jobs:
       - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features hazmat
       - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features pkcs8
       - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features pem
+      - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features serde
       - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features sign
       - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features verify
-      - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features arithmetic,dev,digest,hazmat,pkcs8,pem,sign,verify
+      - run: cargo build --no-default-features --release --target ${{ matrix.target }} --features arithmetic,dev,digest,hazmat,pkcs8,pem,serde,sign,verify
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
There are various feature combinations around `serde` which weren't working.

This commit fixes those combinations, adds TODOs to eventually simplify the feature combinations so they aren't needed, and adds CI to ensure it builds with all feature combinations.