### PR TITLE
ed25519: have `TryFrom<&[u8]>` call `Signature::from_slice`

### DIFF
--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -397,9 +397,7 @@ impl TryFrom<&[u8]> for Signature {
     type Error = Error;
 
     fn try_from(bytes: &[u8]) -> signature::Result<Self> {
-        SignatureBytes::try_from(bytes)
-            .map(Into::into)
-            .map_err(|_| Error::new())
+        Self::from_slice(bytes)
     }
 }
 


### PR DESCRIPTION
The code is otherwise duplicated