### PR TITLE
Bump `signature` to 2.0.0-pre

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "dsa"
-version = "0.4.2"
+version = "0.5.0-pre"
 dependencies = [
  "digest 0.10.5",
  "num-bigint-dig",
@@ -154,13 +154,13 @@ dependencies = [
  "rfc6979",
  "sha1",
  "sha2 0.10.6",
- "signature",
+ "signature 2.0.0-pre.0",
  "zeroize",
 ]
 
 [[package]]
 name = "ecdsa"
-version = "0.14.8"
+version = "0.15.0-pre"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -168,22 +168,7 @@ dependencies = [
  "rfc6979",
  "serdect",
  "sha2 0.10.6",
- "signature",
-]
-
-[[package]]
-name = "ed25519"
-version = "1.5.2"
-dependencies = [
- "bincode",
- "ed25519-dalek",
- "hex-literal",
- "pkcs8",
- "rand_core 0.5.1",
- "serde",
- "serde_bytes",
- "signature",
- "zeroize",
+ "signature 2.0.0-pre.0",
 ]
 
 [[package]]
@@ -192,7 +177,22 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
 dependencies = [
- "signature",
+ "signature 1.6.4",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.0.0-pre"
+dependencies = [
+ "bincode",
+ "ed25519-dalek",
+ "hex-literal",
+ "pkcs8",
+ "rand_core 0.5.1",
+ "serde",
+ "serde_bytes",
+ "signature 2.0.0-pre.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -202,7 +202,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek",
- "ed25519 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ed25519 1.5.2",
  "rand 0.7.3",
  "serde",
  "sha2 0.9.9",
@@ -577,6 +577,12 @@ name = "signature"
 version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+
+[[package]]
+name = "signature"
+version = "2.0.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75dc0120d23bd04b0a818a398647f657a11516c9f0a10849fa20d2dab358889"
 dependencies = [
  "digest 0.10.5",
  "rand_core 0.6.4",

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsa"
-version = "0.4.2"
+version = "0.5.0-pre"
 description = """
 Pure Rust implementation of the Digital Signature Algorithm (DSA) as specified
 in FIPS 186-4 (Digital Signature Standard), providing RFC6979 deterministic
@@ -23,7 +23,7 @@ pkcs8 = { version = "0.9", default-features = false, features = ["alloc"] }
 rand = { version = "0.8", default-features = false }
 rfc6979 = { version = "0.3", path = "../rfc6979" }
 sha2 = { version = "0.10", default-features = false }
-signature = { version = ">= 1.6.4, < 1.7", default-features = false, features = ["digest-preview", "rand-preview", "hazmat-preview"] }
+signature = { version = "=2.0.0-pre.0", default-features = false, features = ["alloc", "digest-preview", "rand-preview"] }
 zeroize = { version = "1.5", default-features = false }
 
 [dev-dependencies]
@@ -31,3 +31,6 @@ pkcs8 = { version = "0.9", default-features = false, features = ["pem"] }
 rand = "0.8"
 rand_chacha = "0.3"
 sha1 = "0.10"
+
+[features]
+std = []

--- a/dsa/examples/sign.rs
+++ b/dsa/examples/sign.rs
@@ -2,7 +2,7 @@ use digest::Digest;
 use dsa::{Components, KeySize, SigningKey};
 use pkcs8::{EncodePrivateKey, EncodePublicKey, LineEnding};
 use sha1::Sha1;
-use signature::{RandomizedDigestSigner, Signature};
+use signature::{RandomizedDigestSigner, SignatureEncoding};
 use std::{fs::File, io::Write};
 
 fn main() {
@@ -22,7 +22,7 @@ fn main() {
     file.flush().unwrap();
 
     let mut file = File::create("signature.der").unwrap();
-    file.write_all(signature.as_bytes()).unwrap();
+    file.write_all(&signature.to_bytes()).unwrap();
     file.flush().unwrap();
 
     let mut file = File::create("private.pem").unwrap();

--- a/dsa/src/verifying_key.rs
+++ b/dsa/src/verifying_key.rs
@@ -55,7 +55,7 @@ impl VerifyingKey {
         let (r, s) = (signature.r(), signature.s());
         let y = self.y();
 
-        if !signature.r_s_valid(q) {
+        if signature.r() >= q || signature.s() >= q {
             return Some(false);
         }
 

--- a/dsa/tests/deterministic.rs
+++ b/dsa/tests/deterministic.rs
@@ -131,6 +131,7 @@ fn from_str_signature(r: &str, s: &str) -> Signature {
         BigUint::from_str_radix(r, 16).unwrap(),
         BigUint::from_str_radix(s, 16).unwrap(),
     )
+    .unwrap()
 }
 
 /// Return the RFC 6979 test cases

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecdsa"
-version = "0.14.8"
+version = "0.15.0-pre"
 description = """
 Pure Rust implementation of the Elliptic Curve Digital Signature Algorithm
 (ECDSA) as specified in FIPS 186-4 (Digital Signature Standard), providing
@@ -17,7 +17,7 @@ rust-version = "1.57"
 
 [dependencies]
 elliptic-curve = { version = "0.12", default-features = false, features = ["digest", "sec1"] }
-signature = { version = ">=1.6.2, <1.7", default-features = false, features = ["hazmat-preview", "rand-preview"] }
+signature = { version = "=2.0.0-pre.0", default-features = false, features = ["rand-preview"] }
 
 # optional dependencies
 der = { version = "0.6", optional = true }
@@ -31,7 +31,7 @@ sha2 = { version = "0.10", default-features = false }
 
 [features]
 default = ["digest"]
-alloc = []
+alloc = ["signature/alloc"]
 arithmetic = ["elliptic-curve/arithmetic"]
 dev = ["arithmetic", "digest", "elliptic-curve/dev", "hazmat"]
 digest = ["signature/digest-preview"]

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -83,7 +83,7 @@ pub use crate::recovery::RecoveryId;
 pub use elliptic_curve::{self, sec1::EncodedPoint, PrimeCurve};
 
 // Re-export the `signature` crate (and select types)
-pub use signature::{self, Error, Result};
+pub use signature::{self, Error, Result, SignatureEncoding};
 
 #[cfg(feature = "sign")]
 #[cfg_attr(docsrs, doc(cfg(feature = "sign")))]
@@ -245,16 +245,6 @@ where
     }
 }
 
-impl<C> signature::Signature for Signature<C>
-where
-    C: PrimeCurve,
-    SignatureSize<C>: ArrayLength<u8>,
-{
-    fn from_bytes(bytes: &[u8]) -> Result<Self> {
-        Self::try_from(bytes)
-    }
-}
-
 impl<C> AsRef<[u8]> for Signature<C>
 where
     C: PrimeCurve,
@@ -287,6 +277,24 @@ where
 
         write!(f, ")")
     }
+}
+
+impl<C> From<Signature<C>> for SignatureBytes<C>
+where
+    C: PrimeCurve,
+    SignatureSize<C>: ArrayLength<u8>,
+{
+    fn from(signature: Signature<C>) -> SignatureBytes<C> {
+        signature.bytes
+    }
+}
+
+impl<C> SignatureEncoding for Signature<C>
+where
+    C: PrimeCurve,
+    SignatureSize<C>: ArrayLength<u8>,
+{
+    type Repr = SignatureBytes<C>;
 }
 
 impl<C> TryFrom<&[u8]> for Signature<C>

