### PR TITLE
ecdsa: bump `elliptic-curve` dependency to v0.12.0-pre.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,7 +152,7 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.14.0-pre.4"
+version = "0.14.0-pre.5"
 dependencies = [
  "der 0.6.0-pre.4",
  "elliptic-curve",
@@ -203,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.12.0-pre.3"
+version = "0.12.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55b80638677d1e9f252a11886f152183c92ccdaf1a4959569cc496f18c42e6e"
+checksum = "45cacccfb55f229c78b61a34857cf13a325c153f7aad7788a33ed33ca55969d7"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -437,13 +437,15 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.3.0-pre.3"
+version = "0.3.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "437ee1920f19c74e2b92630ba247f0716b52249464d97e76bf22ecb8ee75bbee"
+checksum = "0d00c76f7d9f461f9a12a1b67775709f4e1b214272923167195aeb6fc76e8a7a"
 dependencies = [
+ "base16ct",
  "der 0.6.0-pre.4",
  "generic-array",
  "pkcs8 0.9.0-pre.3",
+ "serdect",
  "subtle",
  "zeroize",
 ]

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecdsa"
-version = "0.14.0-pre.4"
+version = "0.14.0-pre.5"
 description = """
 Pure Rust implementation of the Elliptic Curve Digital Signature Algorithm
 (ECDSA) as specified in FIPS 186-4 (Digital Signature Standard)
@@ -15,7 +15,7 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-elliptic-curve = { version = "=0.12.0-pre.3", default-features = false, features = ["digest", "sec1"] }
+elliptic-curve = { version = "=0.12.0-pre.4", default-features = false, features = ["digest", "sec1"] }
 signature = { version = "1.5", default-features = false, features = ["rand-preview"] }
 
 # optional dependencies
@@ -24,7 +24,7 @@ rfc6979 = { version = "=0.2.0-pre.0", optional = true, path = "../rfc6979" }
 serdect = { version = "0.1", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
-elliptic-curve = { version = "=0.12.0-pre.3", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "=0.12.0-pre.4", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 sha2 = { version = "0.10", default-features = false }
 


### PR DESCRIPTION
Also cuts a v0.14.0-pre.5 prerelease of `ecdsa`