### PR TITLE
ecdsa v0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.13.0-pre"
+version = "0.13.0"
 dependencies = [
  "der 0.5.1",
  "elliptic-curve 0.11.1",

--- a/ecdsa/CHANGELOG.md
+++ b/ecdsa/CHANGELOG.md
@@ -4,6 +4,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.13.0 (2021-11-21)
+### Added
+- `RecoveryId` type ([#392])
+- Default generic impl of `SignPrimitive::try_sign_prehashed` ([#396])
+- Default generic impl of `VerifyPrimitive::verify_prehashed` ([#397])
+- `serde` support ([#406])
+
+### Changed
+- Make `Signature::normalize_s` non-mutating ([#355])
+- Switch from `ScalarBytes<C>` to `ScalarCore<C>` ([#356])
+- Use `PrimeCurve` trait ([#357])
+- Replace `FromDigest` trait with `Reduce` ([#372])
+- 2021 edition upgrade; MSRV 1.56 ([#384])
+- Allow `signature` v1.4 as a dependency ([#385])
+- Bump `der` dependency to v0.5 ([#408])
+- Bump `elliptic-curve` dependency to v0.11 ([#408])
+- Split out `rfc6979` crate ([#409])
+
+### Removed
+- `NormalizeLow` trait ([#393])
+- `RecoverableSignPrimitive` ([#394])
+
+[#355]: https://github.com/RustCrypto/signatures/pull/355
+[#356]: https://github.com/RustCrypto/signatures/pull/356
+[#357]: https://github.com/RustCrypto/signatures/pull/357
+[#372]: https://github.com/RustCrypto/signatures/pull/372
+[#384]: https://github.com/RustCrypto/signatures/pull/384
+[#385]: https://github.com/RustCrypto/signatures/pull/385
+[#392]: https://github.com/RustCrypto/signatures/pull/392
+[#393]: https://github.com/RustCrypto/signatures/pull/393
+[#394]: https://github.com/RustCrypto/signatures/pull/394
+[#396]: https://github.com/RustCrypto/signatures/pull/396
+[#397]: https://github.com/RustCrypto/signatures/pull/397
+[#406]: https://github.com/RustCrypto/signatures/pull/406
+[#408]: https://github.com/RustCrypto/signatures/pull/408
+[#409]: https://github.com/RustCrypto/signatures/pull/409
+
 ## 0.12.4 (2021-08-12)
 ### Added
 - Impl `Clone`, `Debug`, `*Eq` for `SigningKey` ([#345])

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ecdsa"
-version = "0.13.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.13.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of the Elliptic Curve Digital Signature Algorithm
 (ECDSA) as specified in FIPS 186-4 (Digital Signature Standard)

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -1,17 +1,6 @@
-//! Elliptic Curve Digital Signature Algorithm (ECDSA) as specified in
-//! [FIPS 186-4] (Digital Signature Standard)
-//!
-//! ## About
-//!
-//! This crate provides generic ECDSA support which can be used in the
-//! following ways:
-//!
-//! - Generic implementation of ECDSA usable with the following crates:
-//!   - [`k256`] (secp256k1)
-//!   - [`p256`] (NIST P-256)
-//! - ECDSA signature types alone which can be used to provide interoperability
-//!   between other crates that provide an ECDSA implementation:
-//!   - [`p384`] (NIST P-384)
+#![doc = include_str!("../README.md")]
+
+//! ## Interop
 //!
 //! Any crates which provide an implementation of ECDSA for a particular
 //! elliptic curve can leverage the types from this crate, along with the
@@ -26,14 +15,6 @@
 //! wrap the ECDSA implementations from [*ring*] in a generic, interoperable
 //! API.
 //!
-//! ## Minimum Supported Rust Version
-//!
-//! Rust **1.56** or higher.
-//!
-//! Minimum supported Rust version may be changed in the future, but it will be
-//! accompanied with a minor version bump.
-//!
-//! [FIPS 186-4]: https://csrc.nist.gov/publications/detail/fips/186/4/final
 //! [`k256`]: https://docs.rs/k256
 //! [`p256`]: https://docs.rs/p256
 //! [`p256::ecdsa::Signature`]: https://docs.rs/p256/latest/p256/ecdsa/type.Signature.html
@@ -49,7 +30,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/ecdsa/0.13.0-pre"
+    html_root_url = "https://docs.rs/ecdsa/0.13.0"
 )]
 
 #[cfg(feature = "alloc")]
@@ -404,7 +385,7 @@ where
 
 // TODO(tarcieri): support deserialization with the `arithmetic` feature disabled
 #[cfg(all(feature = "arithmetic", feature = "serde"))]
-#[cfg_attr(docsrs, doc(all(feature = "arithmetic", feature = "serde")))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "arithmetic", feature = "serde"))))]
 impl<'de, C> Deserialize<'de> for Signature<C>
 where
     C: PrimeCurve + ScalarArithmetic,

--- a/ecdsa/src/verify.rs
+++ b/ecdsa/src/verify.rs
@@ -229,7 +229,7 @@ where
 }
 
 #[cfg(all(feature = "pem", feature = "serde"))]
-#[cfg_attr(docsrs, doc(all(feature = "pem", feature = "serde")))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "pem", feature = "serde"))))]
 impl<C> Serialize for VerifyingKey<C>
 where
     C: PrimeCurve + AlgorithmParameters + ProjectiveArithmetic + PointCompression,
@@ -245,7 +245,7 @@ where
 }
 
 #[cfg(all(feature = "pem", feature = "serde"))]
-#[cfg_attr(docsrs, doc(all(feature = "pem", feature = "serde")))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "pem", feature = "serde"))))]
 impl<'de, C> Deserialize<'de> for VerifyingKey<C>
 where
     C: PrimeCurve + AlgorithmParameters + ProjectiveArithmetic + PointCompression,


### PR DESCRIPTION
### Added
- `RecoveryId` type ([#392])
- Default generic impl of `SignPrimitive::try_sign_prehashed` ([#396])
- Default generic impl of `VerifyPrimitive::verify_prehashed` ([#397])
- `serde` support ([#406])

### Changed
- Make `Signature::normalize_s` non-mutating ([#355])
- Switch from `ScalarBytes<C>` to `ScalarCore<C>` ([#356])
- Use `PrimeCurve` trait ([#357])
- Replace `FromDigest` trait with `Reduce` ([#372])
- 2021 edition upgrade; MSRV 1.56 ([#384])
- Allow `signature` v1.4 as a dependency ([#385])
- Bump `der` dependency to v0.5 ([#408])
- Bump `elliptic-curve` dependency to v0.11 ([#408])
- Split out `rfc6979` crate ([#409])

### Removed
- `NormalizeLow` trait ([#393])
- `RecoverableSignPrimitive` ([#394])

[#355]: https://github.com/RustCrypto/signatures/pull/355
[#356]: https://github.com/RustCrypto/signatures/pull/356
[#357]: https://github.com/RustCrypto/signatures/pull/357
[#372]: https://github.com/RustCrypto/signatures/pull/372
[#384]: https://github.com/RustCrypto/signatures/pull/384
[#385]: https://github.com/RustCrypto/signatures/pull/385
[#392]: https://github.com/RustCrypto/signatures/pull/392
[#393]: https://github.com/RustCrypto/signatures/pull/393
[#394]: https://github.com/RustCrypto/signatures/pull/394
[#396]: https://github.com/RustCrypto/signatures/pull/396
[#397]: https://github.com/RustCrypto/signatures/pull/397
[#406]: https://github.com/RustCrypto/signatures/pull/406
[#408]: https://github.com/RustCrypto/signatures/pull/408
[#409]: https://github.com/RustCrypto/signatures/pull/409