### PR TITLE
Tighten `signature` version requirement of `ecdsa` crate

### DIFF
--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.57"
 
 [dependencies]
 elliptic-curve = { version = "0.12", default-features = false, features = ["digest", "sec1"] }
-signature = { version = "1.5", default-features = false, features = ["rand-preview"] }
+signature = { version = ">= 1.5, < 1.6", default-features = false, features = ["rand-preview"] }
 
 # optional dependencies
 der = { version = "0.6", optional = true }


### PR DESCRIPTION
Tightens the version requirement of the `signature` crate to `>= 1.5, < 1.6` (same as the `dsa` crate) to avoid a potential semver breakage.

Closes #507 