### PR TITLE
dsa: rename key types to `SigningKey` and `VerifyingKey`

### DIFF
--- a/dsa/examples/export.rs
+++ b/dsa/examples/export.rs
@@ -1,21 +1,21 @@
-use dsa::{consts::DSA_2048_256, Components, PrivateKey};
+use dsa::{consts::DSA_2048_256, Components, SigningKey};
 use pkcs8::{EncodePrivateKey, EncodePublicKey, LineEnding};
 use std::{fs::File, io::Write};
 
 fn main() {
     let mut rng = rand::thread_rng();
     let components = Components::generate(&mut rng, DSA_2048_256);
-    let private_key = PrivateKey::generate(&mut rng, components);
-    let public_key = private_key.public_key();
+    let signing_key = SigningKey::generate(&mut rng, components);
+    let verifying_key = signing_key.verifying_key();
 
-    let private_key_bytes = private_key.to_pkcs8_pem(LineEnding::LF).unwrap();
-    let public_key_bytes = public_key.to_public_key_pem(LineEnding::LF).unwrap();
+    let signing_key_bytes = signing_key.to_pkcs8_pem(LineEnding::LF).unwrap();
+    let verifying_key_bytes = verifying_key.to_public_key_pem(LineEnding::LF).unwrap();
 
     let mut file = File::create("public.pem").unwrap();
-    file.write_all(public_key_bytes.as_bytes()).unwrap();
+    file.write_all(verifying_key_bytes.as_bytes()).unwrap();
     file.flush().unwrap();
 
     let mut file = File::create("private.pem").unwrap();
-    file.write_all(private_key_bytes.as_bytes()).unwrap();
+    file.write_all(signing_key_bytes.as_bytes()).unwrap();
     file.flush().unwrap();
 }

--- a/dsa/examples/generate.rs
+++ b/dsa/examples/generate.rs
@@ -1,8 +1,8 @@
-use dsa::{consts::DSA_2048_256, Components, PrivateKey};
+use dsa::{consts::DSA_2048_256, Components, SigningKey};
 
 fn main() {
     let mut rng = rand::thread_rng();
     let components = Components::generate(&mut rng, DSA_2048_256);
-    let private_key = PrivateKey::generate(&mut rng, components);
-    let _public_key = private_key.public_key();
+    let signing_key = SigningKey::generate(&mut rng, components);
+    let _verifying_key = signing_key.verifying_key();
 }

--- a/dsa/examples/sign.rs
+++ b/dsa/examples/sign.rs
@@ -1,5 +1,5 @@
 use digest::Digest;
-use dsa::{consts::DSA_2048_256, Components, PrivateKey};
+use dsa::{consts::DSA_2048_256, Components, SigningKey};
 use pkcs8::{EncodePrivateKey, EncodePublicKey, LineEnding};
 use sha1::Sha1;
 use signature::{RandomizedDigestSigner, Signature};
