### PR TITLE
ecdsa: refactor `prehash_to_field_bytes` to `bits2field` free func

### DIFF
--- a/ecdsa/src/sign.rs
+++ b/ecdsa/src/sign.rs
@@ -3,7 +3,7 @@
 // TODO(tarcieri): support for hardware crypto accelerators
 
 use crate::{
-    hazmat::{DigestPrimitive, SignPrimitive},
+    hazmat::{bits2field, DigestPrimitive, SignPrimitive},
     Error, Result, Signature, SignatureSize,
 };
 use core::fmt::{self, Debug};
@@ -137,11 +137,11 @@ where
     SignatureSize<C>: ArrayLength<u8>,
 {
     fn sign_prehash(&self, prehash: &[u8]) -> Result<Signature<C>> {
-        let prehash = C::prehash_to_field_bytes(prehash)?;
+        let scalar = bits2field::<C>(prehash)?;
 
         Ok(self
             .secret_scalar
-            .try_sign_prehashed_rfc6979::<C::Digest>(prehash, &[])?
+            .try_sign_prehashed_rfc6979::<C::Digest>(scalar, &[])?
             .0)
     }
 }

--- a/ecdsa/src/verify.rs
+++ b/ecdsa/src/verify.rs
@@ -1,7 +1,7 @@
 //! ECDSA verification key.
 
 use crate::{
-    hazmat::{DigestPrimitive, VerifyPrimitive},
+    hazmat::{bits2field, DigestPrimitive, VerifyPrimitive},
     Error, Result, Signature, SignatureSize,
 };
 use core::{cmp::Ordering, fmt::Debug};
@@ -122,8 +122,8 @@ where
     SignatureSize<C>: ArrayLength<u8>,
 {
     fn verify_prehash(&self, prehash: &[u8], signature: &Signature<C>) -> Result<()> {
-        let prehash = C::prehash_to_field_bytes(prehash)?;
-        self.inner.as_affine().verify_prehashed(prehash, signature)
+        let field = bits2field::<C>(prehash)?;
+        self.inner.as_affine().verify_prehashed(field, signature)
     }
 }
 


### PR DESCRIPTION
Removes the verbosely named `prehash_to_field_bytes` from the `DigestPrimitive` trait, chaning it to a `bits2field` free function which has a `C: PrimeCurve` generic parameter.

The name is inspired by `bits2int` from RFC6979, however it does not perform a reduction step.