### PR TITLE
ecdsa v0.16.0

### DIFF
--- a/ecdsa/CHANGELOG.md
+++ b/ecdsa/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.16.0 (2023-03-01)
+### Added
+- `Decode` and `Encode` impls for `der::Signature` ([#666])
+
+### Changed
+- Use `Scalar::invert_vartime` for faster verification ([#651])
+- Bump `serdect` dependency to 0.2 ([#657])
+- Bump `elliptic-curve` dependency to v0.13; MSRV 1.65 ([#660], [#663])
+- Bump `rfc6979` dependency to v0.4 ([#662])
+
+[#651]: https://github.com/RustCrypto/signatures/pull/651
+[#657]: https://github.com/RustCrypto/signatures/pull/657
+[#660]: https://github.com/RustCrypto/signatures/pull/660
+[#662]: https://github.com/RustCrypto/signatures/pull/662
+[#666]: https://github.com/RustCrypto/signatures/pull/666
+
 ## 0.15.1 (2023-01-23)
 ### Added
 - `SigningKey::*_recoverable` methods ([#635])


### PR DESCRIPTION
### Added
- `Decode` and `Encode` impls for `der::Signature` ([#666])

### Changed
- Use `Scalar::invert_vartime` for faster verification ([#651])
- Bump `serdect` dependency to 0.2 ([#657])
- Bump `elliptic-curve` dependency to v0.13; MSRV 1.65 ([#660], [#663])
- Bump `rfc6979` dependency to v0.4 ([#662])

[#651]: https://github.com/RustCrypto/signatures/pull/651
[#657]: https://github.com/RustCrypto/signatures/pull/657
[#660]: https://github.com/RustCrypto/signatures/pull/660
[#662]: https://github.com/RustCrypto/signatures/pull/662
[#663]: https://github.com/RustCrypto/signatures/pull/663
[#666]: https://github.com/RustCrypto/signatures/pull/666