### PR TITLE
ecdsa: add `SigningKey::as_nonzero_scalar`/`VerifyingKey::as_affine`

### DIFF
--- a/ecdsa/src/sign.rs
+++ b/ecdsa/src/sign.rs
@@ -74,6 +74,22 @@ where
         Ok(Self { inner })
     }
 
+    /// Serialize this [`SigningKey`] as bytes
+    pub fn to_bytes(&self) -> FieldBytes<C> {
+        self.inner.to_repr()
+    }
+
+    /// Borrow the secret [`NonZeroScalar`] value for this key.
+    ///
+    /// # ⚠️ Warning
+    ///
+    /// This value is key material.
+    ///
+    /// Please treat it with the care it deserves!
+    pub fn as_nonzero_scalar(&self) -> &NonZeroScalar<C> {
+        &self.inner
+    }
+
     /// Get the [`VerifyingKey`] which corresponds to this [`SigningKey`]
     #[cfg(feature = "verify")]
     #[cfg_attr(docsrs, doc(cfg(feature = "verify")))]
@@ -81,11 +97,6 @@ where
         VerifyingKey {
             inner: PublicKey::from_secret_scalar(&self.inner),
         }
-    }
-
-    /// Serialize this [`SigningKey`] as bytes
-    pub fn to_bytes(&self) -> FieldBytes<C> {
-        self.inner.to_repr()
     }
 }
 

--- a/ecdsa/src/verify.rs
+++ b/ecdsa/src/verify.rs
@@ -84,6 +84,22 @@ where
     pub fn to_encoded_point(&self, compress: bool) -> EncodedPoint<C> {
         self.inner.to_encoded_point(compress)
     }
+
+    /// Borrow the inner [`AffinePoint`] for this public key.
+    pub fn as_affine(&self) -> &AffinePoint<C> {
+        self.inner.as_affine()
+    }
+}
+
+impl<C> AsRef<AffinePoint<C>> for VerifyingKey<C>
+where
+    C: PrimeCurve + ProjectiveArithmetic,
+    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
+    FieldSize<C>: sec1::ModulusSize,
+{
+    fn as_ref(&self) -> &AffinePoint<C> {
+        self.as_affine()
+    }
 }
 
 impl<C> Copy for VerifyingKey<C> where C: PrimeCurve + ProjectiveArithmetic {}


### PR DESCRIPTION
Adds borrowing accessors for the inner `NonZeroScalar` and `AffinePoint` within `SigningKey` and `VerifyingKey` respectively.

These mirror the corresponding inherent methods on `SecretKey` and `PublicKey` as defined in the `elliptic-curve` crate.