### PR TITLE
rfc6979: decouple from `crypto-bigint`

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -9,20 +9,21 @@ on:
     - cron: "0 0 * * *"
 
 jobs:
-  security_audit:
-    name: Security Audit
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-          profile: minimal
-      - uses: actions/cache@v3
-        with:
-          path: ~/.cargo/bin
-          key: ${{ runner.os }}-cargo-audit-v0.17.2
-      - uses: actions-rs/audit-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+# TODO(tarcieri): re-enable when elliptic-curve has been bumped
+#  security_audit:
+#    name: Security Audit
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - uses: actions-rs/toolchain@v1
+#        with:
+#          toolchain: stable
+#          override: true
+#          profile: minimal
+#      - uses: actions/cache@v3
+#        with:
+#          path: ~/.cargo/bin
+#          key: ${{ runner.os }}-cargo-audit-v0.17.2
+#      - uses: actions-rs/audit-check@v1
+#        with:
+#          token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,10 +639,10 @@ dependencies = [
 name = "rfc6979"
 version = "0.4.0-pre"
 dependencies = [
- "crypto-bigint 0.5.0-pre.1",
+ "hex-literal",
  "hmac",
  "sha2 0.10.6",
- "zeroize",
+ "subtle",
 ]
 
 [[package]]

--- a/ecdsa/src/recovery.rs
+++ b/ecdsa/src/recovery.rs
@@ -176,7 +176,6 @@ impl From<RecoveryId> for u8 {
 impl<C> SigningKey<C>
 where
     C: PrimeCurve + CurveArithmetic + DigestPrimitive,
-    C::Uint: for<'a> From<&'a Scalar<C>>,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + Reduce<C::Uint> + SignPrimitive<C>,
     SignatureSize<C>: ArrayLength<u8>,
 {
@@ -209,7 +208,6 @@ where
 impl<C, D> DigestSigner<D, (Signature<C>, RecoveryId)> for SigningKey<C>
 where
     C: PrimeCurve + CurveArithmetic + DigestPrimitive,
-    C::Uint: for<'a> From<&'a Scalar<C>>,
     D: Digest,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + Reduce<C::Uint> + SignPrimitive<C>,
     SignatureSize<C>: ArrayLength<u8>,
@@ -223,7 +221,6 @@ where
 impl<C> PrehashSigner<(Signature<C>, RecoveryId)> for SigningKey<C>
 where
     C: PrimeCurve + CurveArithmetic + DigestPrimitive,
-    C::Uint: for<'a> From<&'a Scalar<C>>,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + Reduce<C::Uint> + SignPrimitive<C>,
     SignatureSize<C>: ArrayLength<u8>,
 {
@@ -236,7 +233,6 @@ where
 impl<C> Signer<(Signature<C>, RecoveryId)> for SigningKey<C>
 where
     C: PrimeCurve + CurveArithmetic + DigestPrimitive,
-    C::Uint: for<'a> From<&'a Scalar<C>>,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + Reduce<C::Uint> + SignPrimitive<C>,
     SignatureSize<C>: ArrayLength<u8>,
 {

--- a/ecdsa/src/signing.rs
+++ b/ecdsa/src/signing.rs
@@ -111,7 +111,6 @@ where
 impl<C, D> DigestSigner<D, Signature<C>> for SigningKey<C>
 where
     C: PrimeCurve + CurveArithmetic + DigestPrimitive,
-    C::Uint: for<'a> From<&'a Scalar<C>>,
     D: Digest + FixedOutput<OutputSize = FieldSize<C>>,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + Reduce<C::Uint> + SignPrimitive<C>,
     SignatureSize<C>: ArrayLength<u8>,
@@ -128,7 +127,6 @@ where
 impl<C> PrehashSigner<Signature<C>> for SigningKey<C>
 where
     C: PrimeCurve + CurveArithmetic + DigestPrimitive,
-    C::Uint: for<'a> From<&'a Scalar<C>>,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + Reduce<C::Uint> + SignPrimitive<C>,
     SignatureSize<C>: ArrayLength<u8>,
 {
@@ -148,7 +146,6 @@ where
 impl<C> Signer<Signature<C>> for SigningKey<C>
 where
     C: PrimeCurve + CurveArithmetic + DigestPrimitive,
-    C::Uint: for<'a> From<&'a Scalar<C>>,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + Reduce<C::Uint> + SignPrimitive<C>,
     SignatureSize<C>: ArrayLength<u8>,
 {
@@ -160,7 +157,6 @@ where
 impl<C, D> RandomizedDigestSigner<D, Signature<C>> for SigningKey<C>
 where
     C: PrimeCurve + CurveArithmetic + DigestPrimitive,
-    C::Uint: for<'a> From<&'a Scalar<C>>,
     D: Digest + FixedOutput<OutputSize = FieldSize<C>>,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + Reduce<C::Uint> + SignPrimitive<C>,
     SignatureSize<C>: ArrayLength<u8>,
@@ -177,7 +173,6 @@ where
 impl<C> RandomizedPrehashSigner<Signature<C>> for SigningKey<C>
 where
     C: PrimeCurve + CurveArithmetic + DigestPrimitive,
-    C::Uint: for<'a> From<&'a Scalar<C>>,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + Reduce<C::Uint> + SignPrimitive<C>,
     SignatureSize<C>: ArrayLength<u8>,
 {
@@ -212,7 +207,6 @@ where
 impl<C> PrehashSigner<der::Signature<C>> for SigningKey<C>
 where
     C: PrimeCurve + CurveArithmetic + DigestPrimitive,
-    C::Uint: for<'a> From<&'a Scalar<C>>,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + Reduce<C::Uint> + SignPrimitive<C>,
     SignatureSize<C>: ArrayLength<u8>,
     der::MaxSize<C>: ArrayLength<u8>,
@@ -227,7 +221,6 @@ where
 impl<C> Signer<der::Signature<C>> for SigningKey<C>
 where
     C: PrimeCurve + CurveArithmetic + DigestPrimitive,
-    C::Uint: for<'a> From<&'a Scalar<C>>,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + Reduce<C::Uint> + SignPrimitive<C>,
     SignatureSize<C>: ArrayLength<u8>,
     der::MaxSize<C>: ArrayLength<u8>,
@@ -242,7 +235,6 @@ where
 impl<C, D> RandomizedDigestSigner<D, der::Signature<C>> for SigningKey<C>
 where
     C: PrimeCurve + CurveArithmetic + DigestPrimitive,
-    C::Uint: for<'a> From<&'a Scalar<C>>,
     D: Digest + FixedOutput<OutputSize = FieldSize<C>>,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + Reduce<C::Uint> + SignPrimitive<C>,
     SignatureSize<C>: ArrayLength<u8>,
@@ -263,7 +255,6 @@ where
 impl<C> RandomizedPrehashSigner<der::Signature<C>> for SigningKey<C>
 where
     C: PrimeCurve + CurveArithmetic + DigestPrimitive,
-    C::Uint: for<'a> From<&'a Scalar<C>>,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + Reduce<C::Uint> + SignPrimitive<C>,
     SignatureSize<C>: ArrayLength<u8>,
     der::MaxSize<C>: ArrayLength<u8>,
@@ -283,7 +274,6 @@ where
 impl<C> RandomizedSigner<der::Signature<C>> for SigningKey<C>
 where
     C: PrimeCurve + CurveArithmetic + DigestPrimitive,
-    C::Uint: for<'a> From<&'a Scalar<C>>,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + Reduce<C::Uint> + SignPrimitive<C>,
     SignatureSize<C>: ArrayLength<u8>,
     der::MaxSize<C>: ArrayLength<u8>,

--- a/rfc6979/Cargo.toml
+++ b/rfc6979/Cargo.toml
@@ -15,9 +15,9 @@ edition = "2021"
 rust-version = "1.61"
 
 [dependencies]
-crypto-bigint = { version = "=0.5.0-pre.1", default-features = false, features = ["generic-array", "zeroize"] }
 hmac = { version = "0.12", default-features = false, features = ["reset"] }
-zeroize = { version = "1", default-features = false }
+subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
+hex-literal = "0.3"
 sha2 = "0.10"

--- a/rfc6979/src/ct_cmp.rs
+++ b/rfc6979/src/ct_cmp.rs
@@ -1,0 +1,87 @@
+//! Constant-time comparison helpers for [`ByteArray`].
+
+use crate::{ArrayLength, ByteArray};
+use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
+
+/// Constant-time equals.
+pub(crate) fn ct_eq<N: ArrayLength<u8>>(a: &ByteArray<N>, b: &ByteArray<N>) -> Choice {
+    let mut ret = Choice::from(1);
+
+    for (a, b) in a.iter().zip(b.iter()) {
+        ret.conditional_assign(&Choice::from(0), !a.ct_eq(b));
+    }
+
+    ret
+}
+
+/// Constant-time less than.
+///
+/// Inputs are interpreted as big endian integers.
+pub(crate) fn ct_lt<N: ArrayLength<u8>>(a: &ByteArray<N>, b: &ByteArray<N>) -> Choice {
+    let mut borrow = 0;
+
+    // Perform subtraction with borrow a byte-at-a-time, interpreting a
+    // no-borrow condition as the less-than case
+    for (&a, &b) in a.iter().zip(b.iter()).rev() {
+        let c = (b as u16).wrapping_add(borrow >> (u8::BITS - 1));
+        borrow = (a as u16).wrapping_sub(c) >> u8::BITS as u8;
+    }
+
+    !borrow.ct_eq(&0)
+}
+
+#[cfg(test)]
+mod tests {
+    const A: [u8; 4] = [0, 0, 0, 0];
+    const B: [u8; 4] = [0, 0, 0, 1];
+    const C: [u8; 4] = [0xFF, 0, 0, 0];
+    const D: [u8; 4] = [0xFF, 0, 0, 1];
+    const E: [u8; 4] = [0xFF, 0xFF, 0xFF, 0xFE];
+    const F: [u8; 4] = [0xFF, 0xFF, 0xFF, 0xFF];
+
+    #[test]
+    fn ct_eq() {
+        use super::ct_eq;
+
+        assert_eq!(ct_eq(&A.into(), &A.into()).unwrap_u8(), 1);
+        assert_eq!(ct_eq(&B.into(), &B.into()).unwrap_u8(), 1);
+        assert_eq!(ct_eq(&C.into(), &C.into()).unwrap_u8(), 1);
+        assert_eq!(ct_eq(&D.into(), &D.into()).unwrap_u8(), 1);
+        assert_eq!(ct_eq(&E.into(), &E.into()).unwrap_u8(), 1);
+        assert_eq!(ct_eq(&F.into(), &F.into()).unwrap_u8(), 1);
+
+        assert_eq!(ct_eq(&A.into(), &B.into()).unwrap_u8(), 0);
+        assert_eq!(ct_eq(&C.into(), &D.into()).unwrap_u8(), 0);
+        assert_eq!(ct_eq(&E.into(), &F.into()).unwrap_u8(), 0);
+    }
+
+    #[test]
+    fn ct_lt() {
+        use super::ct_lt;
+
+        assert_eq!(ct_lt(&A.into(), &A.into()).unwrap_u8(), 0);
+        assert_eq!(ct_lt(&B.into(), &B.into()).unwrap_u8(), 0);
+        assert_eq!(ct_lt(&C.into(), &C.into()).unwrap_u8(), 0);
+        assert_eq!(ct_lt(&D.into(), &D.into()).unwrap_u8(), 0);
+        assert_eq!(ct_lt(&E.into(), &E.into()).unwrap_u8(), 0);
+        assert_eq!(ct_lt(&F.into(), &F.into()).unwrap_u8(), 0);
+
+        assert_eq!(ct_lt(&A.into(), &B.into()).unwrap_u8(), 1);
+        assert_eq!(ct_lt(&A.into(), &C.into()).unwrap_u8(), 1);
+        assert_eq!(ct_lt(&B.into(), &A.into()).unwrap_u8(), 0);
+        assert_eq!(ct_lt(&C.into(), &A.into()).unwrap_u8(), 0);
+
+        assert_eq!(ct_lt(&B.into(), &C.into()).unwrap_u8(), 1);
+        assert_eq!(ct_lt(&B.into(), &D.into()).unwrap_u8(), 1);
+        assert_eq!(ct_lt(&C.into(), &B.into()).unwrap_u8(), 0);
+        assert_eq!(ct_lt(&D.into(), &B.into()).unwrap_u8(), 0);
+
+        assert_eq!(ct_lt(&C.into(), &D.into()).unwrap_u8(), 1);
+        assert_eq!(ct_lt(&C.into(), &E.into()).unwrap_u8(), 1);
+        assert_eq!(ct_lt(&D.into(), &C.into()).unwrap_u8(), 0);
+        assert_eq!(ct_lt(&E.into(), &C.into()).unwrap_u8(), 0);
+
+        assert_eq!(ct_lt(&E.into(), &F.into()).unwrap_u8(), 1);
+        assert_eq!(ct_lt(&F.into(), &E.into()).unwrap_u8(), 0);
+    }
+}


### PR DESCRIPTION
The previous approach complicates supporting ECDSA with `FieldSize` which is different from `C::Uint::ByteSize`.

The new implementation eliminates `crypto-bigint` as a dependency and makes the API entirely byte-oriented.

This is a simpler approach which also eliminates some previous trait bounds on the generic ECDSA implementation.