### PR TITLE
ed25519 v1.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "bincode",
  "ed25519-dalek",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "bincode",
  "ed25519-dalek",

--- a/ed25519/CHANGELOG.md
+++ b/ed25519/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.5.3 (2023-01-15)
+### Changed
+- Fix `signature` version requirement which accidentally matched v2 or above ([#616])
+
+[#616]: https://github.com/RustCrypto/signatures/pull/616
+
 ## 1.5.2 (2022-05-16)
 ### Fixed
 - Overflow handling in `serde` deserializers ([#482])

--- a/ed25519/CHANGELOG.md
+++ b/ed25519/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.5.2 (2022-05-16)
+### Fixed
+- Overflow handling in `serde` deserializers ([#482])
+
+[#482]: https://github.com/RustCrypto/signatures/pull/482
+
 ## 1.5.1 (2022-05-15)
 ### Fixed
 - Use `TryInto` in `serde` deserializers ([#479])

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed25519"
-version = "1.5.2"
+version = "1.5.3"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """
@@ -17,7 +17,7 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-signature = { version = ">=1.3.1", default-features = false }
+signature = { version = "1.3.1", default-features = false }
 
 # optional dependencies
 pkcs8 = { version = "0.9", optional = true }

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed25519"
-version = "1.5.1"
+version = "1.5.2"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """


### PR DESCRIPTION
### Changed
- Fix `signature` version requirement which accidentally matched v2 or above ([#616])

Closes #615.

Note this PR isn't intended to be merged and is just for publicly tracking the changes.

[#616]: https://github.com/RustCrypto/signatures/pull/616