### PR TITLE
ecdsa: bump `elliptic-curve` dependency to v0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ name = "ecdsa"
 version = "0.13.0-pre"
 dependencies = [
  "der 0.5.1",
- "elliptic-curve 0.11.0-pre",
+ "elliptic-curve 0.11.0",
  "hex-literal",
  "hmac",
  "sha2",
@@ -221,8 +221,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.11.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#88d5ea3ad633d13c9ac3b064c084f645830d7713"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be5ff748dcb04505ce82b6447d4bad4ef9cf653a1d811bed2b04083127a44c3f"
 dependencies = [
  "crypto-bigint 0.3.2",
  "der 0.5.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,3 @@
 [workspace]
 resolver = "2"
 members = ["ecdsa", "ed25519"]
-
-[patch.crates-io]
-elliptic-curve = { git = "https://github.com/RustCrypto/traits.git" }

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -15,15 +15,15 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-elliptic-curve = { version = "=0.11.0-pre", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.11", default-features = false, features = ["sec1"] }
 hmac = { version = "0.11", optional = true, default-features = false }
-signature = { version = ">= 1.3.1, < 1.5.0", default-features = false, features = ["rand-preview"] }
+signature = { version = ">= 1.3.1", default-features = false, features = ["rand-preview"] }
 
 # optional dependencies
-der = { version = "0.5.0-pre.1", optional = true }
+der = { version = "0.5", optional = true }
 
 [dev-dependencies]
-elliptic-curve = { version = "=0.11.0-pre", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.11", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 sha2 = { version = "0.9", default-features = false }
 

--- a/ecdsa/src/verify.rs
+++ b/ecdsa/src/verify.rs
@@ -23,7 +23,7 @@ use elliptic_curve::{
 use core::str::FromStr;
 
 #[cfg(all(feature = "pem", feature = "serde"))]
-#[cfg_attr(docsrs, doc(all(feature = "pem", feature = "serde")))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "pem", feature = "serde"))))]
 use elliptic_curve::serde::{de, ser, Deserialize, Serialize};
 
 /// ECDSA verification key (i.e. public key). Generic over elliptic curves.


### PR DESCRIPTION
Also bumps the `der` crate dependency to v0.5