### PR TITLE
dsa: description and boilerplate fixups

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,6 @@ members = [
     "ed25519",
     "rfc6979"
 ]
+
+[profile.dev]
+opt-level = 2

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -1,10 +1,16 @@
 [package]
 name = "dsa"
 version = "0.0.1"
+description = """
+Pure Rust implementation of the Digital Signature Algorithm (DSA) as specified
+in FIPS 186-4 (Digital Signature Standard), providing RFC6979 deterministic
+signatures as well as support for added entropy
+"""
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 readme = "README.md"
-categories = ["cryptography"]
+repository = "https://github.com/RustCrypto/signatures/tree/master/dsa"
+categories = ["cryptography", "no-std"]
 keywords = ["crypto", "nist", "signature"]
 rust-version = "1.57"
 

--- a/dsa/src/sig.rs
+++ b/dsa/src/sig.rs
@@ -57,8 +57,8 @@ impl AsRef<[u8]> for Signature {
 impl<'a> Decode<'a> for Signature {
     fn decode<R: Reader<'a>>(reader: &mut R) -> der::Result<Self> {
         reader.sequence(|sequence| {
-            let r = sequence.decode::<UIntRef<'_>>()?;
-            let s = sequence.decode::<UIntRef<'_>>()?;
+            let r = UIntRef::decode(sequence)?;
+            let s = UIntRef::decode(sequence)?;
 
             let r = BigUint::from_bytes_be(r.as_bytes());
             let s = BigUint::from_bytes_be(s.as_bytes());

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -3,7 +3,8 @@ name = "ecdsa"
 version = "0.14.1"
 description = """
 Pure Rust implementation of the Elliptic Curve Digital Signature Algorithm
-(ECDSA) as specified in FIPS 186-4 (Digital Signature Standard)
+(ECDSA) as specified in FIPS 186-4 (Digital Signature Standard), providing
+RFC6979 deterministic signatures as well as support for added entropy
 """
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
- add description to Cargo.toml
- minor DER signature fixup
- set `opt-level = 2` at workspace level so tests run fast by default