### PR TITLE
ecdsa v0.14.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.14.7"
+version = "0.14.8"
 dependencies = [
  "der",
  "elliptic-curve",

--- a/ecdsa/CHANGELOG.md
+++ b/ecdsa/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.14.8 (2022-09-27)
+### Added
+- Impl `From<SigningKey>` for `SecretKey` ([#548])
+
+### Fixed
+- Prehash must receive zero-pads on left ([#547])
+
+[#547]: https://github.com/RustCrypto/signatures/pull/547
+[#548]: https://github.com/RustCrypto/signatures/pull/548
+
 ## 0.14.7 (2022-09-15)
 ### Changed
 - Relax `Keypair` bounds ([#539])

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecdsa"
-version = "0.14.7"
+version = "0.14.8"
 description = """
 Pure Rust implementation of the Elliptic Curve Digital Signature Algorithm
 (ECDSA) as specified in FIPS 186-4 (Digital Signature Standard), providing


### PR DESCRIPTION
### Added
- Impl `From<SigningKey>` for `SecretKey` ([#548])

### Fixed
- Prehash must receive zero-pads on left ([#547])

[#547]: https://github.com/RustCrypto/signatures/pull/547
[#548]: https://github.com/RustCrypto/signatures/pull/548