### PR TITLE
ecdsa: rename `signing` and `verifying` features

### DIFF
--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -32,6 +32,8 @@ sha2 = { version = "0.10", default-features = false }
 [features]
 default = ["digest"]
 alloc = ["signature/alloc"]
+std = ["alloc", "elliptic-curve/std", "signature/std"]
+
 arithmetic = ["elliptic-curve/arithmetic"]
 dev = ["arithmetic", "digest", "elliptic-curve/dev", "hazmat"]
 digest = ["signature/digest-preview"]
@@ -39,9 +41,8 @@ hazmat = []
 pkcs8 = ["elliptic-curve/pkcs8", "der"]
 pem = ["elliptic-curve/pem", "pkcs8"]
 serde = ["elliptic-curve/serde", "serdect"]
-sign = ["arithmetic", "digest", "hazmat", "rfc6979"]
-std = ["alloc", "elliptic-curve/std", "signature/std"]
-verify = ["arithmetic", "digest", "hazmat"]
+signing = ["arithmetic", "digest", "hazmat", "rfc6979"]
+verifying = ["arithmetic", "digest", "hazmat"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -71,10 +71,10 @@ pub mod dev;
 #[cfg_attr(docsrs, doc(cfg(feature = "hazmat")))]
 pub mod hazmat;
 
-#[cfg(feature = "sign")]
+#[cfg(feature = "signing")]
 mod signing;
 
-#[cfg(feature = "verify")]
+#[cfg(feature = "verifying")]
 mod verifying;
 
 pub use crate::recovery::RecoveryId;
@@ -85,12 +85,12 @@ pub use elliptic_curve::{self, sec1::EncodedPoint, PrimeCurve};
 // Re-export the `signature` crate (and select types)
 pub use signature::{self, Error, Result, SignatureEncoding};
 
-#[cfg(feature = "sign")]
-#[cfg_attr(docsrs, doc(cfg(feature = "sign")))]
+#[cfg(feature = "signing")]
+#[cfg_attr(docsrs, doc(cfg(feature = "signing")))]
 pub use crate::signing::SigningKey;
 
-#[cfg(feature = "verify")]
-#[cfg_attr(docsrs, doc(cfg(feature = "verify")))]
+#[cfg(feature = "verifying")]
+#[cfg_attr(docsrs, doc(cfg(feature = "verifying")))]
 pub use crate::verifying::VerifyingKey;
 
 use core::{

--- a/ecdsa/src/recovery.rs
+++ b/ecdsa/src/recovery.rs
@@ -2,7 +2,7 @@
 
 use crate::{Error, Result};
 
-#[cfg(feature = "verify")]
+#[cfg(feature = "verifying")]
 use {
     crate::{
         hazmat::{bits2field, DigestPrimitive, VerifyPrimitive},
@@ -71,8 +71,8 @@ impl RecoveryId {
     }
 }
 
-#[cfg(feature = "verify")]
-#[cfg_attr(docsrs, doc(cfg(feature = "verify")))]
+#[cfg(feature = "verifying")]
+#[cfg_attr(docsrs, doc(cfg(feature = "verifying")))]
 impl RecoveryId {
     /// Given a public key, message, and signature, use trial recovery
     /// to determine if a suitable recovery ID exists, or return an error
@@ -157,8 +157,8 @@ impl From<RecoveryId> for u8 {
     }
 }
 
-#[cfg(feature = "verify")]
-#[cfg_attr(docsrs, doc(cfg(feature = "verify")))]
+#[cfg(feature = "verifying")]
+#[cfg_attr(docsrs, doc(cfg(feature = "verifying")))]
 impl<C> VerifyingKey<C>
 where
     C: PrimeCurve + ProjectiveArithmetic,

--- a/ecdsa/src/signing.rs
+++ b/ecdsa/src/signing.rs
@@ -38,7 +38,7 @@ use crate::elliptic_curve::{
     AffinePoint,
 };
 
-#[cfg(feature = "verify")]
+#[cfg(feature = "verifying")]
 use {crate::VerifyingKey, elliptic_curve::PublicKey, signature::KeypairRef};
 
 /// ECDSA signing key. Generic over elliptic curves.
@@ -46,7 +46,7 @@ use {crate::VerifyingKey, elliptic_curve::PublicKey, signature::KeypairRef};
 /// Requires an [`elliptic_curve::ProjectiveArithmetic`] impl on the curve, and a
 /// [`SignPrimitive`] impl on its associated `Scalar` type.
 #[derive(Clone)]
-#[cfg_attr(docsrs, doc(cfg(feature = "sign")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "signing")))]
 pub struct SigningKey<C>
 where
     C: PrimeCurve + ProjectiveArithmetic,
@@ -57,7 +57,7 @@ where
     secret_scalar: NonZeroScalar<C>,
 
     /// Verifying key which corresponds to this signing key.
-    #[cfg(feature = "verify")]
+    #[cfg(feature = "verifying")]
     verifying_key: VerifyingKey<C>,
 }
 
@@ -96,8 +96,8 @@ where
     }
 
     /// Get the [`VerifyingKey`] which corresponds to this [`SigningKey`].
-    #[cfg(feature = "verify")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "verify")))]
+    #[cfg(feature = "verifying")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "verifying")))]
     pub fn verifying_key(&self) -> &VerifyingKey<C> {
         &self.verifying_key
     }
@@ -274,8 +274,8 @@ where
 // Other trait impls
 //
 
-#[cfg(feature = "verify")]
-#[cfg_attr(docsrs, doc(cfg(feature = "verify")))]
+#[cfg(feature = "verifying")]
+#[cfg_attr(docsrs, doc(cfg(feature = "verifying")))]
 impl<C> AsRef<VerifyingKey<C>> for SigningKey<C>
 where
     C: PrimeCurve + ProjectiveArithmetic,
@@ -348,12 +348,12 @@ where
     SignatureSize<C>: ArrayLength<u8>,
 {
     fn from(secret_scalar: NonZeroScalar<C>) -> Self {
-        #[cfg(feature = "verify")]
+        #[cfg(feature = "verifying")]
         let public_key = PublicKey::from_secret_scalar(&secret_scalar);
 
         Self {
             secret_scalar,
-            #[cfg(feature = "verify")]
+            #[cfg(feature = "verifying")]
             verifying_key: public_key.into(),
         }
     }
@@ -424,7 +424,7 @@ where
 {
 }
 
-#[cfg(feature = "verify")]
+#[cfg(feature = "verifying")]
 impl<C> From<SigningKey<C>> for VerifyingKey<C>
 where
     C: PrimeCurve + ProjectiveArithmetic,
@@ -436,7 +436,7 @@ where
     }
 }
 
