### PR TITLE
ecdsa: add `ZeroizeOnDrop` marker for `SigningKey`

### DIFF
--- a/ecdsa/src/sign.rs
+++ b/ecdsa/src/sign.rs
@@ -12,7 +12,7 @@ use elliptic_curve::{
     group::ff::PrimeField,
     ops::{Invert, Reduce},
     subtle::{Choice, ConstantTimeEq, CtOption},
-    zeroize::Zeroize,
+    zeroize::{Zeroize, ZeroizeOnDrop},
     FieldBytes, FieldSize, NonZeroScalar, PrimeCurve, ProjectiveArithmetic, Scalar, SecretKey,
 };
 use signature::{
@@ -117,6 +117,14 @@ where
     fn drop(&mut self) {
         self.inner.zeroize();
     }
+}
+
+impl<C> ZeroizeOnDrop for SigningKey<C>
+where
+    C: PrimeCurve + ProjectiveArithmetic,
+    Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + Reduce<C::UInt> + SignPrimitive<C>,
+    SignatureSize<C>: ArrayLength<u8>,
+{
 }
 
 /// Constant-time comparison


### PR DESCRIPTION
`ecdsa` depends on `elliptic-curve` 0.12, which depends on `zeroize` 1.5, so the trait should be safe to use.