### PR TITLE
dsa: expose signing and verifying of prehashed hash value

### DIFF
--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -22,6 +22,7 @@ opaque-debug = "0.3"
 pkcs8 = { version = "0.9", default-features = false, features = ["alloc"] }
 rand = { version = "0.8", default-features = false }
 rfc6979 = { version = "0.3", path = "../rfc6979" }
+sha2 = "0.10"
 signature = { version = ">= 1.6.4, < 1.7", default-features = false, features = ["digest-preview", "rand-preview", "hazmat-preview"] }
 zeroize = { version = "1.5", default-features = false }
 
@@ -30,4 +31,3 @@ pkcs8 = { version = "0.9", default-features = false, features = ["pem"] }
 rand = "0.8"
 rand_chacha = "0.3"
 sha1 = "0.10"
-sha2 = "0.10"

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -22,7 +22,7 @@ opaque-debug = "0.3"
 pkcs8 = { version = "0.9", default-features = false, features = ["alloc"] }
 rand = { version = "0.8", default-features = false }
 rfc6979 = { version = "0.3", path = "../rfc6979" }
-signature = { version = ">= 1.5, < 1.7", default-features = false, features = ["digest-preview", "rand-preview"] }
+signature = { version = ">= 1.6.4, < 1.7", default-features = false, features = ["digest-preview", "rand-preview", "hazmat-preview"] }
 zeroize = { version = "1.5", default-features = false }
 
 [dev-dependencies]

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -22,7 +22,7 @@ opaque-debug = "0.3"
 pkcs8 = { version = "0.9", default-features = false, features = ["alloc"] }
 rand = { version = "0.8", default-features = false }
 rfc6979 = { version = "0.3", path = "../rfc6979" }
-sha2 = "0.10"
+sha2 = { version = "0.10", default-features = false }
 signature = { version = ">= 1.6.4, < 1.7", default-features = false, features = ["digest-preview", "rand-preview", "hazmat-preview"] }
 zeroize = { version = "1.5", default-features = false }
 

