### PR TITLE
dsa: Allow signature v1.6.x

### DIFF
--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -22,7 +22,7 @@ opaque-debug = "0.3"
 pkcs8 = { version = "0.9", default-features = false, features = ["alloc"] }
 rand = { version = "0.8", default-features = false }
 rfc6979 = { version = "0.3", path = "../rfc6979" }
-signature = { version = ">= 1.5, < 1.6", default-features = false, features = ["digest-preview", "rand-preview"] }
+signature = { version = ">= 1.5, < 1.7", default-features = false, features = ["digest-preview", "rand-preview"] }
 zeroize = { version = "1.5", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
Adjust the `signature` version requirement of the `dsa` crate to include v1.6.x.

`digest`, `rand_core`, as well as the MSRV have remained compatible.