### PR TITLE
signature v2.0.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ dependencies = [
  "rfc6979",
  "sha1",
  "sha2 0.10.6",
- "signature 2.0.0-rc.0",
+ "signature 2.0.0-rc.1",
  "zeroize",
 ]
 
@@ -167,7 +167,7 @@ dependencies = [
  "rfc6979",
  "serdect",
  "sha2 0.10.6",
- "signature 2.0.0-rc.0",
+ "signature 2.0.0-rc.1",
 ]
 
 [[package]]
@@ -190,7 +190,7 @@ dependencies = [
  "rand_core 0.5.1",
  "serde",
  "serde_bytes",
- "signature 2.0.0-rc.0",
+ "signature 2.0.0-rc.1",
  "zeroize",
 ]
 
@@ -580,9 +580,9 @@ checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
 name = "signature"
-version = "2.0.0-rc.0"
+version = "2.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51659052c3c82a3cb69d911c1c1d8cb5d383012b7ec537918d5ecc5f42870d2d"
+checksum = "a27af965d7572471973d1307767b3d7ecaff1b7a26674bbbe16877e5dc4cc60d"
 dependencies = [
  "digest 0.10.6",
  "rand_core 0.6.4",

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -21,7 +21,7 @@ num-traits = { version = "0.2", default-features = false }
 pkcs8 = { version = "0.9", default-features = false, features = ["alloc"] }
 rfc6979 = { version = "0.3", path = "../rfc6979" }
 sha2 = { version = "0.10", default-features = false }
-signature = { version = "=2.0.0-rc.0", default-features = false, features = ["alloc", "digest-preview", "rand-preview"] }
+signature = { version = "=2.0.0-rc.1", default-features = false, features = ["alloc", "digest-preview", "rand-preview"] }
 zeroize = { version = "1.5", default-features = false }
 
 [dev-dependencies]

--- a/dsa/src/signing_key.rs
+++ b/dsa/src/signing_key.rs
@@ -112,12 +112,13 @@ impl PrehashSigner<Signature> for SigningKey {
 }
 
 impl RandomizedPrehashSigner<Signature> for SigningKey {
-    fn sign_prehash_with_rng<R: CryptoRngCore + ?Sized>(
+    fn sign_prehash_with_rng(
         &self,
-        mut rng: &mut R,
+        mut rng: &mut impl CryptoRngCore,
         prehash: &[u8],
     ) -> Result<Signature, signature::Error> {
         let components = self.verifying_key.components();
+
         if let Some(k_kinv) = crate::generate::secret_number(&mut rng, components) {
             self.sign_prehashed(k_kinv, prehash)
         } else {
@@ -142,9 +143,9 @@ impl<D> RandomizedDigestSigner<D, Signature> for SigningKey
 where
     D: Digest,
 {
-    fn try_sign_digest_with_rng<R: CryptoRngCore + ?Sized>(
+    fn try_sign_digest_with_rng(
         &self,
-        mut rng: &mut R,
+        mut rng: &mut impl CryptoRngCore,
         digest: D,
     ) -> Result<Signature, signature::Error> {
         let ks = crate::generate::secret_number(&mut rng, self.verifying_key().components())

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.57"
 
 [dependencies]
 elliptic-curve = { version = "0.12", default-features = false, features = ["digest", "sec1"] }
-signature = { version = "=2.0.0-rc.0", default-features = false, features = ["rand-preview"] }
+signature = { version = "=2.0.0-rc.1", default-features = false, features = ["rand-preview"] }
 
 # optional dependencies
 der = { version = "0.6", optional = true }

--- a/ecdsa/src/sign.rs
+++ b/ecdsa/src/sign.rs
@@ -169,9 +169,9 @@ where
     /// Sign message prehash using an ephemeral scalar (`k`) derived according
     /// to a variant of RFC 6979 (Section 3.6) which supplies additional
     /// entropy from an RNG.
-    fn try_sign_digest_with_rng<R: CryptoRngCore + ?Sized>(
+    fn try_sign_digest_with_rng(
         &self,
-        rng: &mut R,
+        rng: &mut impl CryptoRngCore,
         msg_digest: D,
     ) -> Result<Signature<C>> {
         let mut ad = FieldBytes::<C>::default();
@@ -190,11 +190,7 @@ where
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + Reduce<C::UInt> + SignPrimitive<C>,
     SignatureSize<C>: ArrayLength<u8>,
 {
-    fn try_sign_with_rng<R: CryptoRngCore + ?Sized>(
-        &self,
-        rng: &mut R,
-        msg: &[u8],
-    ) -> Result<Signature<C>> {
+    fn try_sign_with_rng(&self, rng: &mut impl CryptoRngCore, msg: &[u8]) -> Result<Signature<C>> {
         self.try_sign_digest_with_rng(rng, C::Digest::new_with_prefix(msg))
     }
 }
@@ -244,9 +240,9 @@ where
     der::MaxSize<C>: ArrayLength<u8>,
     <FieldSize<C> as Add>::Output: Add<der::MaxOverhead> + ArrayLength<u8>,
 {
-    fn try_sign_digest_with_rng<R: CryptoRngCore + ?Sized>(
+    fn try_sign_digest_with_rng(
         &self,
-        rng: &mut R,
+        rng: &mut impl CryptoRngCore,
         msg_digest: D,
     ) -> Result<der::Signature<C>> {
         RandomizedDigestSigner::<D, Signature<C>>::try_sign_digest_with_rng(self, rng, msg_digest)
@@ -265,9 +261,9 @@ where
     der::MaxSize<C>: ArrayLength<u8>,
     <FieldSize<C> as Add>::Output: Add<der::MaxOverhead> + ArrayLength<u8>,
 {
-    fn try_sign_with_rng<R: CryptoRngCore + ?Sized>(
+    fn try_sign_with_rng(
         &self,
-        rng: &mut R,
+        rng: &mut impl CryptoRngCore,
         msg: &[u8],
     ) -> Result<der::Signature<C>> {
         RandomizedSigner::<Signature<C>>::try_sign_with_rng(self, rng, msg).map(Into::into)

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-signature = { version = "=2.0.0-rc.0", default-features = false }
+signature = { version = "=2.0.0-rc.1", default-features = false }
 
 # optional dependencies
 pkcs8 = { version = "0.9", optional = true }


### PR DESCRIPTION
This version moves back to `&mut impl CryptoRngCore` as the type signature for RNGs.

See RustCrypto/traits#1183