### PR TITLE
ecdsa v0.16.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "der 0.7.0",
  "elliptic-curve 0.13.2",

--- a/ecdsa/CHANGELOG.md
+++ b/ecdsa/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.16.1 (2023-03-09)
+### Added
+- `VerifyingKey::to_sec1_bytes` + more conversions ([#675])
+
+[#675]: https://github.com/RustCrypto/signatures/pull/675
+
 ## 0.16.0 (2023-03-01)
 ### Added
 - `Decode` and `Encode` impls for `der::Signature` ([#666])

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecdsa"
-version = "0.16.0"
+version = "0.16.1"
 description = """
 Pure Rust implementation of the Elliptic Curve Digital Signature Algorithm
 (ECDSA) as specified in FIPS 186-4 (Digital Signature Standard), providing


### PR DESCRIPTION
### Added
- `VerifyingKey::to_sec1_bytes` + more conversions ([#675])

[#675]: https://github.com/RustCrypto/signatures/pull/675