### PR TITLE
ecdsa: use `FieldBytesEncoding` to serialize `C::ORDER`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,7 +207,7 @@ name = "ecdsa"
 version = "0.16.0-pre"
 dependencies = [
  "der",
- "elliptic-curve 0.13.0-pre.2",
+ "elliptic-curve 0.13.0-pre.3",
  "hex-literal",
  "rfc6979",
  "serdect",
@@ -284,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.0-pre.2"
+version = "0.13.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec134ae3361336f68d31a0f6f1f9d3cb20c6377156735a60e79fea8407e47978"
+checksum = "a583fbbbfde04e0ef9c8b84c3bf8e504155a1642f91bf5cc2d6e7355cfb6ac4f"
 dependencies = [
  "base16ct",
  "crypto-bigint 0.5.0-pre.3",

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 rust-version = "1.61"
 
 [dependencies]
-elliptic-curve = { version = "=0.13.0-pre.2", default-features = false, features = ["digest", "sec1"] }
+elliptic-curve = { version = "=0.13.0-pre.3", default-features = false, features = ["digest", "sec1"] }
 signature = { version = "2.0, <2.1", default-features = false, features = ["rand_core"] }
 
 # optional dependencies
@@ -25,7 +25,7 @@ rfc6979 = { version = "=0.4.0-pre", optional = true, path = "../rfc6979" }
 serdect = { version = "0.1", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
-elliptic-curve = { version = "=0.13.0-pre.2", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "=0.13.0-pre.3", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 sha2 = { version = "0.10", default-features = false }
 

--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -41,7 +41,7 @@ use {
 use crate::{elliptic_curve::generic_array::ArrayLength, Signature};
 
 #[cfg(feature = "rfc6979")]
-use elliptic_curve::ScalarPrimitive;
+use elliptic_curve::{FieldBytesEncoding, ScalarPrimitive};
 
 /// Try to sign the given prehashed message using ECDSA.
 ///
@@ -134,7 +134,7 @@ where
     {
         let k = Scalar::<C>::from_repr(rfc6979::generate_k::<D, _>(
             &self.to_repr(),
-            &C::encode_field_bytes(&C::ORDER),
+            &C::ORDER.encode_field_bytes(),
             z,
             ad,
         ))


### PR DESCRIPTION
Bumps `elliptic-curve` to v0.13.0-pre.3, and uses the new `FieldBytesEncoding` API.

This is needed to pass the curve's order to the RFC6979 implementation.