### PR TITLE
ecdsa: bump `elliptic-curve` to v0.13.0-rc.0

### DIFF
--- a/.github/workflows/ecdsa.yml
+++ b/.github/workflows/ecdsa.yml
@@ -26,7 +26,7 @@ jobs:
           - thumbv7em-none-eabi
           - wasm32-unknown-unknown
         rust:
-          - 1.61.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3
@@ -44,7 +44,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.61.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64ct"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,9 +89,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "const-oid"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
+checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
 
 [[package]]
 name = "cpufeatures"
@@ -110,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.0-pre.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c37ac947d5ac4ad24acbfe3ae18154b71eb91a360319c2f82e8c9d54d8de71c9"
+checksum = "071c0f5945634bc9ba7a452f492377dd6b1993665ddb58f28704119b32f07a9a"
 dependencies = [
  "generic-array",
  "rand_core 0.6.4",
@@ -150,7 +156,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
  "const-oid",
- "pem-rfc7468",
+ "pem-rfc7468 0.6.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc302fd9b18d66834a6f092d10ea85489c0ca8ad6b7304092135fab171d853cd"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468 0.7.0",
  "zeroize",
 ]
 
@@ -181,7 +198,7 @@ dependencies = [
  "digest 0.10.6",
  "num-bigint-dig",
  "num-traits",
- "pkcs8",
+ "pkcs8 0.9.0",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rfc6979",
@@ -197,7 +214,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82508ce57bd2b245e9914411800f87fd8fc8288f501bb26919cb9b2ee964028f"
 dependencies = [
- "der",
+ "der 0.6.1",
  "elliptic-curve 0.12.3",
  "signature 2.0.0",
 ]
@@ -206,11 +223,11 @@ dependencies = [
 name = "ecdsa"
 version = "0.16.0-pre.1"
 dependencies = [
- "der",
- "elliptic-curve 0.13.0-pre.5",
+ "der 0.7.0",
+ "elliptic-curve 0.13.0-rc.0",
  "hex-literal",
  "rfc6979",
- "serdect",
+ "serdect 0.1.0",
  "sha2 0.10.6",
  "signature 2.0.0",
 ]
@@ -231,7 +248,7 @@ dependencies = [
  "bincode",
  "ed25519-dalek",
  "hex-literal",
- "pkcs8",
+ "pkcs8 0.9.0",
  "rand_core 0.5.1",
  "ring-compat",
  "serde",
@@ -269,37 +286,37 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
- "base16ct",
+ "base16ct 0.1.1",
  "crypto-bigint 0.4.9",
- "der",
+ "der 0.6.1",
  "digest 0.10.6",
  "ff 0.12.1",
  "generic-array",
  "group 0.12.1",
  "rand_core 0.6.4",
- "sec1",
+ "sec1 0.3.0",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.0-pre.5"
+version = "0.13.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1ed75d4b5bc2388c2160e14532c72fa6c9d23b37b742f2c81d3577954e1e23a"
+checksum = "f9c59af7510d2be4d96353963e4ae19bfb0e066179de1eff9e210c360bf4781f"
 dependencies = [
- "base16ct",
- "crypto-bigint 0.5.0-pre.3",
+ "base16ct 0.1.1",
+ "crypto-bigint 0.5.0",
  "digest 0.10.6",
  "ff 0.13.0",
  "generic-array",
  "group 0.13.0",
  "hex-literal",
- "pem-rfc7468",
- "pkcs8",
+ "pem-rfc7468 0.7.0",
+ "pkcs8 0.10.0",
  "rand_core 0.6.4",
- "sec1",
- "serdect",
+ "sec1 0.7.1",
+ "serdect 0.2.0",
  "subtle",
  "zeroize",
 ]
@@ -332,6 +349,7 @@ checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -523,13 +541,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
- "der",
- "spki",
+ "der 0.6.1",
+ "spki 0.6.0",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e34154ec92c136238e7c210443538e64350962b8e2788cadcf5f781a6da70c36"
+dependencies = [
+ "der 0.7.0",
+ "spki 0.7.0",
 ]
 
 [[package]]
@@ -675,7 +712,7 @@ dependencies = [
  "opaque-debug",
  "p256",
  "p384",
- "pkcs8",
+ "pkcs8 0.9.0",
  "ring",
  "signature 2.0.0",
 ]
@@ -686,11 +723,24 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.1.1",
+ "der 0.6.1",
  "generic-array",
- "pkcs8",
- "serdect",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48518a2b5775ba8ca5b46596aae011caa431e6ce7e4a67ead66d92f08884220e"
+dependencies = [
+ "base16ct 0.2.0",
+ "der 0.7.0",
+ "generic-array",
+ "pkcs8 0.10.0",
+ "serdect 0.2.0",
  "subtle",
  "zeroize",
 ]
@@ -716,7 +766,17 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "038fce1bf4d74b9b30ea7dcd59df75ba8ec669a5dcb3cc64fbfcef7334ced32c"
 dependencies = [
- "base16ct",
+ "base16ct 0.1.1",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct 0.2.0",
  "serde",
 ]
 
@@ -790,7 +850,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0445c905640145c7ea8c1993555957f65e7c46d0535b91ba501bc9bfc85522f"
+dependencies = [
+ "base64ct",
+ "der 0.7.0",
 ]
 
 [[package]]

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -13,19 +13,19 @@ readme = "README.md"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "ecc", "nist", "secp256k1", "signature"]
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.65"
 
 [dependencies]
-elliptic-curve = { version = "=0.13.0-pre.5", default-features = false, features = ["digest", "sec1"] }
+elliptic-curve = { version = "=0.13.0-rc.0", default-features = false, features = ["digest", "sec1"] }
 signature = { version = "2.0, <2.1", default-features = false, features = ["rand_core"] }
 
 # optional dependencies
-der = { version = "0.6", optional = true }
+der = { version = "0.7", optional = true }
 rfc6979 = { version = "=0.4.0-pre.0", optional = true, path = "../rfc6979" }
 serdect = { version = "0.1", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
-elliptic-curve = { version = "=0.13.0-pre.5", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "=0.13.0-rc.0", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 sha2 = { version = "0.10", default-features = false }
 

--- a/ecdsa/README.md
+++ b/ecdsa/README.md
@@ -41,7 +41,7 @@ USE AT YOUR OWN RISK!
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.61** at a minimum.
+This crate requires **Rust 1.65** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -70,7 +70,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/signatures/actions/workflows/ecdsa.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/signatures/actions/workflows/ecdsa.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.61+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260048-signatures
 

--- a/ecdsa/src/der.rs
+++ b/ecdsa/src/der.rs
@@ -5,7 +5,7 @@ use core::{
     fmt::{self, Debug},
     ops::{Add, Range},
 };
-use der::{asn1::UIntRef, Decode, Encode, Reader};
+use der::{asn1::UintRef, Decode, Encode, Reader};
 use elliptic_curve::{
     bigint::Integer,
     consts::U9,
@@ -88,8 +88,8 @@ where
 
     /// Create an ASN.1 DER encoded signature from big endian `r` and `s` scalars
     pub(crate) fn from_scalar_bytes(r: &[u8], s: &[u8]) -> der::Result<Self> {
-        let r = UIntRef::new(r)?;
-        let s = UIntRef::new(s)?;
+        let r = UintRef::new(r)?;
+        let s = UintRef::new(s)?;
 
         let mut bytes = SignatureBytes::<C>::default();
         let mut writer = der::SliceWriter::new(&mut bytes);
@@ -280,14 +280,14 @@ where
 }
 
 /// Decode the `r` and `s` components of a DER-encoded ECDSA signature.
-fn decode_der(der_bytes: &[u8]) -> der::Result<(UIntRef<'_>, UIntRef<'_>)> {
+fn decode_der(der_bytes: &[u8]) -> der::Result<(UintRef<'_>, UintRef<'_>)> {
     let mut reader = der::SliceReader::new(der_bytes)?;
     let header = der::Header::decode(&mut reader)?;
     header.tag.assert_eq(der::Tag::Sequence)?;
 
     let ret = reader.read_nested(header.length, |reader| {
-        let r = UIntRef::decode(reader)?;
-        let s = UIntRef::decode(reader)?;
+        let r = UintRef::decode(reader)?;
+        let s = UintRef::decode(reader)?;
         Ok((r, s))
     })?;
 

--- a/ecdsa/src/signing.rs
+++ b/ecdsa/src/signing.rs
@@ -25,13 +25,13 @@ use {crate::der, core::ops::Add};
 
 #[cfg(feature = "pem")]
 use {
-    crate::elliptic_curve::pkcs8::{EncodePrivateKey, SecretDocument},
+    crate::elliptic_curve::pkcs8::{DecodePrivateKey, EncodePrivateKey, SecretDocument},
     core::str::FromStr,
 };
 
 #[cfg(feature = "pkcs8")]
 use crate::elliptic_curve::{
-    pkcs8::{self, AssociatedOid, DecodePrivateKey},
+    pkcs8::{self, AssociatedOid},
     sec1::{self, FromEncodedPoint, ToEncodedPoint},
     AffinePoint,
 };
@@ -526,15 +526,4 @@ where
     fn from_str(s: &str) -> Result<Self> {
         Self::from_pkcs8_pem(s).map_err(|_| Error::new())
     }
-}
-
-#[cfg(feature = "pkcs8")]
-impl<C> DecodePrivateKey for SigningKey<C>
-where
-    C: PrimeCurve + AssociatedOid + CurveArithmetic,
-    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
-    FieldBytesSize<C>: sec1::ModulusSize,
-    Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + SignPrimitive<C>,
-    SignatureSize<C>: ArrayLength<u8>,
-{
 }

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -20,14 +20,14 @@ use signature::{
 #[cfg(feature = "der")]
 use {crate::der, core::ops::Add};
 
+#[cfg(feature = "pem")]
+use {
+    core::str::FromStr,
+    elliptic_curve::pkcs8::{DecodePublicKey, EncodePublicKey},
+};
+
 #[cfg(feature = "pkcs8")]
-use elliptic_curve::pkcs8::{self, AssociatedOid, DecodePublicKey};
-
-#[cfg(feature = "pem")]
-use elliptic_curve::pkcs8::EncodePublicKey;
-
-#[cfg(feature = "pem")]
-use core::str::FromStr;
+use elliptic_curve::pkcs8::{self, AssociatedOid};
 
 #[cfg(all(feature = "pem", feature = "serde"))]
 use serdect::serde::{de, ser, Deserialize, Serialize};
@@ -292,7 +292,7 @@ where
 }
 
 #[cfg(feature = "pkcs8")]
-impl<C> TryFrom<pkcs8::SubjectPublicKeyInfo<'_>> for VerifyingKey<C>
+impl<C> TryFrom<pkcs8::SubjectPublicKeyInfoRef<'_>> for VerifyingKey<C>
 where
     C: PrimeCurve + AssociatedOid + CurveArithmetic + PointCompression,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
@@ -300,18 +300,9 @@ where
 {
     type Error = pkcs8::spki::Error;
 
-    fn try_from(spki: pkcs8::SubjectPublicKeyInfo<'_>) -> pkcs8::spki::Result<Self> {
+    fn try_from(spki: pkcs8::SubjectPublicKeyInfoRef<'_>) -> pkcs8::spki::Result<Self> {
         PublicKey::try_from(spki).map(|inner| Self { inner })
     }
-}
-
-#[cfg(feature = "pkcs8")]
-impl<C> DecodePublicKey for VerifyingKey<C>
-where
-    C: PrimeCurve + AssociatedOid + CurveArithmetic + PointCompression,
-    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
-    FieldBytesSize<C>: sec1::ModulusSize,
-{
 }
 
 #[cfg(feature = "pem")]


### PR DESCRIPTION
Also bumps `der` to v0.7