### PR TITLE
ecdsa: add `VerifyingKey::to_sec1_bytes` + more conversions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc906908ea6458456e5eaa160a9c08543ec3d1e6f71e2235cedd660cb65f9df0"
+checksum = "bc302fd9b18d66834a6f092d10ea85489c0ca8ad6b7304092135fab171d853cd"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -197,7 +197,7 @@ dependencies = [
  "digest 0.10.6",
  "num-bigint-dig",
  "num-traits",
- "pkcs8 0.10.1",
+ "pkcs8 0.10.0",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rfc6979",
@@ -222,8 +222,8 @@ dependencies = [
 name = "ecdsa"
 version = "0.16.0"
 dependencies = [
- "der 0.7.1",
- "elliptic-curve 0.13.1",
+ "der 0.7.0",
+ "elliptic-curve 0.13.2",
  "hex-literal",
  "rfc6979",
  "serdect",
@@ -256,7 +256,7 @@ dependencies = [
  "bincode",
  "ed25519-dalek",
  "hex-literal",
- "pkcs8 0.10.1",
+ "pkcs8 0.10.0",
  "rand_core 0.5.1",
  "ring-compat",
  "serde",
@@ -300,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b984fcbd8df0166b077ec083cbfe076fdffb6e2de92d966794fd060794b620d7"
+checksum = "6ea5a92946e8614bb585254898bb7dd1ddad241ace60c52149e3765e34cc039d"
 dependencies = [
  "base16ct 0.2.0",
  "crypto-bigint 0.5.0",
@@ -312,7 +312,7 @@ dependencies = [
  "group 0.13.0",
  "hex-literal",
  "pem-rfc7468",
- "pkcs8 0.10.1",
+ "pkcs8 0.10.0",
  "rand_core 0.6.4",
  "sec1 0.7.1",
  "serdect",
@@ -551,11 +551,11 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.10.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d2820d87d2b008616e5c27212dd9e0e694fb4c6b522de06094106813328cb49"
+checksum = "e34154ec92c136238e7c210443538e64350962b8e2788cadcf5f781a6da70c36"
 dependencies = [
- "der 0.7.1",
+ "der 0.7.0",
  "spki 0.7.0",
 ]
 
@@ -727,9 +727,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48518a2b5775ba8ca5b46596aae011caa431e6ce7e4a67ead66d92f08884220e"
 dependencies = [
  "base16ct 0.2.0",
- "der 0.7.1",
+ "der 0.7.0",
  "generic-array",
- "pkcs8 0.10.1",
+ "pkcs8 0.10.0",
  "serdect",
  "subtle",
  "zeroize",
@@ -840,7 +840,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0445c905640145c7ea8c1993555957f65e7c46d0535b91ba501bc9bfc85522f"
 dependencies = [
  "base64ct",
- "der 0.7.1",
+ "der 0.7.0",
 ]
 
 [[package]]

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-elliptic-curve = { version = "0.13", default-features = false, features = ["digest", "sec1"] }
+elliptic-curve = { version = "0.13.2", default-features = false, features = ["digest", "sec1"] }
 signature = { version = "2.0, <2.1", default-features = false, features = ["rand_core"] }
 
 # optional dependencies
@@ -31,7 +31,7 @@ sha2 = { version = "0.10", default-features = false }
 
 [features]
 default = ["digest"]
-alloc = ["signature/alloc"]
+alloc = ["elliptic-curve/alloc", "signature/alloc"]
 std = ["alloc", "elliptic-curve/std", "signature/std"]
 
 arithmetic = ["elliptic-curve/arithmetic"]


### PR DESCRIPTION
Adds an inherent method, gated on `alloc`, for serializing a `VerifyingKey` as a boxed byte slice containing the key's SEC1 encoding.

Also adds `From` conversions for converting to
`sec1::{CompressedPoint, EncodedPoint}`.