### PR TITLE
ecdsa: add `hazmat::rfc6979_generate_k` function

### DIFF
--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -64,10 +64,6 @@ pub use elliptic_curve::{self, sec1::EncodedPoint, PrimeCurve};
 // Re-export the `signature` crate (and select types)
 pub use signature::{self, Error, Result};
 
-#[cfg(feature = "rfc6979")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rfc6979")))]
-pub use rfc6979;
-
 #[cfg(feature = "sign")]
 #[cfg_attr(docsrs, doc(cfg(feature = "sign")))]
 pub use crate::sign::SigningKey;


### PR DESCRIPTION
Adds a function for computing RFC6979's `k` generation algorithm specific to the ECDSA use case, i.e. handling type conversions prior to calling the `rfc6979` crate's implementation.