### PR TITLE
ed25519: make `pkcs8::*Document` re-exports public

### DIFF
--- a/ed25519/src/pkcs8.rs
+++ b/ed25519/src/pkcs8.rs
@@ -19,11 +19,11 @@ pub use pkcs8::{DecodePrivateKey, DecodePublicKey, Error, PrivateKeyInfo, Result
 #[cfg(feature = "alloc")]
 pub use pkcs8::{spki::EncodePublicKey, EncodePrivateKey};
 
+#[cfg(feature = "alloc")]
+pub use pkcs8::der::{Document, SecretDocument};
+
 use core::fmt;
 use pkcs8::ObjectIdentifier;
-
-#[cfg(feature = "alloc")]
-use pkcs8::der::{Document, SecretDocument};
 
 #[cfg(feature = "pem")]
 use {


### PR DESCRIPTION
They're needed to properly impl the `EncodePrivateKey`/`EncodePublicKey` traits.