### PR TITLE
Revert "ecdsa: use `FromUintUnchecked` for serializing order (#644)"

### DIFF
--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -37,11 +37,11 @@ use {
     },
 };
 
-#[cfg(feature = "rfc6979")]
-use elliptic_curve::scalar::FromUintUnchecked;
-
 #[cfg(any(feature = "arithmetic", feature = "digest"))]
 use crate::{elliptic_curve::generic_array::ArrayLength, Signature};
+
+#[cfg(feature = "rfc6979")]
+use elliptic_curve::ScalarPrimitive;
 
 /// Try to sign the given prehashed message using ECDSA.
 ///
@@ -129,12 +129,12 @@ where
         ad: &[u8],
     ) -> Result<(Signature<C>, Option<RecoveryId>)>
     where
-        Self: FromUintUnchecked<Uint = C::Uint>,
+        Self: From<ScalarPrimitive<C>>,
         D: Digest + BlockSizeUser + FixedOutput<OutputSize = FieldBytesSize<C>> + FixedOutputReset,
     {
         let k = Scalar::<C>::from_repr(rfc6979::generate_k::<D, _>(
             &self.to_repr(),
-            &Scalar::<C>::from_uint_unchecked(C::ORDER).to_repr(),
+            &C::encode_field_bytes(&C::ORDER),
             z,
             ad,
         ))


### PR DESCRIPTION
This reverts commit 298129cbce828ade61241954eae25d6b7fafe9c6.

Abusing `from_uint_unchecked` for this broke `p384`, which appears to be serializing the order as zero causing an infinite loop when computing RFC6979.

Curiously, this didn't impact `p256`.