--- a/ecdsa/src/sign.rs
+++ b/ecdsa/src/sign.rs
@@ -36,7 +36,7 @@ use crate::elliptic_curve::{
 };
 
 #[cfg(feature = "verify")]
-use {crate::verify::VerifyingKey, elliptic_curve::PublicKey, signature::Keypair};
+use {crate::verify::VerifyingKey, elliptic_curve::PublicKey, signature::KeypairRef};
 
 /// ECDSA signing key. Generic over elliptic curves.
 ///
@@ -243,7 +243,7 @@ where
 
 #[cfg(feature = "verify")]
 #[cfg_attr(docsrs, doc(cfg(feature = "verify")))]
-impl<C> Keypair<Signature<C>> for SigningKey<C>
+impl<C> KeypairRef for SigningKey<C>
 where
     C: PrimeCurve + ProjectiveArithmetic,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + Reduce<C::UInt> + SignPrimitive<C>,

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed25519"
-version = "1.5.2"
+version = "2.0.0-pre"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """
@@ -17,7 +17,7 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-signature = { version = ">=1.3.1", default-features = false }
+signature = { version = "=2.0.0-pre.0", default-features = false }
 
 # optional dependencies
 pkcs8 = { version = "0.9", optional = true }

--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -78,67 +78,68 @@
 //! instantiate and use the previously defined `HelloSigner` and `HelloVerifier`
 //! types with [`ed25519-dalek`] as the signing/verification provider:
 //!
-//! ```
-//! use ed25519_dalek::{Signer, Verifier, Signature};
-//! #
-//! # pub struct HelloSigner<S>
-//! # where
-//! #     S: Signer<Signature>
-//! # {
-//! #     pub signing_key: S
-//! # }
-//! #
-//! # impl<S> HelloSigner<S>
-//! # where
-//! #     S: Signer<Signature>
-//! # {
-//! #     pub fn sign(&self, person: &str) -> Signature {
-//! #         // NOTE: use `try_sign` if you'd like to be able to handle
-//! #         // errors from external signing services/devices (e.g. HSM/KMS)
-//! #         // <https://docs.rs/signature/latest/signature/trait.Signer.html#tymethod.try_sign>
-//! #         self.signing_key.sign(format_message(person).as_bytes())
-//! #     }
-//! # }
-//! #
-//! # pub struct HelloVerifier<V> {
-//! #     pub verify_key: V
-//! # }
-//! #
-//! # impl<V> HelloVerifier<V>
-//! # where
-//! #     V: Verifier<Signature>
-//! # {
-//! #     pub fn verify(
-//! #         &self,
-//! #         person: &str,
-//! #         signature: &Signature
-//! #     ) -> Result<(), ed25519::Error> {
-//! #         self.verify_key.verify(format_message(person).as_bytes(), signature)
-//! #     }
-//! # }
-//! #
-//! # fn format_message(person: &str) -> String {
-//! #     format!("Hello, {}!", person)
-//! # }
-//! use rand_core::OsRng; // Requires the `std` feature of `rand_core`
-//!
-//! /// `HelloSigner` defined above instantiated with `ed25519-dalek` as
-//! /// the signing provider.
-//! pub type DalekHelloSigner = HelloSigner<ed25519_dalek::Keypair>;
-//!
-//! let signing_key = ed25519_dalek::Keypair::generate(&mut OsRng);
-//! let signer = DalekHelloSigner { signing_key };
-//! let person = "Joe"; // Message to sign
-//! let signature = signer.sign(person);
-//!
-//! /// `HelloVerifier` defined above instantiated with `ed25519-dalek`
-//! /// as the signature verification provider.
-//! pub type DalekHelloVerifier = HelloVerifier<ed25519_dalek::PublicKey>;
-//!
-//! let verify_key: ed25519_dalek::PublicKey = signer.signing_key.public;
-//! let verifier = DalekHelloVerifier { verify_key };
-//! assert!(verifier.verify(person, &signature).is_ok());
-//! ```
+// TODO(tarcieri): re-enable when `ed25519-dalek` 2.0 has been released
+// //! ```
+// //! use ed25519_dalek::{Signer, Verifier, Signature};
+// //! #
+// //! # pub struct HelloSigner<S>
+// //! # where
+// //! #     S: Signer<Signature>
+// //! # {
+// //! #     pub signing_key: S
+// //! # }
+// //! #
+// //! # impl<S> HelloSigner<S>
+// //! # where
+// //! #     S: Signer<Signature>
+// //! # {
+// //! #     pub fn sign(&self, person: &str) -> Signature {
+// //! #         // NOTE: use `try_sign` if you'd like to be able to handle
+// //! #         // errors from external signing services/devices (e.g. HSM/KMS)
+// //! #         // <https://docs.rs/signature/latest/signature/trait.Signer.html#tymethod.try_sign>
+// //! #         self.signing_key.sign(format_message(person).as_bytes())
+// //! #     }
+// //! # }
+// //! #
+// //! # pub struct HelloVerifier<V> {
+// //! #     pub verify_key: V
+// //! # }
+// //! #
+// //! # impl<V> HelloVerifier<V>
+// //! # where
+// //! #     V: Verifier<Signature>
+// //! # {
+// //! #     pub fn verify(
+// //! #         &self,
+// //! #         person: &str,
+// //! #         signature: &Signature
+// //! #     ) -> Result<(), ed25519::Error> {
+// //! #         self.verify_key.verify(format_message(person).as_bytes(), signature)
+// //! #     }
+// //! # }
+// //! #
+// //! # fn format_message(person: &str) -> String {
+// //! #     format!("Hello, {}!", person)
+// //! # }
+// //! use rand_core::OsRng; // Requires the `std` feature of `rand_core`
+// //!
+// //! /// `HelloSigner` defined above instantiated with `ed25519-dalek` as
+// //! /// the signing provider.
+// //! pub type DalekHelloSigner = HelloSigner<ed25519_dalek::Keypair>;
+// //!
+// //! let signing_key = ed25519_dalek::Keypair::generate(&mut OsRng);
+// //! let signer = DalekHelloSigner { signing_key };
+// //! let person = "Joe"; // Message to sign
+// //! let signature = signer.sign(person);
+// //!
+// //! /// `HelloVerifier` defined above instantiated with `ed25519-dalek`
+// //! /// as the signature verification provider.
+// //! pub type DalekHelloVerifier = HelloVerifier<ed25519_dalek::PublicKey>;
+// //!
+// //! let verify_key: ed25519_dalek::PublicKey = signer.signing_key.public;
+// //! let verifier = DalekHelloVerifier { verify_key };
+// //! assert!(verifier.verify(person, &signature).is_ok());
+// //! ```
 //!
 //! ## Using above example with `ring-compat`
 //!
@@ -265,7 +266,7 @@ pub mod pkcs8;
 #[cfg(feature = "serde")]
 mod serde;
 
-pub use signature::{self, Error};
+pub use signature::{self, Error, SignatureEncoding};
 
 #[cfg(feature = "pkcs8")]
 pub use crate::pkcs8::KeypairBytes;
@@ -279,9 +280,12 @@ use alloc::vec::Vec;
 #[deprecated(since = "1.3.0", note = "use ed25519::Signature::BYTE_SIZE instead")]
 pub const SIGNATURE_LENGTH: usize = Signature::BYTE_SIZE;
 
+/// Ed25519 signature serialized as a byte array.
+pub type SignatureBytes = [u8; Signature::BYTE_SIZE];
+
 /// Ed25519 signature.
 #[derive(Copy, Clone, Eq, PartialEq)]
-pub struct Signature([u8; Signature::BYTE_SIZE]);
+pub struct Signature(SignatureBytes);
 
 impl Signature {
     /// Size of an encoded Ed25519 signature in bytes.
@@ -332,9 +336,11 @@ impl Signature {
     }
 }
 
-impl signature::Signature for Signature {
-    fn from_bytes(bytes: &[u8]) -> signature::Result<Self> {
-        Self::from_bytes(bytes)
+impl SignatureEncoding for Signature {
+    type Repr = SignatureBytes;
+
+    fn to_bytes(&self) -> SignatureBytes {
+        self.0
     }
 }
 


### PR DESCRIPTION
Implements the proposed breaking changes to the `signature` crate from https://github.com/RustCrypto/traits/pull/1141

Most notably the `Signature` trait has been replaced with a `SignatureEncoding` trait which permits an internally structured signature representation.