### PR TITLE
ecdsa: use `LinearCombination` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ name = "ecdsa"
 version = "0.13.1"
 dependencies = [
  "der 0.5.1",
- "elliptic-curve 0.11.3",
+ "elliptic-curve 0.11.4",
  "hex-literal",
  "rfc6979",
  "sha2",
@@ -221,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4c31bb557a73d165c838b614521f888112f9d4fcff7421d35646376dd17caf"
+checksum = "d9be7b065e66163fd97787a4cadc56625f948e22e914a0deab1d22b1f48fde25"
 dependencies = [
  "crypto-bigint 0.3.2",
  "der 0.5.1",

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-elliptic-curve = { version = "0.11.1", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.11.4", default-features = false, features = ["sec1"] }
 signature = { version = ">= 1.3.1, <1.5", default-features = false, features = ["rand-preview"] }
 
 # optional dependencies

--- a/ecdsa/src/verify.rs
+++ b/ecdsa/src/verify.rs
@@ -7,7 +7,7 @@ use crate::{
 use core::{cmp::Ordering, fmt::Debug};
 use elliptic_curve::{
     generic_array::ArrayLength,
-    ops::Reduce,
+    ops::{LinearCombination, Reduce},
     sec1::{self, EncodedPoint, FromEncodedPoint, ToEncodedPoint},
     AffinePoint, FieldSize, PointCompression, PrimeCurve, ProjectiveArithmetic, PublicKey, Scalar,
 };
@@ -79,7 +79,7 @@ impl<C> Copy for VerifyingKey<C> where C: PrimeCurve + ProjectiveArithmetic {}
 
 impl<C, D> DigestVerifier<D, Signature<C>> for VerifyingKey<C>
 where
-    C: PrimeCurve + ProjectiveArithmetic,
+    C: PrimeCurve + ProjectiveArithmetic + LinearCombination,
     D: Digest<OutputSize = FieldSize<C>>,
     AffinePoint<C>: VerifyPrimitive<C>,
     Scalar<C>: Reduce<C::UInt>,
@@ -93,7 +93,7 @@ where
 
 impl<C> Verifier<Signature<C>> for VerifyingKey<C>
 where
-    C: PrimeCurve + ProjectiveArithmetic + DigestPrimitive,
+    C: PrimeCurve + ProjectiveArithmetic + DigestPrimitive + LinearCombination,
     C::Digest: Digest<OutputSize = FieldSize<C>>,
     AffinePoint<C>: VerifyPrimitive<C>,
     Scalar<C>: Reduce<C::UInt>,


### PR DESCRIPTION
Use the trait introduced in RustCrypto/traits#833 to implement ECDSA verification.