### PR TITLE
ecdsa: add trial recovery functionality

### DIFF
--- a/ecdsa/src/sign.rs
+++ b/ecdsa/src/sign.rs
@@ -200,7 +200,7 @@ where
 impl<C> PrehashSigner<der::Signature<C>> for SigningKey<C>
 where
     C: PrimeCurve + ProjectiveArithmetic + DigestPrimitive,
-    C::Digest: BlockSizeUser + FixedOutput<OutputSize = FieldSize<C>> + FixedOutputReset,
+    C::Digest: FixedOutput<OutputSize = FieldSize<C>>,
     C::UInt: for<'a> From<&'a Scalar<C>>,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + Reduce<C::UInt> + SignPrimitive<C>,
     SignatureSize<C>: ArrayLength<u8>,

--- a/ecdsa/src/verify.rs
+++ b/ecdsa/src/verify.rs
@@ -116,7 +116,7 @@ where
 
 impl<C> PrehashVerifier<Signature<C>> for VerifyingKey<C>
 where
-    C: PrimeCurve + ProjectiveArithmetic + DigestPrimitive,
+    C: PrimeCurve + ProjectiveArithmetic,
     AffinePoint<C>: VerifyPrimitive<C>,
     Scalar<C>: Reduce<C::UInt>,
     SignatureSize<C>: ArrayLength<u8>,


### PR DESCRIPTION
This functionality can be used to compute a `RecoveryId` from a verifying key, message, and signature, without having this information computed during signing time.

It uses a brute force method and is thus much slower than computing it at signing time.