### PR TITLE
dsa v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "dsa"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "digest 0.10.3",
  "num-bigint-dig",

--- a/dsa/CHANGELOG.md
+++ b/dsa/CHANGELOG.md
@@ -4,21 +4,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-
+## 0.3.0 (2022-05-21)
 ### Added
-
-- Internal sanity check validating the `r` and `s` components of the signature
-- Public `OID` constant representing the object identifier defined in RFC-3279, section 2.3.2 
+- Internal sanity check validating the `r` and `s` components of the signature ([#489])
+- Public `OID` constant representing the object identifier defined in RFC3279 § 2.3.2 ([#489]) 
 
 ### Changed
-
-- `Components::generate` now takes an `KeySize` struct instead of an `(u32, u32)` tuple
-- `Components::from_components`, `SigningKey::from_components` and `VerifyingKey::from_components` are now fallible and validate themselves upon creation
+- `Components::generate` now takes an `KeySize` struct instead of an `(u32, u3e2)` tuple ([#489])
+- `Components::from_components`, `SigningKey::from_components` and `VerifyingKey::from_components`
+  are now fallible and validate themselves upon creation ([#489])
 
 ### Removed
+- `is_valid` methods on `Components`, `SigningKey` and `VerifyingKey`: constructor now ensures that
+  invalid forms are unrepresentable ([#489])
 
-- Removed `is_valid` functions on `Components`, `SigningKey` and `VerifyingKey` (successful construction/deserialisation now implies validity)
+[#489]: https://github.com/RustCrypto/signatures/pull/489
 
 ## 0.2.0 (2022-05-16)
-- Initial release
+- Initial RustCrypto crate release
+
+## 0.1.0 (2018-07-13)
+- Pre-RustCrypto release

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsa"
-version = "0.2.0"
+version = "0.3.0"
 description = """
 Pure Rust implementation of the Digital Signature Algorithm (DSA) as specified
 in FIPS 186-4 (Digital Signature Standard), providing RFC6979 deterministic
@@ -24,9 +24,6 @@ rand = { version = "0.8.5", default-features = false }
 rfc6979 = { version = "0.2.0", path = "../rfc6979" }
 signature = { version = ">= 1.5.0, < 1.6.0", default-features = false, features = ["digest-preview", "rand-preview"] }
 zeroize = { version = "1.5.5", default-features = false }
-
-[features]
-default = []
 
 [dev-dependencies]
 pkcs8 = { version = "0.9.0", default-features = false, features = ["pem"] }


### PR DESCRIPTION
### Added
- Internal sanity check validating the `r` and `s` components of the signature ([#489])
- Public `OID` constant representing the object identifier defined in RFC3279 § 2.3.2 ([#489]) 

### Changed
- `Components::generate` now takes an `KeySize` struct instead of an `(u32, u3e2)` tuple ([#489])
- `Components::from_components`, `SigningKey::from_components` and `VerifyingKey::from_components` are now fallible and validate themselves upon creation ([#489])

### Removed
- `is_valid` methods on `Components`, `SigningKey` and `VerifyingKey`: constructor now ensures that invalid forms are unrepresentable ([#489])

[#489]: https://github.com/RustCrypto/signatures/pull/489