### PR TITLE
ed25519: add SemVer policy

### DIFF
--- a/ed25519/README.md
+++ b/ed25519/README.md
@@ -41,6 +41,13 @@ ed25519 = ">=1, <1.4" # ed25519 1.4 requires MSRV 1.56
 Note that is our policy that we may change the MSRV in the future, but it will
 be accompanied by a minor version bump.
 
+## SemVer Policy
+
+- All on-by-default features of this library are covered by SemVer
+- MSRV is considered exempt from SemVer as noted above
+- The `pkcs8` crate is exempted as it's a pre-1.0 dependency, however, upgrades
+  to this crate will be accompanied by a minor version bump.
+
 ## License
 
 All crates licensed under either of


### PR DESCRIPTION
This is primarily to note that PKCS#8 support is exempted from SemVer and minor version updates to the `ed25519` crate may require an accompanying upgrade to the `pkcs8` crate.

Downstream dependencies who wish to avoid breakages should lock to a particular minor version.