### PR TITLE
ecdsa: bump `elliptic-curve` dependency to v0.13.0-pre.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,7 +207,7 @@ name = "ecdsa"
 version = "0.16.0-pre.0"
 dependencies = [
  "der",
- "elliptic-curve 0.13.0-pre.3",
+ "elliptic-curve 0.13.0-pre.4",
  "hex-literal",
  "rfc6979",
  "serdect",
@@ -284,8 +284,8 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.0-pre.3"
-source = "git+https://github.com/rustcrypto/traits.git#d69d5b99ef3f906442030663fb2be515ebfe4e83"
+version = "0.13.0-pre.4"
+source = "git+https://github.com/rustcrypto/traits.git#d57b54b9fcf5b28745547cb9fef313ab09780918"
 dependencies = [
  "base16ct",
  "crypto-bigint 0.5.0-pre.3",

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 rust-version = "1.61"
 
 [dependencies]
-elliptic-curve = { version = "=0.13.0-pre.3", default-features = false, features = ["digest", "sec1"] }
+elliptic-curve = { version = "=0.13.0-pre.4", default-features = false, features = ["digest", "sec1"] }
 signature = { version = "2.0, <2.1", default-features = false, features = ["rand_core"] }
 
 # optional dependencies
@@ -25,7 +25,7 @@ rfc6979 = { version = "=0.4.0-pre.0", optional = true, path = "../rfc6979" }
 serdect = { version = "0.1", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
-elliptic-curve = { version = "=0.13.0-pre.3", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "=0.13.0-pre.4", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 sha2 = { version = "0.10", default-features = false }
 


### PR DESCRIPTION
Would you actually mind releasing a new `ecdsa` v0.16.0-pre.1?