### PR TITLE
ecdsa: bump `elliptic-curve` dependency to v0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,7 +224,7 @@ name = "ecdsa"
 version = "0.16.0-rc.0"
 dependencies = [
  "der 0.7.0",
- "elliptic-curve 0.13.0-rc.0",
+ "elliptic-curve 0.13.0",
  "hex-literal",
  "rfc6979",
  "serdect",
@@ -301,11 +301,11 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.0-rc.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9c59af7510d2be4d96353963e4ae19bfb0e066179de1eff9e210c360bf4781f"
+checksum = "d871fff7b6d8e76698d50bde1dbad4d443cdf9c27e160de7bfa627ce0f85d97b"
 dependencies = [
- "base16ct 0.1.1",
+ "base16ct 0.2.0",
  "crypto-bigint 0.5.0",
  "digest 0.10.6",
  "ff 0.13.0",

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-elliptic-curve = { version = "=0.13.0-rc.0", default-features = false, features = ["digest", "sec1"] }
+elliptic-curve = { version = "0.13", default-features = false, features = ["digest", "sec1"] }
 signature = { version = "2.0, <2.1", default-features = false, features = ["rand_core"] }
 
 # optional dependencies
@@ -25,7 +25,7 @@ rfc6979 = { version = "0.4", optional = true, path = "../rfc6979" }
 serdect = { version = "0.2", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
-elliptic-curve = { version = "=0.13.0-rc.0", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.13", default-features = false, features = ["dev"] }
 hex-literal = "0.3"
 sha2 = { version = "0.10", default-features = false }
 


### PR DESCRIPTION
Release notes: https://github.com/RustCrypto/traits/pull/1255