-#[cfg(feature = "verify")]
+#[cfg(feature = "verifying")]
 impl<C> From<&SigningKey<C>> for VerifyingKey<C>
 where
     C: PrimeCurve + ProjectiveArithmetic,
@@ -448,8 +448,8 @@ where
     }
 }
 
-#[cfg(feature = "verify")]
-#[cfg_attr(docsrs, doc(cfg(feature = "verify")))]
+#[cfg(feature = "verifying")]
+#[cfg_attr(docsrs, doc(cfg(feature = "verifying")))]
 impl<C> KeypairRef for SigningKey<C>
 where
     C: PrimeCurve + ProjectiveArithmetic,

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -46,7 +46,7 @@ use serdect::serde::{de, ser, Deserialize, Serialize};
 ///
 /// The serialization leverages the encoding used by the [`PublicKey`] type,
 /// which is a binary-oriented ASN.1 DER encoding.
-#[cfg_attr(docsrs, doc(cfg(feature = "verify")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "verifying")))]
 #[derive(Clone, Debug)]
 pub struct VerifyingKey<C>
 where


### PR DESCRIPTION
Corresponding to the module name changes in #609, this renames the crate feature names to match:

- `sign` => `signing`
- `verify` => `verifying`

This better matches the `SigningKey` and `VerifyingKey` type names.