### PR TITLE
ed25519: factor out `hex` module

### DIFF
--- a/ed25519/src/hex.rs
+++ b/ed25519/src/hex.rs
@@ -1,0 +1,72 @@
+//! Hexadecimal encoding support
+// TODO(tarcieri): use `base16ct`?
+
+use crate::{Error, Signature};
+use core::{fmt, str};
+
+impl fmt::LowerHex for Signature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for component in [&self.R, &self.s] {
+            for byte in component {
+                write!(f, "{:02x}", byte)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl fmt::UpperHex for Signature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for component in [&self.R, &self.s] {
+            for byte in component {
+                write!(f, "{:02X}", byte)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Decode a signature from hexadecimal.
+///
+/// Upper and lower case hexadecimal are both accepted, however mixed case is
+/// rejected.
+// TODO(tarcieri): use `base16ct`?
+impl str::FromStr for Signature {
+    type Err = Error;
+
+    fn from_str(hex: &str) -> signature::Result<Self> {
+        if hex.as_bytes().len() != Signature::BYTE_SIZE * 2 {
+            return Err(Error::new());
+        }
+
+        let mut upper_case = None;
+
+        // Ensure all characters are valid and case is not mixed
+        for &byte in hex.as_bytes() {
+            match byte {
+                b'0'..=b'9' => (),
+                b'a'..=b'z' => match upper_case {
+                    Some(true) => return Err(Error::new()),
+                    Some(false) => (),
+                    None => upper_case = Some(false),
+                },
+                b'A'..=b'Z' => match upper_case {
+                    Some(true) => (),
+                    Some(false) => return Err(Error::new()),
+                    None => upper_case = Some(true),
+                },
+                _ => return Err(Error::new()),
+            }
+        }
+
+        let mut result = [0u8; Self::BYTE_SIZE];
+        for (digit, byte) in hex.as_bytes().chunks_exact(2).zip(result.iter_mut()) {
+            *byte = str::from_utf8(digit)
+                .ok()
+                .and_then(|s| u8::from_str_radix(s, 16).ok())
+                .ok_or_else(Error::new)?;
+        }
+
+        Self::try_from(&result[..])
+    }
+}

--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -260,6 +260,8 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
+mod hex;
+
 #[cfg(feature = "pkcs8")]
 pub mod pkcs8;
 
@@ -271,20 +273,20 @@ pub use signature::{self, Error, SignatureEncoding};
 #[cfg(feature = "pkcs8")]
 pub use crate::pkcs8::{KeypairBytes, PublicKeyBytes};
 
-use core::{fmt, str};
+use core::fmt;
 
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
-/// Ed25519 signature serialized as a byte array.
-pub type SignatureBytes = [u8; Signature::BYTE_SIZE];
+/// Size of a single component of an Ed25519 signature.
+const COMPONENT_SIZE: usize = 32;
 
 /// Size of an `R` or `s` component of an Ed25519 signature when serialized
 /// as bytes.
 pub type ComponentBytes = [u8; COMPONENT_SIZE];
 
-/// Size of a single component of an Ed25519 signature.
-const COMPONENT_SIZE: usize = 32;
+/// Ed25519 signature serialized as a byte array.
+pub type SignatureBytes = [u8; Signature::BYTE_SIZE];
 
 /// Ed25519 signature.
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -407,72 +409,5 @@ impl fmt::Debug for Signature {
 impl fmt::Display for Signature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:X}", self)
-    }
-}
-
-impl fmt::LowerHex for Signature {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for component in [&self.R, &self.s] {
-            for byte in component {
-                write!(f, "{:02x}", byte)?;
-            }
-        }
-        Ok(())
-    }
-}
-
-impl fmt::UpperHex for Signature {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for component in [&self.R, &self.s] {
-            for byte in component {
-                write!(f, "{:02X}", byte)?;
-            }
-        }
-        Ok(())
-    }
-}
-
-/// Decode a signature from hexadecimal.
-///
-/// Upper and lower case hexadecimal are both accepted, however mixed case is
-/// rejected.
-// TODO(tarcieri): use `base16ct`?
-impl str::FromStr for Signature {
-    type Err = Error;
-
-    fn from_str(hex: &str) -> signature::Result<Self> {
-        if hex.as_bytes().len() != Signature::BYTE_SIZE * 2 {
-            return Err(Error::new());
-        }
-
-        let mut upper_case = None;
-
-        // Ensure all characters are valid and case is not mixed
-        for &byte in hex.as_bytes() {
-            match byte {
-                b'0'..=b'9' => (),
-                b'a'..=b'z' => match upper_case {
-                    Some(true) => return Err(Error::new()),
-                    Some(false) => (),
-                    None => upper_case = Some(false),
-                },
-                b'A'..=b'Z' => match upper_case {
-                    Some(true) => (),
-                    Some(false) => return Err(Error::new()),
-                    None => upper_case = Some(true),
-                },
-                _ => return Err(Error::new()),
-            }
-        }
-
-        let mut result = [0u8; Self::BYTE_SIZE];
-        for (digit, byte) in hex.as_bytes().chunks_exact(2).zip(result.iter_mut()) {
-            *byte = str::from_utf8(digit)
-                .ok()
-                .and_then(|s| u8::from_str_radix(s, 16).ok())
-                .ok_or_else(Error::new)?;
-        }
-
-        Self::try_from(&result[..])
     }
 }


### PR DESCRIPTION
Note: should probably be replaced with `base16ct` as an optional dependency, but this is a quick cleanup.