### PR TITLE
ecdsa v0.14.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "der",
  "elliptic-curve",

--- a/ecdsa/CHANGELOG.md
+++ b/ecdsa/CHANGELOG.md
@@ -4,14 +4,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.14.1 (2022-05-09)
+## 0.14.2 (2022-06-17)
+### Added
+- Security warning in README.md ([#486])
+
+### Changed
+- Use `serdect` for `Signature` types ([#497])
+
+[#486]: https://github.com/RustCrypto/signatures/pull/486
+[#497]: https://github.com/RustCrypto/signatures/pull/497
+
+## 0.14.1 (2022-05-09) [YANKED]
 ### Added
 - `SignPrimitive::try_sign_digest_rfc6979` ([#475])
 - `VerifyPrimitive::verify_digest` ([#475])
 
 [#475]: https://github.com/RustCrypto/signatures/pull/475
 
-## 0.14.0 (2022-05-09)
+## 0.14.0 (2022-05-09) [YANKED]
 ### Added
 - `VerifyingKey::from_affine` ([#452])
 

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecdsa"
-version = "0.14.1"
+version = "0.14.2"
 description = """
 Pure Rust implementation of the Elliptic Curve Digital Signature Algorithm
 (ECDSA) as specified in FIPS 186-4 (Digital Signature Standard), providing

--- a/ecdsa/README.md
+++ b/ecdsa/README.md
@@ -20,6 +20,7 @@ ways:
 - Generic implementation of ECDSA usable with the following crates:
   - [`k256`] (secp256k1)
   - [`p256`] (NIST P-256)
+  - [`p384`] (NIST P-384)
 - Other crates which provide their own complete implementations of ECDSA can
   also leverage the types from this crate to export ECDSA functionality in a
   generic, interoperable way by leveraging [`ecdsa::Signature`] with the
@@ -49,8 +50,8 @@ version bump.
 
 All crates licensed under either of
 
- * [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
- * [MIT license](http://opensource.org/licenses/MIT)
+- [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+- [MIT license](http://opensource.org/licenses/MIT)
 
 at your option.
 
@@ -87,5 +88,6 @@ dual licensed as above, without any additional terms or conditions.
 [`ecdsa::Signature`]: https://docs.rs/ecdsa/latest/ecdsa/struct.Signature.html
 [`k256`]: https://docs.rs/k256
 [`p256`]: https://docs.rs/p256
+[`p384`]: https://docs.rs/p256
 [`signature::Signer`]: https://docs.rs/signature/latest/signature/trait.Signer.html
 [`signature::Verifier`]: https://docs.rs/signature/latest/signature/trait.Verifier.html


### PR DESCRIPTION
### Added
- Security warning in README.md ([#486])

### Changed
- Use `serdect` for `Signature` types ([#497])

[#486]: https://github.com/RustCrypto/signatures/pull/486
[#497]: https://github.com/RustCrypto/signatures/pull/497