### PR TITLE
rsa: add crate with generic RSA signature traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,6 +498,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa-signature"
+version = "0.1.0"
+dependencies = [
+ "digest 0.10.3",
+ "signature",
+]
+
+[[package]]
 name = "sec1"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,8 @@ members = [
     "dsa",
     "ecdsa",
     "ed25519",
-    "rfc6979"
+    "rfc6979",
+    "rsa",
 ]
 
 [profile.dev]

--- a/rsa/Cargo.toml
+++ b/rsa/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "rsa-signature"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+digest = { version = "0.10.3" }
+signature = { version = "1.5", default-features = false, features = ["rand-preview"] }
+
+[features]
+default = []
+alloc = []
+sign = []
+std = ["alloc", "signature/std"]
+verify = []
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/rsa/README.md
+++ b/rsa/README.md
@@ -1,0 +1,52 @@
+# [RustCrypto]: RSA
+
+[![crate][crate-image]][crate-link]
+[![Docs][docs-image]][docs-link]
+[![Build Status][build-image]][build-link]
+![Apache2/MIT licensed][license-image]
+![MSRV][rustc-image]
+[![Project Chat][chat-image]][chat-link]
+
+[Rivest-Shamir-Adleman cryptosystem (RSA)][1] as specified in
+[RFC 8017][2] (PKCS #1: RSA Cryptography Specifications Version 2.2).
+
+## About
+
+This crate provides generic RSA support which can be used in the following
+ways:
+
+- Generic implementation of ECDSA usable with the following crates:
+  - [`rsa`] (rsa)
+- Other crates which provide their own complete implementations of RSA can
+  also leverage the types from this crate to export RSA functionality in a
+  generic, interoperable way by leveraging [`rsa-signature::Signature`] with the
+  [`signature::Signer`] and [`signature::Verifier`] traits.
+
+[//]: # (badges)
+
+[crate-image]: https://buildstats.info/crate/rsa-signature
+[crate-link]: https://crates.io/crates/rsa-signature
+[docs-image]: https://docs.rs/rsa-signature/badge.svg
+[docs-link]: https://docs.rs/rsa-signature/
+[build-image]: https://github.com/RustCrypto/signatures/actions/workflows/rsa-signature.yml/badge.svg
+[build-link]: https://github.com/RustCrypto/signatures/actions/workflows/rsa-signature.yml
+[license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.57+-blue.svg
+[chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
+[chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260048-signatures
+
+[//]: # (links)
+
+[RustCrypto]: https://github.com/RustCrypto
+
+[//]: # (footnotes)
+
+[1]: https://en.wikipedia.org/wiki/RSA_(cryptosystem)
+[2]: https://www.rfc-editor.org/rfc/rfc8017
+
+[//]: # (docs.rs definitions)
+
+[`rsa`]: https://doc.rs/rsa
+[`rsa-signature::Signature`]: https://docs.rs/rsa-signature/latest/rsa-signature/struct.Signature.html
+[`signature::Signer`]: https://docs.rs/signature/latest/signature/trait.Signer.html
+[`signature::Verifier`]: https://docs.rs/signature/latest/signature/trait.Verifier.html

--- a/rsa/src/lib.rs
+++ b/rsa/src/lib.rs
@@ -1,0 +1,123 @@
+#![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/8f1a9894/logo.svg"
+)]
+#![forbid(unsafe_code, clippy::unwrap_used)]
+#![warn(missing_docs, rust_2018_idioms)]
+
+#[cfg(feature = "sign")]
+mod sign;
+
+#[cfg(feature = "verify")]
+mod verify;
+
+use core::fmt::{Debug, Display, Formatter, LowerHex, UpperHex};
+use signature::{Result, Signature as SignSignature};
+
+#[cfg(feature = "sign")]
+pub use crate::sign::*;
+
+#[cfg(feature = "verify")]
+pub use crate::verify::*;
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
+#[cfg(not(feature = "alloc"))]
+/// Limit ourselves to RSA16384 as an unsane boundary
+const MAX_RSA_SIZE: usize = 16384 / 8;
+
+#[cfg(not(feature = "alloc"))]
+/// Generic RSA Signature implementation
+#[derive(Clone, Copy)]
+pub struct Signature {
+    len: usize,
+    bytes: [u8; MAX_RSA_SIZE],
+}
+
+#[cfg(not(feature = "alloc"))]
+impl signature::Signature for Signature {
+    fn from_bytes(bytes: &[u8]) -> Result<Self> {
+        let mut s = Signature {
+            len: bytes.len(),
+            bytes: [0; MAX_RSA_SIZE],
+        };
+        s.bytes[0..bytes.len()].copy_from_slice(bytes);
+        Ok(s)
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        &self.bytes[..self.len]
+    }
+}
+
+#[cfg(feature = "alloc")]
+/// Generic RSA Signature implementation
+#[derive(Clone)]
+pub struct Signature {
+    bytes: Vec<u8>,
+}
+
+#[cfg(feature = "alloc")]
+impl signature::Signature for Signature {
+    fn from_bytes(bytes: &[u8]) -> Result<Self> {
+        let mut s = Signature {
+            bytes: bytes.into(),
+        };
+        s.bytes[0..bytes.len()].copy_from_slice(bytes);
+        Ok(s)
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        &self.bytes.as_slice()
+    }
+}
+
+impl PartialEq for Signature {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_bytes() == other.as_bytes()
+    }
+}
+
+impl Eq for Signature {}
+
+impl Debug for Signature {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> core::result::Result<(), core::fmt::Error> {
+        fmt.debug_list().entries(self.as_bytes().iter()).finish()
+    }
+}
+
+impl AsRef<[u8]> for Signature {
+    fn as_ref(&self) -> &[u8] {
+        &self.as_bytes()
+    }
+}
+
+impl LowerHex for Signature {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        for byte in self.as_bytes() {
+            write!(f, "{:02x}", byte)?;
+        }
+        Ok(())
+    }
+}
+
+impl UpperHex for Signature {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        for byte in self.as_bytes() {
+            write!(f, "{:02X}", byte)?;
+        }
+        Ok(())
+    }
+}
+
+impl Display for Signature {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:X}", self)
+    }
+}

--- a/rsa/src/sign.rs
+++ b/rsa/src/sign.rs
@@ -1,0 +1,15 @@
+//! RSA signing key.
+
+use crate::Signature;
+use digest::DynDigest;
+use signature::{RandomizedSigner, Signer};
+
+/// RSA Signing key using PKCS1v15 padding
+pub trait PKCS1v15SigningKey: Signer<Signature> {}
+/// RSA Verifying key using PKCS1v15 padding
+pub trait PKCS1v15BlindedSigningKey: RandomizedSigner<Signature> {}
+
+/// RSA Signing key using PSS padding
+pub trait PSSSigningKey<D: DynDigest>: RandomizedSigner<Signature> {}
+/// RSA Verifying key using PSS padding
+pub trait PSSBlindedSigningKey<D: DynDigest>: RandomizedSigner<Signature> {}

--- a/rsa/src/verify.rs
+++ b/rsa/src/verify.rs
@@ -1,0 +1,11 @@
+//! RSA verifying key.
+
+use crate::Signature;
+use digest::DynDigest;
+use signature::Verifier;
+
+/// RSA Verifying key using PKCS1v15 padding
+pub trait PKCS1v15VerifyingKey: Verifier<Signature> {}
+
+/// RSA Verifying key using PSS padding
+pub trait PSSVerifyingKey<D: DynDigest>: Verifier<Signature> {}


### PR DESCRIPTION
Add crate declaring generic RSA traits used for PKCS#1 v1.5 and PSS
signatures.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>