### PR TITLE
Bump `signature` crate dependency to v2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ dependencies = [
  "rfc6979",
  "sha1",
  "sha2 0.10.6",
- "signature 2.0.0-rc.1",
+ "signature 2.0.0",
  "zeroize",
 ]
 
@@ -167,7 +167,7 @@ dependencies = [
  "rfc6979",
  "serdect",
  "sha2 0.10.6",
- "signature 2.0.0-rc.1",
+ "signature 2.0.0",
 ]
 
 [[package]]
@@ -190,7 +190,7 @@ dependencies = [
  "rand_core 0.5.1",
  "serde",
  "serde_bytes",
- "signature 2.0.0-rc.1",
+ "signature 2.0.0",
  "zeroize",
 ]
 
@@ -580,9 +580,9 @@ checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
 name = "signature"
-version = "2.0.0-rc.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27af965d7572471973d1307767b3d7ecaff1b7a26674bbbe16877e5dc4cc60d"
+checksum = "8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d"
 dependencies = [
  "digest 0.10.6",
  "rand_core 0.6.4",

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -21,7 +21,7 @@ num-traits = { version = "0.2", default-features = false }
 pkcs8 = { version = "0.9", default-features = false, features = ["alloc"] }
 rfc6979 = { version = "0.3", path = "../rfc6979" }
 sha2 = { version = "0.10", default-features = false }
-signature = { version = "=2.0.0-rc.1", default-features = false, features = ["alloc", "digest-preview", "rand-preview"] }
+signature = { version = "2.0, <2.1", default-features = false, features = ["alloc", "digest", "rand_core"] }
 zeroize = { version = "1.5", default-features = false }
 
 [dev-dependencies]

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.57"
 
 [dependencies]
 elliptic-curve = { version = "0.12", default-features = false, features = ["digest", "sec1"] }
-signature = { version = "=2.0.0-rc.1", default-features = false, features = ["rand-preview"] }
+signature = { version = "2.0, <2.1", default-features = false, features = ["rand_core"] }
 
 # optional dependencies
 der = { version = "0.6", optional = true }
@@ -36,7 +36,7 @@ std = ["alloc", "elliptic-curve/std", "signature/std"]
 
 arithmetic = ["elliptic-curve/arithmetic"]
 dev = ["arithmetic", "digest", "elliptic-curve/dev", "hazmat"]
-digest = ["signature/digest-preview"]
+digest = ["signature/digest"]
 hazmat = []
 pkcs8 = ["elliptic-curve/pkcs8", "der"]
 pem = ["elliptic-curve/pem", "pkcs8"]

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-signature = { version = "=2.0.0-rc.1", default-features = false }
+signature = { version = "2", default-features = false }
 
 # optional dependencies
 pkcs8 = { version = "0.9", optional = true }


### PR DESCRIPTION
Release notes: https://github.com/RustCrypto/traits/pull/1211