### PR TITLE
dsa+ecdsa: add security warnings to README.md(s)

### DIFF
--- a/dsa/README.md
+++ b/dsa/README.md
@@ -17,6 +17,16 @@
 This crate provides an implementation of DSA in pure Rust.  
 It utilises the [`signature`] crate to provide an interface for creating and verifying signatures.  
 
+## ⚠️ Security Warning
+
+The DSA implementation contained in this crate has never been
+independently audited for security.
+
+It may contain timing variabilities or other sidechannels which could
+potentially disclose secret information, including secret keys.
+
+USE AT YOUR OWN RISK!
+
 ## Minimum Supported Rust Version
 
 This crate requires **Rust 1.57** at a minimum.

--- a/ecdsa/README.md
+++ b/ecdsa/README.md
@@ -25,6 +25,19 @@ ways:
   generic, interoperable way by leveraging [`ecdsa::Signature`] with the
   [`signature::Signer`] and [`signature::Verifier`] traits.
 
+## ⚠️ Security Warning
+
+The ECDSA implementation contained in this crate has never been independently
+audited for security!
+
+This crate contains a generic implementation of ECDSA which must be
+instantiated using a separate crate providing a concrete implementation of
+arithmetic for a particular curve. It's possible timing variability can exist
+in concrete curve implementations, and thus this crate's security can only be
+properly assessed for a specific elliptic curve.
+
+USE AT YOUR OWN RISK!
+
 ## Minimum Supported Rust Version
 
 This crate requires **Rust 1.57** at a minimum.


### PR DESCRIPTION
Note that neither crate has been audited by a third party, and that there may potentially be timing variabilities or other sidechannels in the implementations.