### PR TITLE
ecdsa: fix prerelease version pinning

### DIFF
--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-elliptic-curve = { version = "0.12.0-pre.0", default-features = false, features = ["digest", "sec1"] }
+elliptic-curve = { version = "=0.12.0-pre.1", default-features = false, features = ["digest", "sec1"] }
 signature = { version = "1.5", default-features = false, features = ["rand-preview"] }
 
 # optional dependencies
@@ -23,7 +23,7 @@ der = { version = "0.5", optional = true }
 rfc6979 = { version = "=0.2.0-pre.0", optional = true, path = "../rfc6979" }
 
 [dev-dependencies]
-elliptic-curve = { version = "0.12.0-pre.1", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "=0.12.0-pre.1", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 sha2 = { version = "0.10", default-features = false }
 


### PR DESCRIPTION
The `elliptic-curve` crate was pinned to inconsistent versions, and without the `=` predicate.

It should still resolve to the correct version for now. This fixes the inconsistency and pins it directly to specific prerelease versions.