### PR TITLE
ecdsa: impl `signature::hazmat::{PrehashSigner, PrehashVerifier}`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,9 +574,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0ea32af43239f0d353a7dd75a22d94c329c8cdaafdcb4c1c1335aa10c298a4a"
+checksum = "e90531723b08e4d6d71b791108faf51f03e1b4a7784f96b2b87f852ebc247228"
 dependencies = [
  "digest 0.10.3",
  "rand_core 0.6.3",

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.57"
 
 [dependencies]
 elliptic-curve = { version = "0.12", default-features = false, features = ["digest", "sec1"] }
-signature = { version = ">=1.5, <1.7", default-features = false, features = ["rand-preview"] }
+signature = { version = ">=1.6.1, <1.7", default-features = false, features = ["hazmat-preview", "rand-preview"] }
 
 # optional dependencies
 der = { version = "0.6", optional = true }


### PR DESCRIPTION
Adds "hazmat" trait impls to `SigningKey` and `VerifyingKey` respectively which allow computing signatures over raw message digests. See RustCrypto/traits#1099.

The implementation allows digests which are shorter or longer than the field size of the curve, using zero-padding if the digest is too short, and truncating if it's too long. The minimum digest size is set to half of the curve's field size.