@@ -8,17 +8,17 @@ use std::{fs::File, io::Write};
 fn main() {
     let mut rng = rand::thread_rng();
     let components = Components::generate(&mut rng, DSA_2048_256);
-    let private_key = PrivateKey::generate(&mut rng, components);
-    let public_key = private_key.public_key();
+    let signing_key = SigningKey::generate(&mut rng, components);
+    let verifying_key = signing_key.verifying_key();
 
-    let signature = private_key
+    let signature = signing_key
         .sign_digest_with_rng(rand::thread_rng(), Sha1::new().chain_update(b"hello world"));
 
-    let private_key_bytes = private_key.to_pkcs8_pem(LineEnding::LF).unwrap();
-    let public_key_bytes = public_key.to_public_key_pem(LineEnding::LF).unwrap();
+    let signing_key_bytes = signing_key.to_pkcs8_pem(LineEnding::LF).unwrap();
+    let verifying_key_bytes = verifying_key.to_public_key_pem(LineEnding::LF).unwrap();
 
     let mut file = File::create("public.pem").unwrap();
-    file.write_all(public_key_bytes.as_bytes()).unwrap();
+    file.write_all(verifying_key_bytes.as_bytes()).unwrap();
     file.flush().unwrap();
 
     let mut file = File::create("signature.der").unwrap();
@@ -26,6 +26,6 @@ fn main() {
     file.flush().unwrap();
 
     let mut file = File::create("private.pem").unwrap();
-    file.write_all(private_key_bytes.as_bytes()).unwrap();
+    file.write_all(signing_key_bytes.as_bytes()).unwrap();
     file.flush().unwrap();
 }

--- a/dsa/src/generate/keypair.rs
+++ b/dsa/src/generate/keypair.rs
@@ -2,20 +2,20 @@
 //! Generate a DSA keypair
 //!
 
-use crate::{generate::components, Components, PrivateKey, PublicKey};
+use crate::{generate::components, Components, SigningKey, VerifyingKey};
 use num_bigint::{BigUint, RandBigInt};
 use num_traits::One;
 use rand::{CryptoRng, RngCore};
 
 /// Generate a new keypair
 #[inline]
-pub fn keypair<R>(rng: &mut R, components: Components) -> PrivateKey
+pub fn keypair<R>(rng: &mut R, components: Components) -> SigningKey
 where
     R: CryptoRng + RngCore + ?Sized,
 {
     let x = rng.gen_biguint_range(&BigUint::one(), components.q());
     let y = components::public(&components, &x);
 
-    let public_key = PublicKey::from_components(components, y);
-    PrivateKey::from_components(public_key, x)
+    let verifying_key = VerifyingKey::from_components(components, y);
+    SigningKey::from_components(verifying_key, x)
 }

--- a/dsa/src/generate/secret_number.rs
+++ b/dsa/src/generate/secret_number.rs
@@ -2,7 +2,7 @@
 //! Generate a per-message secret number
 //!
 
-use crate::{Components, PrivateKey};
+use crate::{Components, SigningKey};
 use alloc::{vec, vec::Vec};
 use core::cmp::min;
 use digest::{
@@ -42,7 +42,7 @@ fn reduce_hash(q: &BigUint, hash: &[u8]) -> Vec<u8> {
 ///
 /// Secret number k and its modular multiplicative inverse with q
 #[inline]
-pub fn secret_number_rfc6979<D>(private_key: &PrivateKey, hash: &[u8]) -> (BigUint, BigUint)
+pub fn secret_number_rfc6979<D>(signing_key: &SigningKey, hash: &[u8]) -> (BigUint, BigUint)
 where
     D: CoreProxy + FixedOutput,
     D::Core: BlockSizeUser
@@ -55,11 +55,11 @@ where
     <D::Core as BlockSizeUser>::BlockSize: IsLess<U256>,
     Le<<D::Core as BlockSizeUser>::BlockSize, U256>: NonZero,
 {
-    let q = private_key.public_key().components().q();
+    let q = signing_key.verifying_key().components().q();
     let k_size = q.bits() / 8;
     let hash = reduce_hash(q, hash);
 
-    let mut x_bytes = private_key.x().to_bytes_be();
+    let mut x_bytes = signing_key.x().to_bytes_be();
     let mut hmac = HmacDrbg::<D>::new(&x_bytes, &hash, &[]);
     x_bytes.zeroize();
 

--- a/dsa/src/lib.rs
+++ b/dsa/src/lib.rs
@@ -11,17 +11,17 @@
 //! Generate a DSA keypair
 //!
 //! ```
-//! # use dsa::{consts::DSA_2048_256, Components, PrivateKey};
+//! # use dsa::{consts::DSA_2048_256, Components, SigningKey};
 //! let mut csprng = rand::thread_rng();
 //! let components = Components::generate(&mut csprng, DSA_2048_256);
-//! let private_key = PrivateKey::generate(&mut csprng, components);
-//! let public_key = private_key.public_key();
+//! let signing_key = SigningKey::generate(&mut csprng, components);
+//! let verifying_key = signing_key.verifying_key();
 //! ```
 //!
 //! Create keypair from existing components
 //!
 //! ```
-//! # use dsa::{Components, PrivateKey, PublicKey};
+//! # use dsa::{Components, SigningKey, VerifyingKey};
 //! # use num_bigint::BigUint;
 //! # use num_traits::One;
 //! # let read_common_parameters = || (BigUint::one(), BigUint::one(), BigUint::one());
@@ -31,10 +31,10 @@
 //! let components = Components::from_components(p, q, g);
 //!
 //! let x = read_public_component();
-//! let public_key = PublicKey::from_components(components, x);
+//! let verifying_key = VerifyingKey::from_components(components, x);
 //!
 //! let y = read_private_component();
-//! let private_key = PrivateKey::from_components(public_key, y);
+//! let signing_key = SigningKey::from_components(verifying_key, y);
 //! ```
 //!
 
@@ -43,10 +43,9 @@ extern crate alloc;
 /// DSA object identifier as defined by RFC-3279, section 2.3.2
 const DSA_OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.10040.4.1");
 
-pub use self::components::Components;
-pub use self::private_key::PrivateKey;
-pub use self::public_key::PublicKey;
-pub use self::sig::Signature;
+pub use crate::{
+    components::Components, sig::Signature, signing_key::SigningKey, verifying_key::VerifyingKey,
+};
 
 pub use pkcs8;
 pub use signature;
@@ -58,9 +57,9 @@ use pkcs8::spki::ObjectIdentifier;
 
 mod components;
 mod generate;
-mod private_key;
-mod public_key;
 mod sig;
+mod signing_key;
+mod verifying_key;
 
 /// Returns a `BigUint` with the value 2
 #[inline]

--- a/dsa/src/verifying_key.rs
+++ b/dsa/src/verifying_key.rs
@@ -13,10 +13,10 @@ use pkcs8::{
 };
 use signature::DigestVerifier;
 
-/// DSA public key
+/// DSA public key.
 #[derive(Clone, PartialEq, PartialOrd)]
 #[must_use]
-pub struct PublicKey {
+pub struct VerifyingKey {
     /// common components
     components: Components,
 
@@ -24,9 +24,9 @@ pub struct PublicKey {
     y: BigUint,
 }
 
-opaque_debug::implement!(PublicKey);
+opaque_debug::implement!(VerifyingKey);
 
-impl PublicKey {
+impl VerifyingKey {
     /// Construct a new public key from the common components and the public component
     ///
     /// These values are not getting verified for validity
@@ -85,7 +85,7 @@ impl PublicKey {
     }
 }
 
-impl<D> DigestVerifier<D, Signature> for PublicKey
+impl<D> DigestVerifier<D, Signature> for VerifyingKey
 where
     D: Digest,
 {
@@ -104,7 +104,7 @@ where
     }
 }
 
-impl EncodePublicKey for PublicKey {
+impl EncodePublicKey for VerifyingKey {
     fn to_public_key_der(&self) -> spki::Result<spki::Document> {
         let parameters = self.components.to_vec()?;
         let parameters = AnyRef::from_der(&parameters)?;
@@ -117,16 +117,15 @@ impl EncodePublicKey for PublicKey {
         let y = UIntRef::new(&y_bytes)?;
         let public_key = y.to_vec()?;
 
-        let public_key_info = SubjectPublicKeyInfo {
+        SubjectPublicKeyInfo {
             algorithm,
             subject_public_key: &public_key,
-        };
-
-        public_key_info.try_into()
+        }
+        .try_into()
     }
 }
 
-impl<'a> TryFrom<SubjectPublicKeyInfo<'a>> for PublicKey {
+impl<'a> TryFrom<SubjectPublicKeyInfo<'a>> for VerifyingKey {
     type Error = spki::Error;
 
     fn try_from(value: SubjectPublicKeyInfo<'a>) -> Result<Self, Self::Error> {
@@ -142,4 +141,4 @@ impl<'a> TryFrom<SubjectPublicKeyInfo<'a>> for PublicKey {
     }
 }
 
-impl DecodePublicKey for PublicKey {}
+impl DecodePublicKey for VerifyingKey {}

--- a/dsa/tests/private_key.rs
+++ b/dsa/tests/private_key.rs
@@ -3,7 +3,7 @@
 #![allow(deprecated)]
 
 use digest::Digest;
-use dsa::{consts::DSA_1024_160, Components, PrivateKey};
+use dsa::{consts::DSA_1024_160, Components, SigningKey};
 use num_bigint::BigUint;
 use num_traits::Zero;
 use pkcs8::{DecodePrivateKey, EncodePrivateKey, LineEnding};
@@ -12,61 +12,61 @@ use signature::{DigestVerifier, RandomizedDigestSigner};
 
 const OPENSSL_PEM_PRIVATE_KEY: &str = include_str!("pems/private.pem");
 
-fn generate_keypair() -> PrivateKey {
+fn generate_keypair() -> SigningKey {
     let mut rng = rand::thread_rng();
     let components = Components::generate(&mut rng, DSA_1024_160);
-    PrivateKey::generate(&mut rng, components)
+    SigningKey::generate(&mut rng, components)
 }
 
 #[test]
-fn decode_encode_openssl_private_key() {
-    let private_key = PrivateKey::from_pkcs8_pem(OPENSSL_PEM_PRIVATE_KEY)
+fn decode_encode_openssl_signing_key() {
+    let signing_key = SigningKey::from_pkcs8_pem(OPENSSL_PEM_PRIVATE_KEY)
         .expect("Failed to decode PEM encoded OpenSSL key");
-    assert!(private_key.is_valid());
+    assert!(signing_key.is_valid());
 
-    let reencoded_private_key = private_key
+    let reencoded_signing_key = signing_key
         .to_pkcs8_pem(LineEnding::LF)
         .expect("Failed to encode private key into PEM representation");
 
-    assert_eq!(*reencoded_private_key, OPENSSL_PEM_PRIVATE_KEY);
+    assert_eq!(*reencoded_signing_key, OPENSSL_PEM_PRIVATE_KEY);
 }
 
 #[test]
-fn encode_decode_private_key() {
-    let private_key = generate_keypair();
-    let encoded_private_key = private_key.to_pkcs8_pem(LineEnding::LF).unwrap();
-    let decoded_private_key = PrivateKey::from_pkcs8_pem(&encoded_private_key).unwrap();
+fn encode_decode_signing_key() {
+    let signing_key = generate_keypair();
+    let encoded_signing_key = signing_key.to_pkcs8_pem(LineEnding::LF).unwrap();
+    let decoded_signing_key = SigningKey::from_pkcs8_pem(&encoded_signing_key).unwrap();
 
-    assert_eq!(private_key, decoded_private_key);
+    assert_eq!(signing_key, decoded_signing_key);
 }
 
 #[test]
 fn sign_and_verify() {
     const DATA: &[u8] = b"SIGN AND VERIFY THOSE BYTES";
 
-    let private_key = generate_keypair();
-    let public_key = private_key.public_key();
+    let signing_key = generate_keypair();
+    let verifying_key = signing_key.verifying_key();
 
     let signature =
-        private_key.sign_digest_with_rng(rand::thread_rng(), Sha1::new().chain_update(DATA));
+        signing_key.sign_digest_with_rng(rand::thread_rng(), Sha1::new().chain_update(DATA));
 
-    assert!(public_key
+    assert!(verifying_key
         .verify_digest(Sha1::new().chain_update(DATA), &signature)
         .is_ok());
 }
 
 #[test]
 fn verify_validity() {
-    let private_key = generate_keypair();
-    let components = private_key.public_key().components();
+    let signing_key = generate_keypair();
+    let components = signing_key.verifying_key().components();
 
     assert!(
-        BigUint::zero() < *private_key.x() && private_key.x() < components.q(),
+        BigUint::zero() < *signing_key.x() && signing_key.x() < components.q(),
         "Requirement 0<x<q not met"
     );
     assert_eq!(
-        *private_key.public_key().y(),
-        components.g().modpow(private_key.x(), components.p()),
+        *signing_key.verifying_key().y(),
+        components.g().modpow(signing_key.x(), components.p()),
         "Requirement y=(g^x)%p not met"
     );
 }

--- a/dsa/tests/public_key.rs
+++ b/dsa/tests/public_key.rs
@@ -2,49 +2,49 @@
 // But we want to use those small key sizes for fast tests
 #![allow(deprecated)]
 
-use dsa::{consts::DSA_1024_160, Components, PrivateKey, PublicKey};
+use dsa::{consts::DSA_1024_160, Components, SigningKey, VerifyingKey};
 use num_bigint::BigUint;
 use num_traits::One;
 use pkcs8::{DecodePublicKey, EncodePublicKey, LineEnding};
 
 const OPENSSL_PEM_PUBLIC_KEY: &str = include_str!("pems/public.pem");
 
-fn generate_public_key() -> PublicKey {
+fn generate_verifying_key() -> VerifyingKey {
     let mut rng = rand::thread_rng();
     let components = Components::generate(&mut rng, DSA_1024_160);
-    let private_key = PrivateKey::generate(&mut rng, components);
+    let signing_key = SigningKey::generate(&mut rng, components);
 
-    private_key.public_key().clone()
+    signing_key.verifying_key().clone()
 }
 
 #[test]
-fn decode_encode_openssl_public_key() {
-    let public_key = PublicKey::from_public_key_pem(OPENSSL_PEM_PUBLIC_KEY)
+fn decode_encode_openssl_verifying_key() {
+    let verifying_key = VerifyingKey::from_public_key_pem(OPENSSL_PEM_PUBLIC_KEY)
         .expect("Failed to decode PEM encoded OpenSSL public key");
-    assert!(public_key.is_valid());
+    assert!(verifying_key.is_valid());
 
-    let reencoded_public_key = public_key
+    let reencoded_verifying_key = verifying_key
         .to_public_key_pem(LineEnding::LF)
         .expect("Failed to encode public key into PEM representation");
 
-    assert_eq!(reencoded_public_key, OPENSSL_PEM_PUBLIC_KEY);
+    assert_eq!(reencoded_verifying_key, OPENSSL_PEM_PUBLIC_KEY);
 }
 
 #[test]
-fn encode_decode_public_key() {
-    let public_key = generate_public_key();
-    let encoded_public_key = public_key.to_public_key_pem(LineEnding::LF).unwrap();
-    let decoded_public_key = PublicKey::from_public_key_pem(&encoded_public_key).unwrap();
+fn encode_decode_verifying_key() {
+    let verifying_key = generate_verifying_key();
+    let encoded_verifying_key = verifying_key.to_public_key_pem(LineEnding::LF).unwrap();
+    let decoded_verifying_key = VerifyingKey::from_public_key_pem(&encoded_verifying_key).unwrap();
 
-    assert_eq!(public_key, decoded_public_key);
+    assert_eq!(verifying_key, decoded_verifying_key);
 }
 
 #[test]
-fn validate_public_key() {
-    let public_key = generate_public_key();
-    let p = public_key.components().p();
-    let q = public_key.components().q();
+fn validate_verifying_key() {
+    let verifying_key = generate_verifying_key();
+    let p = verifying_key.components().p();
+    let q = verifying_key.components().q();
 
     // Taken from the parameter validation from bouncy castle
-    assert_eq!(public_key.y().modpow(q, p), BigUint::one());
+    assert_eq!(verifying_key.y().modpow(q, p), BigUint::one());
 }


### PR DESCRIPTION
For consistency with the `ecdsa` crate: see [`ecdsa::SigningKey`](https://docs.rs/ecdsa/latest/ecdsa/struct.SigningKey.html) and [`ecdsa::VerifyingKey`](https://docs.rs/ecdsa/latest/ecdsa/struct.VerifyingKey.html).

This naming scheme follows the philosophy that in a digital signature scheme, it's clearer to name keys after their roles.

DSA admittedly benefits less than other schemes where there are other potential algorithms that can be implemented using the same core mathematics which share the same key representations.

cc @aumetra