### PR TITLE
ecdsa: use `AffineCoordinates` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,8 +285,7 @@ dependencies = [
 [[package]]
 name = "elliptic-curve"
 version = "0.13.0-pre.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a583fbbbfde04e0ef9c8b84c3bf8e504155a1642f91bf5cc2d6e7355cfb6ac4f"
+source = "git+https://github.com/rustcrypto/traits.git#d69d5b99ef3f906442030663fb2be515ebfe4e83"
 dependencies = [
  "base16ct",
  "crypto-bigint 0.5.0-pre.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ members = [
 
 [profile.dev]
 opt-level = 2
+
+[patch.crates-io.elliptic-curve]
+git = "https://github.com/rustcrypto/traits.git"

--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -21,7 +21,7 @@ use {
         ff::PrimeField,
         group::{Curve as _, Group},
         ops::{Invert, LinearCombination, MulByGenerator, Reduce},
-        point::{AffineXCoordinate, AffineYIsOdd},
+        point::AffineCoordinates,
         scalar::IsHigh,
         subtle::CtOption,
         CurveArithmetic, ProjectivePoint, Scalar,
@@ -150,7 +150,7 @@ where
 /// the affine point represeting the public key via `&self`, such as a
 /// particular curve's `AffinePoint` type.
 #[cfg(feature = "arithmetic")]
-pub trait VerifyPrimitive<C>: AffineXCoordinate<FieldRepr = FieldBytes<C>> + Copy + Sized
+pub trait VerifyPrimitive<C>: AffineCoordinates<FieldRepr = FieldBytes<C>> + Copy + Sized
 where
     C: PrimeCurve + CurveArithmetic<AffinePoint = Self> + CurveArithmetic,
     SignatureSize<C>: ArrayLength<u8>,


### PR DESCRIPTION
Switches to the newly consolidated `AffineCoordinates` trait.

See RustCrypto/traits#1237