### PR TITLE
ecdsa v0.14.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "der",
  "elliptic-curve",

--- a/ecdsa/CHANGELOG.md
+++ b/ecdsa/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.14.1 (2022-05-09)
+### Added
+- `SignPrimitive::try_sign_digest_rfc6979` ([#475])
+- `VerifyPrimitive::verify_digest` ([#475])
+
+[#475]: https://github.com/RustCrypto/signatures/pull/475
+
 ## 0.14.0 (2022-05-09)
 ### Added
 - `VerifyingKey::from_affine` ([#452])

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecdsa"
-version = "0.14.0"
+version = "0.14.1"
 description = """
 Pure Rust implementation of the Elliptic Curve Digital Signature Algorithm
 (ECDSA) as specified in FIPS 186-4 (Digital Signature Standard)


### PR DESCRIPTION
### Added
- `SignPrimitive::try_sign_digest_rfc6979` ([#475])
- `VerifyPrimitive::verify_digest` ([#475])

[#475]: https://github.com/RustCrypto/signatures/pull/475