### PR TITLE
ecdsa: use `Scalar::invert_vartime` for verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,7 +207,7 @@ name = "ecdsa"
 version = "0.16.0-pre.0"
 dependencies = [
  "der",
- "elliptic-curve 0.13.0-pre.3",
+ "elliptic-curve 0.13.0-pre.4",
  "hex-literal",
  "rfc6979",
  "serdect",
@@ -284,8 +284,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.0-pre.3"
-source = "git+https://github.com/rustcrypto/traits.git#d69d5b99ef3f906442030663fb2be515ebfe4e83"
+version = "0.13.0-pre.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e522fa74a88db6c494a11741a6cca2d8d74a6ff725be30162a01110aa5ba873d"
 dependencies = [
  "base16ct",
  "crypto-bigint 0.5.0-pre.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,3 @@ members = [
 
 [profile.dev]
 opt-level = 2
-
-[patch.crates-io.elliptic-curve]
-git = "https://github.com/rustcrypto/traits.git"

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 rust-version = "1.61"
 
 [dependencies]
-elliptic-curve = { version = "=0.13.0-pre.3", default-features = false, features = ["digest", "sec1"] }
+elliptic-curve = { version = "=0.13.0-pre.4", default-features = false, features = ["digest", "sec1"] }
 signature = { version = "2.0, <2.1", default-features = false, features = ["rand_core"] }
 
 # optional dependencies
@@ -25,7 +25,7 @@ rfc6979 = { version = "=0.4.0-pre.0", optional = true, path = "../rfc6979" }
 serdect = { version = "0.1", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
-elliptic-curve = { version = "=0.13.0-pre.3", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "=0.13.0-pre.4", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 sha2 = { version = "0.10", default-features = false }
 

--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -165,7 +165,7 @@ where
     fn verify_prehashed(&self, z: &FieldBytes<C>, sig: &Signature<C>) -> Result<()> {
         let z = Scalar::<C>::reduce_bytes(z);
         let (r, s) = sig.split_scalars();
-        let s_inv = *s.invert();
+        let s_inv = *s.invert_vartime();
         let u1 = z * s_inv;
         let u2 = *r * s_inv;
         let x = ProjectivePoint::<C>::lincomb(


### PR DESCRIPTION
Variable-time inversions can be faster than constant-time inversions and are fine in the context of verification.