### PR TITLE
ecdsa: Implementation of recoverable signatures

### DIFF
--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -77,7 +77,7 @@ mod sign;
 #[cfg(feature = "verify")]
 mod verify;
 
-pub use crate::recovery::RecoveryId;
+pub use crate::recovery::*;
 
 // Re-export the `elliptic-curve` crate (and select types)
 pub use elliptic_curve::{self, sec1::EncodedPoint, PrimeCurve};

--- a/ecdsa/src/recovery.rs
+++ b/ecdsa/src/recovery.rs
@@ -69,21 +69,19 @@ impl From<RecoveryId> for u8 {
     }
 }
 
-#[cfg(all(feature = "arithmetic", feature = "verify"))]
+#[cfg(feature = "verify")]
 mod signature {
-    use core::ops::Add;
-
     use crate::{
         hazmat::{DigestPrimitive, VerifyPrimitive},
         RecoveryId, SignatureSize, VerifyingKey,
     };
+    use core::ops::Add;
     use elliptic_curve::{
         generic_array::{
             typenum::{Add1, Unsigned, B1},
             ArrayLength, GenericArray,
         },
-        ops::Reduce,
-        ops::{Invert, LinearCombination},
+        ops::{Invert, LinearCombination, Reduce},
         sec1::{self, FromEncodedPoint, ToEncodedPoint},
         AffinePoint, DecompressPoint, FieldBytes, FieldSize, Group, PrimeCurve, PrimeField,
         ProjectiveArithmetic, ProjectivePoint, Scalar,
@@ -251,7 +249,7 @@ mod signature {
     }
 }
 
-#[cfg(all(feature = "arithmetic", feature = "verify"))]
+#[cfg(feature = "verify")]
 pub use self::signature::Signature as RecoverySignature;
 
 #[cfg(test)]


### PR DESCRIPTION
Adds an initial implementation of Ethereum-style recoverable signatures that's generic over the underlying curve.  
This is mostly a port of the code in the `k256` crate adapted to work generically.  

"Marked ready for review" checklist:

- [x] Implementation of the algorithm to recover verifying keys
- [x] Implementation of `SignatureEncoding` for the recoverable signature
- [ ] More granular `cfg` flags 
- [ ] Implementation of the signer and verifier traits on the key types for the new `RecoverySignature` 
- [ ] Update the internal ECDSA logic to actually emit a `RecoveryId` (instead of always returning `None`)

Trial recovery was tested with P256 and P384 and their respective preferred digest  

Closes #525 