### PR TITLE
dsa: implement `Signer` and `Verifier` using SHA-256 as default

### DIFF
--- a/dsa/src/signing_key.rs
+++ b/dsa/src/signing_key.rs
@@ -14,7 +14,7 @@ use pkcs8::{
 use rand::{CryptoRng, RngCore};
 use signature::{
     hazmat::{PrehashSigner, RandomizedPrehashSigner},
-    DigestSigner, RandomizedDigestSigner,
+    DigestSigner, RandomizedDigestSigner, Signer,
 };
 use zeroize::{Zeroize, Zeroizing};
 
@@ -92,6 +92,13 @@ impl SigningKey {
         }
 
         Some(signature)
+    }
+}
+
+impl Signer<Signature> for SigningKey {
+    fn try_sign(&self, msg: &[u8]) -> Result<Signature, signature::Error> {
+        let digest = sha2::Sha256::new_with_prefix(msg);
+        self.try_sign_digest(digest)
     }
 }
 

--- a/dsa/src/verifying_key.rs
+++ b/dsa/src/verifying_key.rs
@@ -11,7 +11,7 @@ use pkcs8::{
     der::{asn1::UIntRef, AnyRef, Decode, Encode},
     spki, AlgorithmIdentifier, DecodePublicKey, EncodePublicKey, SubjectPublicKeyInfo,
 };
-use signature::{hazmat::PrehashVerifier, DigestVerifier};
+use signature::{hazmat::PrehashVerifier, DigestVerifier, Verifier};
 
 /// DSA public key.
 #[derive(Clone, PartialEq, PartialOrd)]
@@ -72,6 +72,12 @@ impl VerifyingKey {
         let v = (g.modpow(&u1, p) * y.modpow(&u2, p) % p) % q;
 
         Some(v == *r)
+    }
+}
+
+impl Verifier<Signature> for VerifyingKey {
+    fn verify(&self, msg: &[u8], signature: &Signature) -> Result<(), signature::Error> {
+        self.verify_digest(sha2::Sha256::new_with_prefix(msg), signature)
     }
 }
 


### PR DESCRIPTION
In follow-up of discussion in #520: a minimal implementation for `Signer` and `Verifier` using SHA-256 for digests. The issue discusses possible options of introducing the OID, however this is not part of this implementation.