### PR TITLE
ecdsa: refactor RFC6979 usage and trait impls

### DIFF
--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -30,16 +30,13 @@ use {
 use {
     elliptic_curve::FieldSize,
     signature::{
-        digest::{core_api::BlockSizeUser, Digest, FixedOutputReset},
+        digest::{core_api::BlockSizeUser, Digest, FixedOutput, FixedOutputReset},
         PrehashSignature,
     },
 };
 
 #[cfg(any(feature = "arithmetic", feature = "digest"))]
 use crate::{elliptic_curve::generic_array::ArrayLength, Signature};
-
-#[cfg(all(feature = "arithmetic", feature = "digest"))]
-use signature::digest::FixedOutput;
 
 #[cfg(feature = "rfc6979")]
 use elliptic_curve::ScalarPrimitive;
@@ -134,24 +131,6 @@ where
         let k = Self::from(ScalarPrimitive::<C>::new(*k).unwrap());
         self.try_sign_prehashed(k, z)
     }
-
-    /// Try to sign the given digest instance using the method described in
-    /// [RFC6979].
-    ///
-    /// [RFC6979]: https://datatracker.ietf.org/doc/html/rfc6979
-    #[cfg(all(feature = "rfc6979"))]
-    fn try_sign_digest_rfc6979<D>(
-        &self,
-        msg_digest: D,
-        ad: &[u8],
-    ) -> Result<(Signature<C>, Option<RecoveryId>)>
-    where
-        Self: From<ScalarPrimitive<C>>,
-        C::Uint: for<'a> From<&'a Self>,
-        D: Digest + BlockSizeUser + FixedOutput<OutputSize = FieldSize<C>> + FixedOutputReset,
-    {
-        self.try_sign_prehashed_rfc6979::<D>(msg_digest.finalize_fixed(), ad)
-    }
 }
 
 /// Verify the given prehashed message using ECDSA.
@@ -219,7 +198,10 @@ where
 pub trait DigestPrimitive: PrimeCurve {
     /// Preferred digest to use when computing ECDSA signatures for this
     /// elliptic curve. This is typically a member of the SHA-2 family.
-    type Digest: BlockSizeUser + Digest + FixedOutputReset;
+    type Digest: BlockSizeUser
+        + Digest
+        + FixedOutput<OutputSize = FieldSize<Self>>
+        + FixedOutputReset;
 }
 
 #[cfg(feature = "digest")]

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -32,7 +32,8 @@ use core::str::FromStr;
 #[cfg(all(feature = "pem", feature = "serde"))]
 use serdect::serde::{de, ser, Deserialize, Serialize};
 
-/// ECDSA verification key (i.e. public key). Generic over elliptic curves.
+/// ECDSA public key used for verifying signatures. Generic over prime order
+/// elliptic curves (e.g. NIST P-curves)
 ///
 /// Requires an [`elliptic_curve::CurveArithmetic`] impl on the curve, and a
 /// [`VerifyPrimitive`] impl on its associated `AffinePoint` type.


### PR DESCRIPTION
Uses `C::Digest` unilaterally as the digest function to instantiate HMAC-DRBG for RFC6979. This replaces the previous inconsistent usage where sometimes `C::Digest` was used while in `DigestSigner` the generic `D` parameter was used.

With this, the various trait impls can be composed one in terms of the other:

    `*Signer` -> `*DigestSigner` -> `*PrehashSigner`

This commit also removes `SignPrimitive::try_sign_digest_rfc6979` as the `*PrehashSigner` impls are now the only caller into `SignPrimitive` and the `DigestSigner` impls handle hashing.