### PR TITLE
dsa v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "dsa"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "digest 0.10.3",
  "num-bigint-dig",

--- a/dsa/CHANGELOG.md
+++ b/dsa/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2022-08-15)
+### Changed
+- Bump `rfc6979` to v0.3 ([#500])
+- Allow `signature` v1.6 ([#513])
+
+[#500]: https://github.com/RustCrypto/signatures/pull/500
+[#513]: https://github.com/RustCrypto/signatures/pull/513
+
 ## 0.3.0 (2022-05-21)
 ### Added
 - Internal sanity check validating the `r` and `s` components of the signature ([#489])

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsa"
-version = "0.4.0-pre"
+version = "0.4.0"
 description = """
 Pure Rust implementation of the Digital Signature Algorithm (DSA) as specified
 in FIPS 186-4 (Digital Signature Standard), providing RFC6979 deterministic


### PR DESCRIPTION
### Changed
- Bump `rfc6979` to v0.3 ([#500])
- Allow `signature` v1.6 ([#513])

[#500]: https://github.com/RustCrypto/signatures/pull/500
[#513]: https://github.com/RustCrypto/signatures/pull/513