### PR TITLE
rfc6979 v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.3.0-pre"
+version = "0.3.0"
 dependencies = [
  "crypto-bigint",
  "hmac",

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -15,19 +15,19 @@ keywords = ["crypto", "nist", "signature"]
 rust-version = "1.57"
 
 [dependencies]
-digest = "0.10.3"
-num-bigint = { package = "num-bigint-dig", version = "0.8.1", default-features = false, features = ["prime", "rand", "zeroize"] }
-num-traits = { version = "0.2.15", default-features = false }
-opaque-debug = "0.3.0"
-pkcs8 = { version = "0.9.0", default-features = false, features = ["alloc"] }
-rand = { version = "0.8.5", default-features = false }
-rfc6979 = { version = "=0.3.0-pre", path = "../rfc6979" }
-signature = { version = ">= 1.5.0, < 1.6.0", default-features = false, features = ["digest-preview", "rand-preview"] }
-zeroize = { version = "1.5.5", default-features = false }
+digest = "0.10"
+num-bigint = { package = "num-bigint-dig", version = "0.8", default-features = false, features = ["prime", "rand", "zeroize"] }
+num-traits = { version = "0.2", default-features = false }
+opaque-debug = "0.3"
+pkcs8 = { version = "0.9", default-features = false, features = ["alloc"] }
+rand = { version = "0.8", default-features = false }
+rfc6979 = { version = "0.3", path = "../rfc6979" }
+signature = { version = ">= 1.5, < 1.6", default-features = false, features = ["digest-preview", "rand-preview"] }
+zeroize = { version = "1.5", default-features = false }
 
 [dev-dependencies]
-pkcs8 = { version = "0.9.0", default-features = false, features = ["pem"] }
-rand = "0.8.5"
-rand_chacha = "0.3.1"
-sha1 = "0.10.1"
-sha2 = "0.10.2"
+pkcs8 = { version = "0.9", default-features = false, features = ["pem"] }
+rand = "0.8"
+rand_chacha = "0.3"
+sha1 = "0.10"
+sha2 = "0.10"

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -21,7 +21,7 @@ signature = { version = "1.5", default-features = false, features = ["rand-previ
 
 # optional dependencies
 der = { version = "0.6", optional = true }
-rfc6979 = { version = "=0.3.0-pre", optional = true, path = "../rfc6979" }
+rfc6979 = { version = "0.3", optional = true, path = "../rfc6979" }
 serdect = { version = "0.1", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]

--- a/rfc6979/CHANGELOG.md
+++ b/rfc6979/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2022-06-26)
+### Changed
+- Use `SimpleHmac` to implement `HmacDrbg` ([#499])
+
+[#499]: https://github.com/RustCrypto/signatures/pull/499
+
 ## 0.2.0 (2022-05-08)
 ### Added
 - License files ([#447])

--- a/rfc6979/Cargo.toml
+++ b/rfc6979/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rfc6979"
-version = "0.3.0-pre"
+version = "0.3.0"
 description = """
 Pure Rust implementation of RFC6979: Deterministic Usage of the
 Digital Signature Algorithm (DSA) and Elliptic Curve Digital Signature Algorithm (ECDSA)


### PR DESCRIPTION
### Changed
- Use `SimpleHmac` to implement `HmacDrbg` ([#499])

[#499]: https://github.com/RustCrypto/signatures/pull/499