### PR TITLE
ecdsa v0.13.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,23 +131,23 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ae02c7618ee05108cd86a0be2f5586d1f0d965bede7ecfd46815f1b860227"
+dependencies = [
+ "der",
+ "elliptic-curve",
+ "signature",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.13.4"
 dependencies = [
  "der",
  "elliptic-curve",
  "hex-literal",
  "rfc6979",
  "sha2",
- "signature",
-]
-
-[[package]]
-name = "ecdsa"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ae02c7618ee05108cd86a0be2f5586d1f0d965bede7ecfd46815f1b860227"
-dependencies = [
- "der",
- "elliptic-curve",
  "signature",
 ]
 
@@ -327,7 +327,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0e0c5310031b5d4528ac6534bccc1446c289ac45c47b277d5aa91089c5f74fa"
 dependencies = [
- "ecdsa 0.13.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ecdsa 0.13.3",
  "elliptic-curve",
  "sec1",
 ]
@@ -338,7 +338,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "755d8266e41f57bd8562ed9b6e93cdcf73ead050e1e8c3a27ea3871b6643a20c"
 dependencies = [
- "ecdsa 0.13.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ecdsa 0.13.3",
  "elliptic-curve",
  "sec1",
 ]
@@ -469,7 +469,7 @@ checksum = "80f9cf4a178de62d388e6502dae2101b37c1becf65227bf1210e6cf12dc633a3"
 dependencies = [
  "aead",
  "digest",
- "ecdsa 0.13.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ecdsa 0.13.3",
  "ed25519 1.3.0",
  "generic-array",
  "opaque-debug",

--- a/ecdsa/CHANGELOG.md
+++ b/ecdsa/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.13.4 (2022-01-06)
+### Added
+- `Signature::to_vec` ([#428])
+
+[#428]: https://github.com/RustCrypto/signatures/pull/428
+
 ## 0.13.3 (2021-12-04)
 ### Changed
 - Use revised `LinearCombination` trait ([#419])

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ecdsa"
-version = "0.13.3" # Also update html_root_url in lib.rs when bumping this
+version = "0.13.4" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust implementation of the Elliptic Curve Digital Signature Algorithm
 (ECDSA) as specified in FIPS 186-4 (Digital Signature Standard)

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -38,7 +38,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/ecdsa/0.13.3"
+    html_root_url = "https://docs.rs/ecdsa/0.13.4"
 )]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
### Added
- `Signature::to_vec` ([#428])

[#428]: https://github.com/RustCrypto/signatures/pull/428