### PR TITLE
ecdsa: add `*Signer`/`*Verifier` impls for `der::Signature`

### DIFF
--- a/ecdsa/src/der.rs
+++ b/ecdsa/src/der.rs
@@ -159,6 +159,17 @@ where
     }
 }
 
+impl<C> From<crate::Signature<C>> for Signature<C>
+where
+    C: PrimeCurve,
+    MaxSize<C>: ArrayLength<u8>,
+    <FieldSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
+{
+    fn from(sig: crate::Signature<C>) -> Signature<C> {
+        sig.to_der()
+    }
+}
+
 impl<C> TryFrom<&[u8]> for Signature<C>
 where
     C: PrimeCurve,
@@ -192,7 +203,7 @@ where
     }
 }
 
-impl<C> TryFrom<Signature<C>> for super::Signature<C>
+impl<C> TryFrom<Signature<C>> for crate::Signature<C>
 where
     C: PrimeCurve,
     MaxSize<C>: ArrayLength<u8>,


### PR DESCRIPTION
This allows using these traits along with `SigningKey`/`VerifyingKey` to directly sign and verify `der::Signature`s.

cc @lumag