### PR TITLE
dsa v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,7 @@ dependencies = [
 
 [[package]]
 name = "dsa"
-version = "0.6.0-pre"
+version = "0.6.0"
 dependencies = [
  "digest 0.10.6",
  "num-bigint-dig",

--- a/dsa/CHANGELOG.md
+++ b/dsa/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2023-03-01)
+### Changed
+- Bump `rfc6979` dependency to v0.4 ([#662])
+- Bump `pkcs8` dependency to v0.10; MSRV 1.65 ([#664])
+
+[#662]: https://github.com/RustCrypto/signatures/pull/662
+[#664]: https://github.com/RustCrypto/signatures/pull/664
+
 ## 0.5.0 (2023-01-15)
 ### Changed
 - Use `&mut impl CryptoRngCore` ([#579])

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsa"
-version = "0.6.0-pre"
+version = "0.6.0"
 description = """
 Pure Rust implementation of the Digital Signature Algorithm (DSA) as specified
 in FIPS 186-4 (Digital Signature Standard), providing RFC6979 deterministic


### PR DESCRIPTION
### Changed
- Bump `rfc6979` dependency to v0.4 ([#662])
- Bump `pkcs8` dependency to v0.10; MSRV 1.65 ([#664])

[#662]: https://github.com/RustCrypto/signatures/pull/662
[#664]: https://github.com/RustCrypto/signatures/pull/664