### PR TITLE
ecdsa: have primitive methods accept field bytes + RFC6979 API

### DIFF
--- a/ecdsa/src/verify.rs
+++ b/ecdsa/src/verify.rs
@@ -96,8 +96,8 @@ where
     SignatureSize<C>: ArrayLength<u8>,
 {
     fn verify_digest(&self, msg_digest: D, signature: &Signature<C>) -> Result<()> {
-        let scalar = Scalar::<C>::from_be_digest_reduced(msg_digest);
-        self.inner.as_affine().verify_prehashed(scalar, signature)
+        let digest = msg_digest.finalize_fixed();
+        self.inner.as_affine().verify_prehashed(digest, signature)
     }
 }
 


### PR DESCRIPTION
Changes `SignPrimitive` and `VerifyPrimitive` to accept `FieldBytes<C>` rather than `Scalar<C>`, performing a reduction internally.

Also refactors the `hazmat::rfc6979_generate_k` free function as a method of `SignPrimitive`, i.e.:

```
SignPrimitive::try_sign_prehashed_rfc6979
```