--- a/dsa/src/signing_key.rs
+++ b/dsa/src/signing_key.rs
@@ -86,6 +86,7 @@ impl SigningKey {
 
         let n = (q.bits() / 8) as usize;
         let block_size = hash.len(); // Hash function output size
+        // FIXME shouldn't `hash.len() < n` be a hard error (bad API use)? According to DSA documentation: "An approved hash function, as specified in FIPS 180, shall be used during the generation of key pairs and digital signatures. When used during the generation of an RSA key pair (as specified in this Standard), the length in bits of the hash function output block shall meet or exceed the security strength associated with the bit length of the modulus n (see SP 800-57)."
 
         let z_len = min(n, block_size);
         let z = BigUint::from_bytes_be(&hash[..z_len]);

--- a/dsa/src/signing_key.rs
+++ b/dsa/src/signing_key.rs
@@ -66,6 +66,16 @@ impl SigningKey {
         &self.x
     }
 
+    /// `sign_hash` signs a pre-hashed value.
+    #[must_use]
+    pub fn sign_hash<D>(&self, hash: &[u8]) -> Option<Signature>
+    where
+        D: Digest + BlockSizeUser + FixedOutputReset,
+    {
+        let k_kinv = crate::generate::secret_number_rfc6979::<D>(&self, hash);
+        self.sign_prehashed(k_kinv, hash)
+    }
+
     /// Sign some pre-hashed data
     fn sign_prehashed(&self, (k, inv_k): (BigUint, BigUint), hash: &[u8]) -> Option<Signature> {
         let components = self.verifying_key().components();

--- a/dsa/src/signing_key.rs
+++ b/dsa/src/signing_key.rs
@@ -77,7 +77,7 @@ impl SigningKey {
 
         let r = g.modpow(&k, p) % q;
 
-        let n = (q.bits() / 8) as usize;
+        let n = q.bits() / 8;
         let block_size = hash.len(); // Hash function output size
 
         let z_len = min(n, block_size);

--- a/dsa/src/signing_key.rs
+++ b/dsa/src/signing_key.rs
@@ -97,7 +97,7 @@ impl SigningKey {
 
 impl PrehashSigner<Signature> for SigningKey {
     fn sign_prehash(&self, prehash: &[u8]) -> Result<Signature, signature::Error> {
-        let k_kinv = crate::generate::secret_number_rfc6979::<D>(&self, prehash);
+        let k_kinv = crate::generate::secret_number_rfc6979::<sha2::Sha256>(&self, prehash);
         self.sign_prehashed(k_kinv, prehash)
             .ok_or_else(signature::Error::new)
     }
@@ -106,7 +106,7 @@ impl PrehashSigner<Signature> for SigningKey {
 impl RandomizedPrehashSigner<Signature> for SigningKey {
     fn sign_prehash_with_rng(
         &self,
-        rng: impl CryptoRng + RngCore,
+        mut rng: impl CryptoRng + RngCore,
         prehash: &[u8],
     ) -> Result<Signature, signature::Error> {
         let components = self.verifying_key.components();

--- a/dsa/src/signing_key.rs
+++ b/dsa/src/signing_key.rs
@@ -97,7 +97,7 @@ impl SigningKey {
 
 impl PrehashSigner<Signature> for SigningKey {
     fn sign_prehash(&self, prehash: &[u8]) -> Result<Signature, signature::Error> {
-        let k_kinv = crate::generate::secret_number_rfc6979::<sha2::Sha256>(&self, prehash);
+        let k_kinv = crate::generate::secret_number_rfc6979::<sha2::Sha256>(self, prehash);
         self.sign_prehashed(k_kinv, prehash)
             .ok_or_else(signature::Error::new)
     }

--- a/dsa/src/signing_key.rs
+++ b/dsa/src/signing_key.rs
@@ -84,9 +84,12 @@ impl SigningKey {
 
         let r = g.modpow(&k, p) % q;
 
-        let n = (q.bits() / 8) as usize;
+        let n = q.bits() / 8;
         let block_size = hash.len(); // Hash function output size
-        // FIXME shouldn't `hash.len() < n` be a hard error (bad API use)? According to DSA documentation: "An approved hash function, as specified in FIPS 180, shall be used during the generation of key pairs and digital signatures. When used during the generation of an RSA key pair (as specified in this Standard), the length in bits of the hash function output block shall meet or exceed the security strength associated with the bit length of the modulus n (see SP 800-57)."
+        // FIPS 186-4: "An approved hash function, [..], the length in bits of the hash function
+        // output block shall meet or exceed the security strength associated with the bit length of
+        // the modulus n (see SP 800-57)."
+        assert!(block_size >= n, "The block size of the hash function must be at least as strong as the modulus");
 
         let z_len = min(n, block_size);
         let z = BigUint::from_bytes_be(&hash[..z_len]);

--- a/dsa/src/signing_key.rs
+++ b/dsa/src/signing_key.rs
@@ -77,16 +77,8 @@ impl SigningKey {
 
         let r = g.modpow(&k, p) % q;
 
-        let n = q.bits() / 8;
+        let n = (q.bits() / 8) as usize;
         let block_size = hash.len(); // Hash function output size
-
-        // FIPS 186-4: "An approved hash function, [..], the length in bits of the hash function
-        // output block shall meet or exceed the security strength associated with the bit length of
-        // the modulus n (see SP 800-57)."
-        assert!(
-            block_size >= n,
-            "The block size of the hash function must be at least as strong as the modulus"
-        );
 
         let z_len = min(n, block_size);
         let z = BigUint::from_bytes_be(&hash[..z_len]);

--- a/dsa/src/verifying_key.rs
+++ b/dsa/src/verifying_key.rs
@@ -47,6 +47,12 @@ impl VerifyingKey {
         &self.y
     }
 
+    /// `verify_hash` verifies a pre-hashed value using the provided signature.
+    #[must_use]
+    pub fn verify_hash(&self, hash: &[u8], signature: &Signature) -> Option<bool> {
+        self.verify_prehashed(hash, signature)
+    }
+
     /// Verify some prehashed data
     #[must_use]
     fn verify_prehashed(&self, hash: &[u8], signature: &Signature) -> Option<bool> {


### PR DESCRIPTION
Expose the ability for the user to provide a prehashed hash-value for signing/verification. In rare cases, this is needed in other protocols. I have attempted to solve this with a custom Digest implementation, but eventually ran into (forced) finalization which affects the hash value.