### PR TITLE
rfc6979: use `SimpleHmac` to implement `HmacDrbg`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "dsa"
-version = "0.3.0"
+version = "0.4.0-pre"
 dependencies = [
  "digest 0.10.3",
  "num-bigint-dig",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.2.0"
+version = "0.3.0-pre"
 dependencies = [
  "crypto-bigint",
  "hmac",

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsa"
-version = "0.3.0"
+version = "0.4.0-pre"
 description = """
 Pure Rust implementation of the Digital Signature Algorithm (DSA) as specified
 in FIPS 186-4 (Digital Signature Standard), providing RFC6979 deterministic
@@ -21,7 +21,7 @@ num-traits = { version = "0.2.15", default-features = false }
 opaque-debug = "0.3.0"
 pkcs8 = { version = "0.9.0", default-features = false, features = ["alloc"] }
 rand = { version = "0.8.5", default-features = false }
-rfc6979 = { version = "0.2.0", path = "../rfc6979" }
+rfc6979 = { version = "=0.3.0-pre", path = "../rfc6979" }
 signature = { version = ">= 1.5.0, < 1.6.0", default-features = false, features = ["digest-preview", "rand-preview"] }
 zeroize = { version = "1.5.5", default-features = false }
 

--- a/dsa/src/generate/secret_number.rs
+++ b/dsa/src/generate/secret_number.rs
@@ -5,13 +5,7 @@
 use crate::{Components, SigningKey};
 use alloc::{vec, vec::Vec};
 use core::cmp::min;
-use digest::{
-    block_buffer::Eager,
-    consts::U256,
-    core_api::{BlockSizeUser, BufferKindUser, CoreProxy, FixedOutputCore},
-    typenum::{IsLess, Le, NonZero},
-    FixedOutput, HashMarker, OutputSizeUser,
-};
+use digest::{core_api::BlockSizeUser, Digest, FixedOutputReset};
 use num_bigint::{BigUint, ModInverse, RandBigInt};
 use num_traits::{One, Zero};
 use rand::{CryptoRng, RngCore};
@@ -44,16 +38,7 @@ fn reduce_hash(q: &BigUint, hash: &[u8]) -> Vec<u8> {
 #[inline]
 pub fn secret_number_rfc6979<D>(signing_key: &SigningKey, hash: &[u8]) -> (BigUint, BigUint)
 where
-    D: CoreProxy + FixedOutput,
-    D::Core: BlockSizeUser
-        + BufferKindUser<BufferKind = Eager>
-        + Clone
-        + Default
-        + FixedOutputCore
-        + HashMarker
-        + OutputSizeUser<OutputSize = D::OutputSize>,
-    <D::Core as BlockSizeUser>::BlockSize: IsLess<U256>,
-    Le<<D::Core as BlockSizeUser>::BlockSize, U256>: NonZero,
+    D: Digest + BlockSizeUser + FixedOutputReset,
 {
     let q = signing_key.verifying_key().components().q();
     let k_size = q.bits() / 8;

--- a/dsa/src/signing_key.rs
+++ b/dsa/src/signing_key.rs
@@ -4,13 +4,7 @@
 
 use crate::{sig::Signature, Components, VerifyingKey, OID};
 use core::cmp::min;
-use digest::{
-    block_buffer::Eager,
-    consts::U256,
-    core_api::{BlockSizeUser, BufferKindUser, CoreProxy, FixedOutputCore},
-    typenum::{IsLess, Le, NonZero},
-    Digest, FixedOutput, HashMarker, OutputSizeUser,
-};
+use digest::{core_api::BlockSizeUser, Digest, FixedOutputReset};
 use num_bigint::BigUint;
 use num_traits::Zero;
 use pkcs8::{
@@ -100,16 +94,7 @@ impl SigningKey {
 
 impl<D> DigestSigner<D, Signature> for SigningKey
 where
-    D: Digest + CoreProxy + FixedOutput,
-    D::Core: BlockSizeUser
-        + BufferKindUser<BufferKind = Eager>
-        + Clone
-        + Default
-        + FixedOutputCore
-        + HashMarker
-        + OutputSizeUser<OutputSize = D::OutputSize>,
-    <D::Core as BlockSizeUser>::BlockSize: IsLess<U256>,
-    Le<<D::Core as BlockSizeUser>::BlockSize, U256>: NonZero,
+    D: Digest + BlockSizeUser + FixedOutputReset,
 {
     fn try_sign_digest(&self, digest: D) -> Result<Signature, signature::Error> {
         let hash = digest.finalize_fixed();

--- a/dsa/tests/deterministic.rs
+++ b/dsa/tests/deterministic.rs
@@ -1,10 +1,4 @@
-use digest::{
-    block_buffer::Eager,
-    consts::U256,
-    core_api::{BlockSizeUser, BufferKindUser, CoreProxy, FixedOutputCore},
-    typenum::{IsLess, Le, NonZero},
-    Digest, FixedOutput, HashMarker, OutputSizeUser,
-};
+use digest::{core_api::BlockSizeUser, Digest, FixedOutputReset};
 use dsa::{Components, Signature, SigningKey, VerifyingKey};
 use num_bigint::BigUint;
 use num_traits::Num;
@@ -110,16 +104,7 @@ fn dsa_2048_signing_key() -> SigningKey {
 /// Generate a signature given the unhashed message and a private key
 fn generate_signature<D>(signing_key: SigningKey, data: &[u8]) -> Signature
 where
-    D: Digest + CoreProxy + FixedOutput,
-    D::Core: BlockSizeUser
-        + BufferKindUser<BufferKind = Eager>
-        + Clone
-        + Default
-        + FixedOutputCore
-        + HashMarker
-        + OutputSizeUser<OutputSize = D::OutputSize>,
-    <D::Core as BlockSizeUser>::BlockSize: IsLess<U256>,
-    Le<<D::Core as BlockSizeUser>::BlockSize, U256>: NonZero,
+    D: Digest + BlockSizeUser + FixedOutputReset,
 {
     signing_key.sign_digest(<D as Digest>::new().chain_update(data))
 }
@@ -127,16 +112,7 @@ where
 /// Generate a signature using the 1024-bit DSA key
 fn generate_1024_signature<D>(data: &[u8]) -> Signature
 where
-    D: Digest + CoreProxy + FixedOutput,
-    D::Core: BlockSizeUser
-        + BufferKindUser<BufferKind = Eager>
-        + Clone
-        + Default
-        + FixedOutputCore
-        + HashMarker
-        + OutputSizeUser<OutputSize = D::OutputSize>,
-    <D::Core as BlockSizeUser>::BlockSize: IsLess<U256>,
-    Le<<D::Core as BlockSizeUser>::BlockSize, U256>: NonZero,
+    D: Digest + BlockSizeUser + FixedOutputReset,
 {
     generate_signature::<D>(dsa_1024_signing_key(), data)
 }
@@ -144,16 +120,7 @@ where
 /// Generate a signature using the 2048-bit DSA key
 fn generate_2048_signature<D>(data: &[u8]) -> Signature
 where
-    D: Digest + CoreProxy + FixedOutput,
-    D::Core: BlockSizeUser
-        + BufferKindUser<BufferKind = Eager>
-        + Clone
-        + Default
-        + FixedOutputCore
-        + HashMarker
-        + OutputSizeUser<OutputSize = D::OutputSize>,
-    <D::Core as BlockSizeUser>::BlockSize: IsLess<U256>,
-    Le<<D::Core as BlockSizeUser>::BlockSize, U256>: NonZero,
+    D: Digest + BlockSizeUser + FixedOutputReset,
 {
     generate_signature::<D>(dsa_2048_signing_key(), data)
 }

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecdsa"
-version = "0.14.1"
+version = "0.14.2"
 description = """
 Pure Rust implementation of the Elliptic Curve Digital Signature Algorithm
 (ECDSA) as specified in FIPS 186-4 (Digital Signature Standard), providing
@@ -21,7 +21,7 @@ signature = { version = "1.5", default-features = false, features = ["rand-previ
 
 # optional dependencies
 der = { version = "0.6", optional = true }
-rfc6979 = { version = "0.2", optional = true, path = "../rfc6979" }
+rfc6979 = { version = "=0.3.0-pre", optional = true, path = "../rfc6979" }
 serdect = { version = "0.1", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]

--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -41,12 +41,7 @@ use signature::digest::FixedOutput;
 #[cfg(all(feature = "rfc6979"))]
 use {
     elliptic_curve::ScalarCore,
-    signature::digest::{
-        block_buffer::Eager,
-        core_api::{BlockSizeUser, BufferKindUser, CoreProxy, FixedOutputCore},
-        generic_array::typenum::{IsLess, Le, NonZero, U256},
-        HashMarker, OutputSizeUser,
-    },
+    signature::digest::{core_api::BlockSizeUser, FixedOutputReset},
 };
 
 /// Try to sign the given prehashed message using ECDSA.
@@ -126,16 +121,7 @@ where
     where
         Self: From<ScalarCore<C>>,
         C::UInt: for<'a> From<&'a Self>,
-        D: CoreProxy + FixedOutput<OutputSize = FieldSize<C>>,
-        D::Core: BlockSizeUser
-            + BufferKindUser<BufferKind = Eager>
-            + Clone
-            + Default
-            + FixedOutputCore
-            + HashMarker
-            + OutputSizeUser<OutputSize = D::OutputSize>,
-        <D::Core as BlockSizeUser>::BlockSize: IsLess<U256>,
-        Le<<D::Core as BlockSizeUser>::BlockSize, U256>: NonZero,
+        D: Digest + BlockSizeUser + FixedOutput<OutputSize = FieldSize<C>> + FixedOutputReset,
     {
         let x = C::UInt::from(self);
         let k = rfc6979::generate_k::<D, C::UInt>(&x, &C::ORDER, &z, ad);
@@ -157,16 +143,7 @@ where
     where
         Self: From<ScalarCore<C>>,
         C::UInt: for<'a> From<&'a Self>,
-        D: CoreProxy + FixedOutput<OutputSize = FieldSize<C>>,
-        D::Core: BlockSizeUser
-            + BufferKindUser<BufferKind = Eager>
-            + Clone
-            + Default
-            + FixedOutputCore
-            + HashMarker
-            + OutputSizeUser<OutputSize = D::OutputSize>,
-        <D::Core as BlockSizeUser>::BlockSize: IsLess<U256>,
-        Le<<D::Core as BlockSizeUser>::BlockSize, U256>: NonZero,
+        D: Digest + BlockSizeUser + FixedOutput<OutputSize = FieldSize<C>> + FixedOutputReset,
     {
         self.try_sign_prehashed_rfc6979::<D>(msg_digest.finalize_fixed(), ad)
     }

--- a/ecdsa/src/sign.rs
+++ b/ecdsa/src/sign.rs
@@ -16,12 +16,7 @@ use elliptic_curve::{
     FieldBytes, FieldSize, NonZeroScalar, PrimeCurve, ProjectiveArithmetic, Scalar, SecretKey,
 };
 use signature::{
-    digest::{
-        block_buffer::Eager,
-        core_api::{BlockSizeUser, BufferKindUser, CoreProxy, FixedOutputCore},
-        generic_array::typenum::{IsLess, Le, NonZero, U256},
-        Digest, FixedOutput, HashMarker, OutputSizeUser,
-    },
+    digest::{core_api::BlockSizeUser, Digest, FixedOutput, FixedOutputReset},
     rand_core::{CryptoRng, RngCore},
     DigestSigner, RandomizedDigestSigner, RandomizedSigner, Signer,
 };
@@ -173,16 +168,7 @@ impl<C, D> DigestSigner<D, Signature<C>> for SigningKey<C>
 where
     C: PrimeCurve + ProjectiveArithmetic,
     C::UInt: for<'a> From<&'a Scalar<C>>,
-    D: CoreProxy + Digest + FixedOutput<OutputSize = FieldSize<C>>,
-    D::Core: BlockSizeUser
-        + BufferKindUser<BufferKind = Eager>
-        + Clone
-        + Default
-        + FixedOutputCore
-        + HashMarker
-        + OutputSizeUser<OutputSize = D::OutputSize>,
-    <D::Core as BlockSizeUser>::BlockSize: IsLess<U256>,
-    Le<<D::Core as BlockSizeUser>::BlockSize, U256>: NonZero,
+    D: Digest + BlockSizeUser + FixedOutput<OutputSize = FieldSize<C>> + FixedOutputReset,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + Reduce<C::UInt> + SignPrimitive<C>,
     SignatureSize<C>: ArrayLength<u8>,
 {
@@ -211,16 +197,7 @@ impl<C, D> RandomizedDigestSigner<D, Signature<C>> for SigningKey<C>
 where
     C: PrimeCurve + ProjectiveArithmetic,
     C::UInt: for<'a> From<&'a Scalar<C>>,
-    D: CoreProxy + Digest + FixedOutput<OutputSize = FieldSize<C>>,
-    D::Core: BlockSizeUser
-        + BufferKindUser<BufferKind = Eager>
-        + Clone
-        + Default
-        + FixedOutputCore
-        + HashMarker
-        + OutputSizeUser<OutputSize = D::OutputSize>,
-    <D::Core as BlockSizeUser>::BlockSize: IsLess<U256>,
-    Le<<D::Core as BlockSizeUser>::BlockSize, U256>: NonZero,
+    D: Digest + BlockSizeUser + FixedOutput<OutputSize = FieldSize<C>> + FixedOutputReset,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + Reduce<C::UInt> + SignPrimitive<C>,
     SignatureSize<C>: ArrayLength<u8>,
 {

--- a/rfc6979/Cargo.toml
+++ b/rfc6979/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rfc6979"
-version = "0.2.0"
+version = "0.3.0-pre"
 description = """
 Pure Rust implementation of RFC6979: Deterministic Usage of the
 Digital Signature Algorithm (DSA) and Elliptic Curve Digital Signature Algorithm (ECDSA)


### PR DESCRIPTION
`SimpleHmac` allows for significantly simpler bounds on generic digest types versus `Hmac`.