### PR TITLE
dsa v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "dsa"
-version = "0.5.0-rc.1"
+version = "0.5.0"
 dependencies = [
  "digest 0.10.6",
  "num-bigint-dig",

--- a/dsa/CHANGELOG.md
+++ b/dsa/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2023-01-15)
+### Changed
+- Use `&mut impl CryptoRngCore` ([#579])
+- Bump `signature` crate dependency to v2.0 ([#614])
+
+### Removed
+- Use of `opaque-debug` ([#572])
+
+[#572]: https://github.com/RustCrypto/signatures/pull/572
+[#579]: https://github.com/RustCrypto/signatures/pull/579
+[#614]: https://github.com/RustCrypto/signatures/pull/614
+
 ## 0.4.2 (2022-10-29)
 ### Added
 - Expose signing and verifying of prehashed hash value ([#558])

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsa"
-version = "0.5.0-rc.1"
+version = "0.5.0"
 description = """
 Pure Rust implementation of the Digital Signature Algorithm (DSA) as specified
 in FIPS 186-4 (Digital Signature Standard), providing RFC6979 deterministic

--- a/dsa/LICENSE-MIT
+++ b/dsa/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2018-2022 RustCrypto Developers
+Copyright (c) 2018-2023 RustCrypto Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated


### PR DESCRIPTION
### Changed
- Use `&mut impl CryptoRngCore` ([#579])
- Bump `signature` crate dependency to v2.0 ([#614])

### Removed
- Use of `opaque-debug` ([#572])

[#572]: https://github.com/RustCrypto/signatures/pull/572
[#579]: https://github.com/RustCrypto/signatures/pull/579
[#614]: https://github.com/RustCrypto/signatures/pull/614