### PR TITLE
rfc6979 v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.2.0-pre.0"
+version = "0.2.0"
 dependencies = [
  "crypto-bigint",
  "hmac",

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -20,7 +20,7 @@ signature = { version = "1.5", default-features = false, features = ["rand-previ
 
 # optional dependencies
 der = { version = "0.6", optional = true }
-rfc6979 = { version = "=0.2.0-pre.0", optional = true, path = "../rfc6979" }
+rfc6979 = { version = "0.2", optional = true, path = "../rfc6979" }
 serdect = { version = "0.1", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]

--- a/rfc6979/CHANGELOG.md
+++ b/rfc6979/CHANGELOG.md
@@ -4,5 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2022-05-08)
+### Added
+- License files ([#447])
+
+### Changed
+- Bump `hmac` dependency to v0.12 ([#433])
+- Bump `crypto-bigint` dependency to v0.4 ([#469])
+
+[#433]: https://github.com/RustCrypto/signatures/pull/433
+[#447]: https://github.com/RustCrypto/signatures/pull/447
+[#469]: https://github.com/RustCrypto/signatures/pull/469
+
 ### 0.1.0 (2021-11-21)
 - Initial release

--- a/rfc6979/Cargo.toml
+++ b/rfc6979/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rfc6979"
-version = "0.2.0-pre.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.0"
 description = """
 Pure Rust implementation of RFC6979: Deterministic Usage of the
 Digital Signature Algorithm (DSA) and Elliptic Curve Digital Signature Algorithm (ECDSA)

--- a/rfc6979/src/lib.rs
+++ b/rfc6979/src/lib.rs
@@ -10,8 +10,7 @@
 #![warn(missing_docs, rust_2018_idioms)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
-    html_root_url = "https://docs.rs/rfc6979/0.1.0"
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
 )]
 
 use crypto_bigint::{ArrayEncoding, ByteArray, Integer};


### PR DESCRIPTION
### Added
- License files ([#447])

### Changed
- Bump `hmac` dependency to v0.12 ([#433])
- Bump `crypto-bigint` dependency to v0.4 ([#469])

[#433]: https://github.com/RustCrypto/signatures/pull/433
[#447]: https://github.com/RustCrypto/signatures/pull/447
[#469]: https://github.com/RustCrypto/signatures/pull/469