### PR TITLE
ecdsa v0.14.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "der",
  "elliptic-curve",

--- a/ecdsa/CHANGELOG.md
+++ b/ecdsa/CHANGELOG.md
@@ -4,7 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.14.3 (2022-06-26)
+## 0.14.4 (2022-08-15)
+### Added
+- Impl `EncodePublicKey` for `VerifyingKey` ([#505])
+- ZeroizeOnDrop marker for SigningKey ([#509])
+
+### Changed
+- Restrict `signature` version to v1.5-v1.6 ([#508], [#512])
+
+[#505]: https://github.com/RustCrypto/signatures/pull/505
+[#508]: https://github.com/RustCrypto/signatures/pull/508
+[#509]: https://github.com/RustCrypto/signatures/pull/509
+[#512]: https://github.com/RustCrypto/signatures/pull/512
+
+## 0.14.3 (2022-06-26) [YANKED]
 ### Changed
 - Simplified digest trait bounds ([#499])
 - Bump `rfc6979` dependency to v0.3 ([#500])

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecdsa"
-version = "0.14.3"
+version = "0.14.4"
 description = """
 Pure Rust implementation of the Elliptic Curve Digital Signature Algorithm
 (ECDSA) as specified in FIPS 186-4 (Digital Signature Standard), providing


### PR DESCRIPTION
### Added
- Impl `EncodePublicKey` for `VerifyingKey` ([#505])
- ZeroizeOnDrop marker for SigningKey ([#509])

### Changed
- Restrict `signature` version to v1.5-v1.6 ([#508], [#512])

[#505]: https://github.com/RustCrypto/signatures/pull/505
[#508]: https://github.com/RustCrypto/signatures/pull/508
[#509]: https://github.com/RustCrypto/signatures/pull/509
[#512]: https://github.com/RustCrypto/signatures/pull/512