### PR TITLE
ed25519: infallible signature parsing

### DIFF
--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -289,6 +289,13 @@ pub type ComponentBytes = [u8; COMPONENT_SIZE];
 pub type SignatureBytes = [u8; Signature::BYTE_SIZE];
 
 /// Ed25519 signature.
+///
+/// This type represents a container for the byte serialization of an Ed25519
+/// signature, and does not necessarily represent well-formed elements of the
+/// respective elliptic curve fields.
+///
+/// Signature verification libraries are expected to reject invalid field
+/// elements at the time a signature is verified.
 #[derive(Copy, Clone, Eq, PartialEq)]
 #[repr(C)]
 pub struct Signature {

--- a/ed25519/src/serde.rs
+++ b/ed25519/src/serde.rs
@@ -51,8 +51,9 @@ impl<'de> Deserialize<'de> for Signature {
             }
         }
 
-        let bytes = deserializer.deserialize_tuple(Signature::BYTE_SIZE, ByteArrayVisitor)?;
-        Self::from_bytes(&bytes).map_err(de::Error::custom)
+        deserializer
+            .deserialize_tuple(Signature::BYTE_SIZE, ByteArrayVisitor)
+            .map(Into::into)
     }
 }
 
@@ -93,8 +94,9 @@ impl<'de> serde_bytes::Deserialize<'de> for Signature {
             }
         }
 
-        let bytes = deserializer.deserialize_bytes(ByteArrayVisitor)?;
-        Self::from_bytes(&bytes).map_err(de::Error::custom)
+        deserializer
+            .deserialize_bytes(ByteArrayVisitor)
+            .map(Into::into)
     }
 }
 
@@ -114,15 +116,9 @@ mod tests {
 
     #[test]
     fn round_trip() {
-        let signature = Signature::from_bytes(&SIGNATURE_BYTES).unwrap();
+        let signature = Signature::from_bytes(&SIGNATURE_BYTES);
         let serialized = bincode::serialize(&signature).unwrap();
         let deserialized = bincode::deserialize(&serialized).unwrap();
         assert_eq!(signature, deserialized);
-    }
-
-    #[test]
-    fn overflow() {
-        let bytes = hex!("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-        assert!(bincode::deserialize::<Signature>(&bytes).is_err());
     }
 }

--- a/ed25519/tests/hex.rs
+++ b/ed25519/tests/hex.rs
@@ -15,19 +15,19 @@ const TEST_1_SIGNATURE: [u8; Signature::BYTE_SIZE] = hex!(
 
 #[test]
 fn display() {
-    let sig = Signature::from_bytes(&TEST_1_SIGNATURE).unwrap();
+    let sig = Signature::from_bytes(&TEST_1_SIGNATURE);
     assert_eq!(sig.to_string(), "E5564300C360AC729086E2CC806E828A84877F1EB8E5D974D873E065224901555FB8821590A33BACC61E39701CF9B46BD25BF5F0595BBE24655141438E7A100B")
 }
 
 #[test]
 fn lower_hex() {
-    let sig = Signature::from_bytes(&TEST_1_SIGNATURE).unwrap();
+    let sig = Signature::from_bytes(&TEST_1_SIGNATURE);
     assert_eq!(format!("{:x}", sig), "e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b")
 }
 
 #[test]
 fn upper_hex() {
-    let sig = Signature::from_bytes(&TEST_1_SIGNATURE).unwrap();
+    let sig = Signature::from_bytes(&TEST_1_SIGNATURE);
     assert_eq!(format!("{:X}", sig), "E5564300C360AC729086E2CC806E828A84877F1EB8E5D974D873E065224901555FB8821590A33BACC61E39701CF9B46BD25BF5F0595BBE24655141438E7A100B")
 }
 
@@ -46,11 +46,5 @@ fn from_str_upper() {
 #[test]
 fn from_str_rejects_mixed_case() {
     let result = Signature::from_str("E5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b");
-    assert!(result.is_err());
-}
-
-#[test]
-fn from_str_rejects_invalid_signature() {
-    let result = Signature::from_str("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
     assert!(result.is_err());
 }


### PR DESCRIPTION
We've had a couple request to make signature parsing infallible. Presently it checks that the `s` scalar component of the signature has its three highest bits clear, which will reject some but not all signatures where `s` overflows the curve's order.

However, this check will not reject *all* such invalid signatures (at least as presently implemented), and the same check will be performed at the time the signature is verified (which *will* reject all such invalid signatures).

Though we already shipped `ed25519` v2.0.0 and this is a breaking change, that release has been yanked so we can get this change in last minute.