### PR TITLE
ed25519 v2.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "2.2.0-pre"
+version = "2.2.0"
 dependencies = [
  "bincode",
  "ed25519-dalek",

--- a/ed25519/CHANGELOG.md
+++ b/ed25519/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.2.0 (2023-03-01)
+### Changed
+- Bump `pkcs8` dependency to v0.10 ([#665])
+
+[#665]: https://github.com/RustCrypto/signatures/pull/665
+
 ## 2.1.0 (2023-01-21)
 ### Changed
 - Use namespaced features for `serde_bytes`; MSRV 1.60 ([#628])

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed25519"
-version = "2.2.0-pre"
+version = "2.2.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """


### PR DESCRIPTION
### Changed
- Bump `pkcs8` dependency to v0.10 ([#665])

[#665]: https://github.com/RustCrypto/signatures/pull/665