### PR TITLE
rfc6979: add CI workflow

### DIFF
--- a/.github/workflows/ecdsa.yml
+++ b/.github/workflows/ecdsa.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - "ecdsa/**"
+      - "rfc6979/**"
       - "Cargo.*"
   push:
     branches: master

--- a/.github/workflows/rfc6979.yml
+++ b/.github/workflows/rfc6979.yml
@@ -1,0 +1,54 @@
+name: rfc6979
+on:
+  pull_request:
+    paths:
+      - "rfc6979/**"
+      - "Cargo.*"
+  push:
+    branches: master
+
+defaults:
+  run:
+    working-directory: rfc6979
+
+env:
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: "-Dwarnings"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - thumbv7em-none-eabi
+          - wasm32-unknown-unknown
+        rust:
+          - 1.57.0 # MSRV
+          - stable
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
+          override: true
+      - run: cargo build --no-default-features --release --target ${{ matrix.target }}
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.57.0 # MSRV
+          - stable
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - run: cargo check --all-features
+      - run: cargo test


### PR DESCRIPTION
It was previously missing one, and only vicariously tested via the `ecdsa` crate.