### PR TITLE
ed25519 v2.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "bincode",
  "ed25519-dalek",

--- a/ed25519/CHANGELOG.md
+++ b/ed25519/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 2.0.0 (2023-01-15)
+## 2.0.1 (2023-01-21)
+### Changed
+- Make `Signature` parsing infallible ([#623])
+
+[#623]: https://github.com/RustCrypto/signatures/pull/623
+
+## 2.0.0 (2023-01-15) [YANKED]
 ### Added
 - `pkcs8` re-exports ([#589], [#590], [#591], [#592])
 - `Signature::from_components` method ([#600])

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed25519"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """

--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -291,8 +291,8 @@ pub type SignatureBytes = [u8; Signature::BYTE_SIZE];
 /// Ed25519 signature.
 ///
 /// This type represents a container for the byte serialization of an Ed25519
-/// signature, and does not necessarily represent well-formed elements of the
-/// respective elliptic curve fields.
+/// signature, and does not necessarily represent well-formed field or curve
+/// elements.
 ///
 /// Signature verification libraries are expected to reject invalid field
 /// elements at the time a signature is verified.


### PR DESCRIPTION
### Changed
- Make `Signature` parsing infallible ([#623])

[#623]: https://github.com/RustCrypto/signatures/pull/623