### PR TITLE
ed25519: store `R` and `s` components separately

### DIFF
--- a/ed25519/src/serde.rs
+++ b/ed25519/src/serde.rs
@@ -1,6 +1,6 @@
 //! `serde` support.
 
-use crate::Signature;
+use crate::{Signature, SignatureBytes};
 use ::serde::{de, ser, Deserialize, Serialize};
 use core::fmt;
 
@@ -14,8 +14,8 @@ impl Serialize for Signature {
 
         let mut seq = serializer.serialize_tuple(Signature::BYTE_SIZE)?;
 
-        for byte in &self.0[..] {
-            seq.serialize_element(byte)?;
+        for byte in self.to_bytes() {
+            seq.serialize_element(&byte)?;
         }
 
         seq.end()
@@ -65,7 +65,7 @@ impl serde_bytes::Serialize for Signature {
     where
         S: serde::Serializer,
     {
-        serializer.serialize_bytes(&self.0)
+        serializer.serialize_bytes(&self.to_bytes())
     }
 }
 
@@ -79,7 +79,7 @@ impl<'de> serde_bytes::Deserialize<'de> for Signature {
         struct ByteArrayVisitor;
 
         impl<'de> de::Visitor<'de> for ByteArrayVisitor {
-            type Value = [u8; Signature::BYTE_SIZE];
+            type Value = SignatureBytes;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("bytestring of length 64")
@@ -104,10 +104,10 @@ impl<'de> serde_bytes::Deserialize<'de> for Signature {
 
 #[cfg(test)]
 mod tests {
-    use crate::Signature;
+    use crate::{Signature, SignatureBytes};
     use hex_literal::hex;
 
-    const SIGNATURE_BYTES: [u8; Signature::BYTE_SIZE] = hex!(
+    const SIGNATURE_BYTES: SignatureBytes = hex!(
         "
         e5564300c360ac729086e2cc806e828a
         84877f1eb8e5d974d873e06522490155

--- a/ed25519/tests/hex.rs
+++ b/ed25519/tests/hex.rs
@@ -34,13 +34,13 @@ fn upper_hex() {
 #[test]
 fn from_str_lower() {
     let sig = Signature::from_str("e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b").unwrap();
-    assert_eq!(sig.as_ref(), TEST_1_SIGNATURE);
+    assert_eq!(sig.to_bytes(), TEST_1_SIGNATURE);
 }
 
 #[test]
 fn from_str_upper() {
     let sig = Signature::from_str("E5564300C360AC729086E2CC806E828A84877F1EB8E5D974D873E065224901555FB8821590A33BACC61E39701CF9B46BD25BF5F0595BBE24655141438E7A100B").unwrap();
-    assert_eq!(sig.as_ref(), TEST_1_SIGNATURE);
+    assert_eq!(sig.to_bytes(), TEST_1_SIGNATURE);
 }
 
 #[test]

--- a/ed25519/tests/serde.rs
+++ b/ed25519/tests/serde.rs
@@ -2,16 +2,16 @@
 
 #![cfg(feature = "serde")]
 
-use ed25519::Signature;
+use ed25519::{Signature, SignatureBytes};
+use hex_literal::hex;
 
 #[cfg(feature = "serde_bytes")]
 use serde_bytes_crate as serde_bytes;
 
-const EXAMPLE_SIGNATURE: [u8; Signature::BYTE_SIZE] = [
-    63, 62, 61, 60, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43, 42, 41, 40,
-    39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16,
-    15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0,
-];
+const EXAMPLE_SIGNATURE: SignatureBytes = hex!(
+    "3f3e3d3c3b3a393837363534333231302f2e2d2c2b2a29282726252423222120"
+    "1f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100"
+);
 
 #[test]
 fn test_serialize() {
@@ -23,7 +23,7 @@ fn test_serialize() {
 #[test]
 fn test_deserialize() {
     let signature = bincode::deserialize::<Signature>(&EXAMPLE_SIGNATURE).unwrap();
-    assert_eq!(&EXAMPLE_SIGNATURE[..], signature.as_ref());
+    assert_eq!(EXAMPLE_SIGNATURE, signature.to_bytes());
 }
 
 #[cfg(feature = "serde_bytes")]
@@ -60,5 +60,5 @@ fn test_deserialize_bytes() {
 
     let signature: Signature = serde_bytes::deserialize(&mut deserializer).unwrap();
 
-    assert_eq!(&EXAMPLE_SIGNATURE[..], signature.as_ref());
+    assert_eq!(EXAMPLE_SIGNATURE, signature.to_bytes());
 }


### PR DESCRIPTION
Adds a `ComponentBytes` type alias for `[u8; 32]` and stores the `R` and `s` component signatures as separate byte arrays.

This allows for simple, infallible `ComponentBytes` accessors:

- `pub fn r_bytes(&self) -> &ComponentBytes`
- `pub fn s_bytes(&self) -> &ComponentBytes`