### PR TITLE
ecdsa: use `&FieldBytes<C>` consistently; fix tests

### DIFF
--- a/ecdsa/src/dev.rs
+++ b/ecdsa/src/dev.rs
@@ -53,7 +53,7 @@ macro_rules! new_signing_test {
                 let d = decode_scalar(vector.d).expect("invalid vector.d");
                 let k = decode_scalar(vector.k).expect("invalid vector.m");
                 let z = GenericArray::clone_from_slice(vector.m);
-                let sig = d.try_sign_prehashed(k, z).expect("ECDSA sign failed").0;
+                let sig = d.try_sign_prehashed(k, &z).expect("ECDSA sign failed").0;
 
                 assert_eq!(vector.r, sig.r().to_bytes().as_slice());
                 assert_eq!(vector.s, sig.s().to_bytes().as_slice());
@@ -95,7 +95,7 @@ macro_rules! new_verification_test {
                 )
                 .unwrap();
 
-                let result = q.verify_prehashed(z, &sig);
+                let result = q.verify_prehashed(&z, &sig);
                 assert!(result.is_ok());
             }
         }
@@ -120,7 +120,7 @@ macro_rules! new_verification_test {
                     Signature::from_scalars(GenericArray::clone_from_slice(vector.r), s_tweaked)
                         .unwrap();
 
-                let result = q.verify_prehashed(z, &sig);
+                let result = q.verify_prehashed(&z, &sig);
                 assert!(result.is_err());
             }
         }
@@ -133,7 +133,11 @@ macro_rules! new_verification_test {
 #[macro_export]
 macro_rules! new_wycheproof_test {
     ($name:ident, $test_name: expr, $curve:path) => {
-        use $crate::{elliptic_curve::sec1::EncodedPoint, signature::Verifier, Signature};
+        use $crate::{
+            elliptic_curve::{bigint::Integer, sec1::EncodedPoint},
+            signature::Verifier,
+            Signature,
+        };
 
         #[test]
         fn $name() {

--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -125,7 +125,7 @@ where
     #[cfg(all(feature = "rfc6979"))]
     fn try_sign_prehashed_rfc6979<D>(
         &self,
-        z: FieldBytes<C>,
+        z: &FieldBytes<C>,
         ad: &[u8],
     ) -> Result<(Signature<C>, Option<RecoveryId>)>
     where
@@ -135,11 +135,11 @@ where
         let k = rfc6979::generate_k::<D, FieldBytesSize<C>>(
             &self.to_repr(),
             &C::encode_field_bytes(&C::ORDER),
-            &z,
+            z,
             ad,
         );
         let k = ScalarPrimitive::<C>::new(C::decode_field_bytes(&k)).unwrap();
-        self.try_sign_prehashed::<Self>(k.into(), &z)
+        self.try_sign_prehashed::<Self>(k.into(), z)
     }
 }
 
@@ -162,8 +162,8 @@ where
     /// - `z`: message digest to be verified. MUST BE OUTPUT OF A
     ///        CRYPTOGRAPHICALLY SECURE DIGEST ALGORITHM!!!
     /// - `sig`: signature to be verified against the key and message
-    fn verify_prehashed(&self, z: FieldBytes<C>, sig: &Signature<C>) -> Result<()> {
-        let z = Scalar::<C>::reduce(C::decode_field_bytes(&z));
+    fn verify_prehashed(&self, z: &FieldBytes<C>, sig: &Signature<C>) -> Result<()> {
+        let z = Scalar::<C>::reduce(C::decode_field_bytes(z));
         let (r, s) = sig.split_scalars();
         let s_inv = *s.invert();
         let u1 = z * s_inv;
@@ -190,7 +190,7 @@ where
     where
         D: FixedOutput<OutputSize = FieldBytesSize<C>>,
     {
-        self.verify_prehashed(msg_digest.finalize_fixed(), sig)
+        self.verify_prehashed(&msg_digest.finalize_fixed(), sig)
     }
 }
 

--- a/ecdsa/src/recovery.rs
+++ b/ecdsa/src/recovery.rs
@@ -185,7 +185,7 @@ where
         let z = bits2field::<C>(prehash)?;
         let (sig, recid) = self
             .as_nonzero_scalar()
-            .try_sign_prehashed_rfc6979::<C::Digest>(z, &[])?;
+            .try_sign_prehashed_rfc6979::<C::Digest>(&z, &[])?;
 
         Ok((sig, recid.ok_or_else(Error::new)?))
     }

--- a/ecdsa/src/signing.rs
+++ b/ecdsa/src/signing.rs
@@ -141,7 +141,7 @@ where
         let z = bits2field::<C>(prehash)?;
         Ok(self
             .secret_scalar
-            .try_sign_prehashed_rfc6979::<C::Digest>(z, &[])?
+            .try_sign_prehashed_rfc6979::<C::Digest>(&z, &[])?
             .0)
     }
 }
@@ -193,7 +193,7 @@ where
         rng.fill_bytes(&mut ad);
         Ok(self
             .secret_scalar
-            .try_sign_prehashed_rfc6979::<C::Digest>(z, &ad)?
+            .try_sign_prehashed_rfc6979::<C::Digest>(&z, &ad)?
             .0)
     }
 }

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -123,7 +123,7 @@ where
 {
     fn verify_prehash(&self, prehash: &[u8], signature: &Signature<C>) -> Result<()> {
         let field = bits2field::<C>(prehash)?;
-        self.inner.as_affine().verify_prehashed(field, signature)
+        self.inner.as_affine().verify_prehashed(&field, signature)
     }
 }
 


### PR DESCRIPTION
Always borrow the input field bytes.

Fix test macros in the `dev` module.