### PR TITLE
ecdsa: add `Invert` bound

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,8 +285,7 @@ dependencies = [
 [[package]]
 name = "elliptic-curve"
 version = "0.13.0-pre.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e522fa74a88db6c494a11741a6cca2d8d74a6ff725be30162a01110aa5ba873d"
+source = "git+https://github.com/RustCrypto/traits.git#d14be8eb1510812efc7422711ee285ee79f76a80"
 dependencies = [
  "base16ct",
  "crypto-bigint 0.5.0-pre.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ members = [
 
 [profile.dev]
 opt-level = 2
+
+[patch.crates-io]
+elliptic-curve = { git = "https://github.com/RustCrypto/traits.git" }

--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -129,7 +129,7 @@ where
         ad: &[u8],
     ) -> Result<(Signature<C>, Option<RecoveryId>)>
     where
-        Self: From<ScalarPrimitive<C>>,
+        Self: From<ScalarPrimitive<C>> + Invert<Output = CtOption<Self>>,
         D: Digest + BlockSizeUser + FixedOutput<OutputSize = FieldBytesSize<C>> + FixedOutputReset,
     {
         let k = Scalar::<C>::from_repr(rfc6979::generate_k::<D, _>(


### PR DESCRIPTION
Previously this was handled by a blanket impl for `ff::Field`, but that precludes curves being able to impl `invert_vartime`.

See also: https://github.com/RustCrypto/traits/pull/1242