### PR TITLE
ecdsa: bump `elliptic-curve` to v0.13.0-pre.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.0-pre.1"
+version = "0.5.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "753eaa5e38b15c84bd939057ae9cee3d12eb52fff0ddf93d40ba5febcc0eb9ee"
+checksum = "c77f9ab26f2f9ea03c23c9da7d10ca989f6888e6960dbbbe1dc13cfe0d6d07b2"
 dependencies = [
  "generic-array",
  "rand_core 0.6.4",
@@ -207,7 +207,7 @@ name = "ecdsa"
 version = "0.16.0-pre"
 dependencies = [
  "der",
- "elliptic-curve 0.13.0-pre",
+ "elliptic-curve 0.13.0-pre.1",
  "hex-literal",
  "rfc6979",
  "serdect",
@@ -284,11 +284,12 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#778e6f4368422f87ba5d667095673423f8abccda"
+version = "0.13.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb7effce4b08a32c6550a49a6dd7b4cd5534c6478d2099cbd0a8918008adb52"
 dependencies = [
  "base16ct",
- "crypto-bigint 0.5.0-pre.1",
+ "crypto-bigint 0.5.0-pre.2",
  "digest 0.10.6",
  "ff 0.13.0",
  "generic-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,3 @@ members = [
 
 [profile.dev]
 opt-level = 2
-
-[patch.crates-io.elliptic-curve]
-git = "https://github.com/RustCrypto/traits.git"

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 rust-version = "1.61"
 
 [dependencies]
-elliptic-curve = { version = "=0.13.0-pre", default-features = false, features = ["digest", "sec1"] }
+elliptic-curve = { version = "=0.13.0-pre.1", default-features = false, features = ["digest", "sec1"] }
 signature = { version = "2.0, <2.1", default-features = false, features = ["rand_core"] }
 
 # optional dependencies
@@ -25,7 +25,7 @@ rfc6979 = { version = "=0.4.0-pre", optional = true, path = "../rfc6979" }
 serdect = { version = "0.1", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
-elliptic-curve = { version = "=0.13.0-pre", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "=0.13.0-pre.1", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 sha2 = { version = "0.10", default-features = false }
 

--- a/ecdsa/src/der.rs
+++ b/ecdsa/src/der.rs
@@ -10,7 +10,7 @@ use elliptic_curve::{
     bigint::Integer,
     consts::U9,
     generic_array::{ArrayLength, GenericArray},
-    FieldSize, PrimeCurve,
+    FieldBytesSize, PrimeCurve,
 };
 
 #[cfg(feature = "alloc")]
@@ -39,7 +39,7 @@ use serdect::serde::{de, ser, Deserialize, Serialize};
 pub type MaxOverhead = U9;
 
 /// Maximum size of an ASN.1 DER encoded signature for the given elliptic curve.
-pub type MaxSize<C> = <<FieldSize<C> as Add>::Output as Add<MaxOverhead>>::Output;
+pub type MaxSize<C> = <<FieldBytesSize<C> as Add>::Output as Add<MaxOverhead>>::Output;
 
 /// Byte array containing a serialized ASN.1 signature
 type SignatureBytes<C> = GenericArray<u8, MaxSize<C>>;
@@ -51,7 +51,7 @@ pub struct Signature<C>
 where
     C: PrimeCurve,
     MaxSize<C>: ArrayLength<u8>,
-    <FieldSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
+    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
 {
     /// ASN.1 DER-encoded signature data
     bytes: SignatureBytes<C>,
@@ -68,7 +68,7 @@ impl<C> Signature<C>
 where
     C: PrimeCurve,
     MaxSize<C>: ArrayLength<u8>,
-    <FieldSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
+    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
 {
     /// Get the length of the signature in bytes
     pub fn len(&self) -> usize {
@@ -120,7 +120,7 @@ impl<C> AsRef<[u8]> for Signature<C>
 where
     C: PrimeCurve,
     MaxSize<C>: ArrayLength<u8>,
-    <FieldSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
+    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
 {
     fn as_ref(&self) -> &[u8] {
         self.as_bytes()
@@ -131,7 +131,7 @@ impl<C> Clone for Signature<C>
 where
     C: PrimeCurve,
     MaxSize<C>: ArrayLength<u8>,
-    <FieldSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
+    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
 {
     fn clone(&self) -> Self {
         Self {
@@ -146,7 +146,7 @@ impl<C> Debug for Signature<C>
 where
     C: PrimeCurve,
     MaxSize<C>: ArrayLength<u8>,
-    <FieldSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
+    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "ecdsa::der::Signature<{:?}>(", C::default())?;
@@ -163,7 +163,7 @@ impl<C> From<crate::Signature<C>> for Signature<C>
 where
     C: PrimeCurve,
     MaxSize<C>: ArrayLength<u8>,
-    <FieldSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
+    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
 {
     fn from(sig: crate::Signature<C>) -> Signature<C> {
         sig.to_der()
@@ -174,7 +174,7 @@ impl<C> TryFrom<&[u8]> for Signature<C>
 where
     C: PrimeCurve,
     MaxSize<C>: ArrayLength<u8>,
-    <FieldSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
+    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
 {
     type Error = Error;
 
@@ -207,7 +207,7 @@ impl<C> TryFrom<Signature<C>> for crate::Signature<C>
 where
     C: PrimeCurve,
     MaxSize<C>: ArrayLength<u8>,
-    <FieldSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
+    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
 {
     type Error = Error;
 
@@ -226,7 +226,7 @@ impl<C> From<Signature<C>> for Box<[u8]>
 where
     C: PrimeCurve,
     MaxSize<C>: ArrayLength<u8>,
-    <FieldSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
+    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
 {
     fn from(signature: Signature<C>) -> Box<[u8]> {
         signature.to_vec().into_boxed_slice()
@@ -238,7 +238,7 @@ impl<C> SignatureEncoding for Signature<C>
 where
     C: PrimeCurve,
     MaxSize<C>: ArrayLength<u8>,
-    <FieldSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
+    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
 {
     type Repr = Box<[u8]>;
 
@@ -252,7 +252,7 @@ impl<C> Serialize for Signature<C>
 where
     C: PrimeCurve,
     MaxSize<C>: ArrayLength<u8>,
-    <FieldSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
+    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
 {
     fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
@@ -267,7 +267,7 @@ impl<'de, C> Deserialize<'de> for Signature<C>
 where
     C: PrimeCurve,
     MaxSize<C>: ArrayLength<u8>,
-    <FieldSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
+    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
 {
     fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
@@ -310,7 +310,7 @@ impl<C> signature::PrehashSignature for Signature<C>
 where
     C: PrimeCurve + crate::hazmat::DigestPrimitive,
     MaxSize<C>: ArrayLength<u8>,
-    <FieldSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
+    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
 {
     type Digest = C::Digest;
 }


### PR DESCRIPTION
Bumps the `elliptic-curve` crate to the latest prerelease on crates.io.

Notably this includes changes to how `FieldBytes` is encoded made with the goal of supporting elliptic curves with unusual moduli such as P-224 and P-521:

https://github.com/RustCrypto/traits/pull/1220