### PR TITLE
rfc6979 v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,7 +675,7 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.4.0-pre.0"
+version = "0.4.0"
 dependencies = [
  "hex-literal",
  "hmac",

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -19,7 +19,7 @@ digest = "0.10"
 num-bigint = { package = "num-bigint-dig", version = "0.8", default-features = false, features = ["prime", "rand", "zeroize"] }
 num-traits = { version = "0.2", default-features = false }
 pkcs8 = { version = "0.9", default-features = false, features = ["alloc"] }
-rfc6979 = { version = "=0.4.0-pre.0", path = "../rfc6979" }
+rfc6979 = { version = "0.4", path = "../rfc6979" }
 sha2 = { version = "0.10", default-features = false }
 signature = { version = "2.0, <2.1", default-features = false, features = ["alloc", "digest", "rand_core"] }
 zeroize = { version = "1.5", default-features = false }

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -21,7 +21,7 @@ signature = { version = "2.0, <2.1", default-features = false, features = ["rand
 
 # optional dependencies
 der = { version = "0.7", optional = true }
-rfc6979 = { version = "=0.4.0-pre.0", optional = true, path = "../rfc6979" }
+rfc6979 = { version = "0.4", optional = true, path = "../rfc6979" }
 serdect = { version = "0.1", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]

--- a/rfc6979/CHANGELOG.md
+++ b/rfc6979/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2023-02-28)
+### Changed
+- MSRV 1.60 ([#628])
+- Decouple from `crypto-bigint` ([#639])
+
+[#628]: https://github.com/RustCrypto/signatures/pull/628
+[#639]: https://github.com/RustCrypto/signatures/pull/639
+
 ## 0.3.1 (2022-11-03)
 ### Added
 - Usage example ([#577])

--- a/rfc6979/Cargo.toml
+++ b/rfc6979/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rfc6979"
-version = "0.4.0-pre.0"
+version = "0.4.0"
 description = """
 Pure Rust implementation of RFC6979: Deterministic Usage of the
 Digital Signature Algorithm (DSA) and Elliptic Curve Digital Signature Algorithm (ECDSA)


### PR DESCRIPTION
### Changed
- MSRV 1.60 ([#628])
- Decouple from `crypto-bigint` ([#639])

[#628]: https://github.com/RustCrypto/signatures/pull/628
[#639]: https://github.com/RustCrypto/signatures/pull/639