### PR TITLE
v0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "dsa"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "digest 0.10.5",
  "num-bigint-dig",

--- a/dsa/CHANGELOG.md
+++ b/dsa/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.1 (2022-10-11)
+### Added
+- Re-export `BigUint` ([#553])
+
+[#553]: https://github.com/RustCrypto/signatures/pull/553
+
 ## 0.4.0 (2022-08-15)
 ### Changed
 - Bump `rfc6979` to v0.3 ([#500])

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsa"
-version = "0.4.0"
+version = "0.4.1"
 description = """
 Pure Rust implementation of the Digital Signature Algorithm (DSA) as specified
 in FIPS 186-4 (Digital Signature Standard), providing RFC6979 deterministic


### PR DESCRIPTION
### Added
- Re-export `BigUint` ([#553])

[#553]: https://github.com/RustCrypto/signatures/pull/553