### PR TITLE
dsa v0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "dsa"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "digest 0.10.5",
  "num-bigint-dig",

--- a/dsa/CHANGELOG.md
+++ b/dsa/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.2 (2022-10-29)
+### Added
+- Expose signing and verifying of prehashed hash value ([#558])
+- Implement `Signer` and `Verifier` using SHA-256 as default ([#559])
+
+[#558]: https://github.com/RustCrypto/signatures/pull/558
+[#559]: https://github.com/RustCrypto/signatures/pull/559
+
 ## 0.4.1 (2022-10-11)
 ### Added
 - Re-export `BigUint` ([#553])

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsa"
-version = "0.4.1"
+version = "0.4.2"
 description = """
 Pure Rust implementation of the Digital Signature Algorithm (DSA) as specified
 in FIPS 186-4 (Digital Signature Standard), providing RFC6979 deterministic


### PR DESCRIPTION
### Added
- Expose signing and verifying of prehashed hash value ([#558])
- Implement `Signer` and `Verifier` using SHA-256 as default ([#559])

[#558]: https://github.com/RustCrypto/signatures/pull/558
[#559]: https://github.com/RustCrypto/signatures/pull/559