### PR TITLE
ed25519 v1.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "bincode",
  "ed25519-dalek",

--- a/ed25519/CHANGELOG.md
+++ b/ed25519/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.5.2 (2022-05-16)
+### Fixed
+- Overflow handling in `serde` deserializers ([#482])
+
+[#482]: https://github.com/RustCrypto/signatures/pull/482
+
 ## 1.5.1 (2022-05-15)
 ### Fixed
 - Use `TryInto` in `serde` deserializers ([#479])

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed25519"
-version = "1.5.1"
+version = "1.5.2"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """


### PR DESCRIPTION
### Fixed
- Overflow handling in `serde` deserializers ([#482])

[#482]: https://github.com/RustCrypto/signatures/pull/482