### PR TITLE
dsa: remove use of `opaque-debug`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,6 @@ dependencies = [
  "digest 0.10.5",
  "num-bigint-dig",
  "num-traits",
- "opaque-debug",
  "pkcs8",
  "rand 0.8.5",
  "rand_chacha 0.3.1",

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -18,7 +18,6 @@ rust-version = "1.57"
 digest = "0.10"
 num-bigint = { package = "num-bigint-dig", version = "0.8", default-features = false, features = ["prime", "rand", "zeroize"] }
 num-traits = { version = "0.2", default-features = false }
-opaque-debug = "0.3"
 pkcs8 = { version = "0.9", default-features = false, features = ["alloc"] }
 rand = { version = "0.8", default-features = false }
 rfc6979 = { version = "0.3", path = "../rfc6979" }

--- a/dsa/src/components.rs
+++ b/dsa/src/components.rs
@@ -11,7 +11,7 @@ use rand::{CryptoRng, RngCore};
 /// The common components of an DSA keypair
 ///
 /// (the prime p, quotient q and generator g)
-#[derive(Clone, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
 #[must_use]
 pub struct Components {
     /// Prime p
@@ -23,8 +23,6 @@ pub struct Components {
     /// Generator g
     g: BigUint,
 }
-
-opaque_debug::implement!(Components);
 
 impl Components {
     /// Construct the common components container from its inner values (p, q and g)

--- a/dsa/src/lib.rs
+++ b/dsa/src/lib.rs
@@ -73,7 +73,7 @@ use pkcs8::der::{self, asn1::UIntRef, Decode, Encode, Reader, Sequence};
 use signature::SignatureEncoding;
 
 /// Container of the DSA signature
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 #[must_use]
 pub struct Signature {
     /// Signature part r
@@ -82,8 +82,6 @@ pub struct Signature {
     /// Signature part s
     s: BigUint,
 }
-
-opaque_debug::implement!(Signature);
 
 impl Signature {
     /// Create a new Signature container from its components

--- a/dsa/src/signing_key.rs
+++ b/dsa/src/signing_key.rs
@@ -3,7 +3,10 @@
 //!
 
 use crate::{Components, Signature, VerifyingKey, OID};
-use core::cmp::min;
+use core::{
+    cmp::min,
+    fmt::{self, Debug},
+};
 use digest::{core_api::BlockSizeUser, Digest, FixedOutputReset};
 use num_bigint::BigUint;
 use num_traits::Zero;
@@ -31,8 +34,6 @@ pub struct SigningKey {
     /// Private component x
     x: Zeroizing<BigUint>,
 }
-
-opaque_debug::implement!(SigningKey);
 
 impl SigningKey {
     /// Construct a new private key from the public key and private component
@@ -207,3 +208,11 @@ impl<'a> TryFrom<PrivateKeyInfo<'a>> for SigningKey {
 }
 
 impl DecodePrivateKey for SigningKey {}
+
+impl Debug for SigningKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SigningKey")
+            .field("verifying_key", &self.verifying_key)
+            .finish_non_exhaustive()
+    }
+}

--- a/dsa/src/verifying_key.rs
+++ b/dsa/src/verifying_key.rs
@@ -14,7 +14,7 @@ use pkcs8::{
 use signature::{hazmat::PrehashVerifier, DigestVerifier, Verifier};
 
 /// DSA public key.
-#[derive(Clone, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
 #[must_use]
 pub struct VerifyingKey {
     /// common components
@@ -23,8 +23,6 @@ pub struct VerifyingKey {
     /// Public component y
     y: BigUint,
 }
-
-opaque_debug::implement!(VerifyingKey);
 
 impl VerifyingKey {
     /// Construct a new public key from the common components and the public component


### PR DESCRIPTION
All of the `Debug` impls in this crate benefit from displaying something, including `SigningKey` which can display its associated `VerifyingKey`.

This commit switches to derived `Debug` for all types except `SigningKey`, where it displays the `verifying_key` field then uses `finish_non_exhaustive` to prevent displaying the secret component `x`.

They could probably benefit from some better formatting than what the derived implementation provides.