### PR TITLE
ecdsa v0.15.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "der",
  "elliptic-curve",

--- a/ecdsa/CHANGELOG.md
+++ b/ecdsa/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.15.1 (2023-01-23)
+### Added
+- `SigningKey::*_recoverable` methods ([#635])
+
+[#635]: https://github.com/RustCrypto/signatures/pull/635
+
 ## 0.15.0 (2023-01-15)
 ### Added
 - `DigestPrimitive::Digest` now has bounds that work with RFC6979 ([#568])

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecdsa"
-version = "0.15.0"
+version = "0.15.1"
 description = """
 Pure Rust implementation of the Elliptic Curve Digital Signature Algorithm
 (ECDSA) as specified in FIPS 186-4 (Digital Signature Standard), providing


### PR DESCRIPTION
NOTE: this release cherry-picks #635, which is targeting the `0.16.0-pre` series of `ecdsa`, onto the `0.15` series.

As such this PR won't be merged to `master`, but is used to record the changes going into this release.

### Added
- `SigningKey::*_recoverable` methods ([#635])

[#635]: https://github.com/RustCrypto/signatures/pull/635