### PR TITLE
ed25519: fix `rust-version` in Cargo.toml

### DIFF
--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "curve25519", "ecc", "signature", "signing"]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [dependencies]
 signature = { version = "2", default-features = false }


### PR DESCRIPTION
The tested MSRV is 1.57, not 1.56.

It's correctly noted in the crate's README.md.