### PR TITLE
ecdsa v0.13.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "der 0.5.1",
  "elliptic-curve 0.11.4",

--- a/ecdsa/CHANGELOG.md
+++ b/ecdsa/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.13.1 (2021-12-03)
+## 0.13.2 (2021-12-04)
+### Changed
+- Use `LinearCombination` trait ([#417])
+
+[#417]: https://github.com/RustCrypto/signatures/pull/417
+
+## 0.13.1 (2021-12-03) [YANKED]
 ### Added
 - `hazmat::rfc6979_generate_k` function ([#414])
 

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ecdsa"
-version = "0.13.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.13.2" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of the Elliptic Curve Digital Signature Algorithm
 (ECDSA) as specified in FIPS 186-4 (Digital Signature Standard)

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -38,7 +38,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/ecdsa/0.13.1"
+    html_root_url = "https://docs.rs/ecdsa/0.13.2"
 )]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
### Changed
- Use `LinearCombination` trait ([#417])

[#417]: https://github.com/RustCrypto/signatures/pull/417