### PR TITLE
ed25519: Fix compilation of `pem` feature

### DIFF
--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -35,7 +35,7 @@ rand_core = { version = "0.5", features = ["std"] }
 [features]
 default = ["std"]
 alloc = ["pkcs8/alloc"]
-pem = ["pkcs8/pem"]
+pem = ["alloc", "pkcs8/pem"]
 serde_bytes = ["serde", "serde_bytes_crate", "std"]
 std = ["signature/std"]
 


### PR DESCRIPTION
The `ed25519` crate fails to compile with only the `pem` feature flag since the current implementation depends on the `alloc` crate (via `alloc::string::{String, ToString}`).

The `pkcs8`'s `pem` feature already depends on the `alloc` crate anyway, so enabling the `ed25519`'s `alloc` feature together with the `pem` feature should be fine.