### PR TITLE
ecdsa v0.14.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "der",
  "elliptic-curve",

--- a/ecdsa/CHANGELOG.md
+++ b/ecdsa/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.14.5 (2022-09-06)
+### Added
+- Impl `EncodePrivateKey` for `SigningKey` ([#523])
+- `SigningKey::as_nonzero_scalar` ([#528])
+- `VerifyingKey::as_affine` ([#528])
+- `RecoveryId::from_byte` ([#531])
+
+### Changed
+- Make `RecoveryId` methods `const fn` ([#529])
+
+[#523]: https://github.com/RustCrypto/signatures/pull/523
+[#528]: https://github.com/RustCrypto/signatures/pull/528
+[#529]: https://github.com/RustCrypto/signatures/pull/529
+[#531]: https://github.com/RustCrypto/signatures/pull/531
+
 ## 0.14.4 (2022-08-15)
 ### Added
 - Impl `EncodePublicKey` for `VerifyingKey` ([#505])

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecdsa"
-version = "0.14.4"
+version = "0.14.5"
 description = """
 Pure Rust implementation of the Elliptic Curve Digital Signature Algorithm
 (ECDSA) as specified in FIPS 186-4 (Digital Signature Standard), providing


### PR DESCRIPTION
### Added
- Impl `EncodePrivateKey` for `SigningKey` ([#523])
- `SigningKey::as_nonzero_scalar` ([#528])
- `VerifyingKey::as_affine` ([#528])
- `RecoveryId::from_byte` ([#531])

### Changed
- Make `RecoveryId` methods `const fn` ([#529])

[#523]: https://github.com/RustCrypto/signatures/pull/523
[#528]: https://github.com/RustCrypto/signatures/pull/528
[#529]: https://github.com/RustCrypto/signatures/pull/529
[#531]: https://github.com/RustCrypto/signatures/pull/531