### PR TITLE
ecdsa: impl `Keypair` for `SigningKey`

### DIFF
--- a/ecdsa/src/verify.rs
+++ b/ecdsa/src/verify.rs
@@ -136,7 +136,7 @@ where
 impl<C> Verifier<Signature<C>> for VerifyingKey<C>
 where
     C: PrimeCurve + ProjectiveArithmetic + DigestPrimitive,
-    C::Digest: Digest + FixedOutput<OutputSize = FieldSize<C>>,
+    C::Digest: FixedOutput<OutputSize = FieldSize<C>>,
     AffinePoint<C>: VerifyPrimitive<C>,
     Scalar<C>: Reduce<C::UInt>,
     SignatureSize<C>: ArrayLength<u8>,


### PR DESCRIPTION
This trait describes the relationship between signing and verifying keys, allowing the latter to be accessed from the former in a trait-based manner.