### PR TITLE
Handle the reduced x case in public key recovery

### DIFF
--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -95,6 +95,7 @@ where
         // Lift x-coordinate of 𝑹 (element of base field) into a serialized big
         // integer, then reduce it into an element of the scalar field
         let r = Self::reduce_bytes(&R.x());
+        let x_reduced = r.to_repr() != R.x();
 
         // Compute 𝒔 as a signature over 𝒓 and 𝒛.
         let s = k_inv * (z + (r * self));
@@ -108,8 +109,7 @@ where
         let is_s_high = s.is_high();
         let is_y_odd = is_r_odd ^ is_s_high;
 
-        // TODO(tarcieri): handle `is_x_reduced` case (currently hardcoded to `false`)
-        let recovery_id = RecoveryId::new(is_y_odd.into(), false);
+        let recovery_id = RecoveryId::new(is_y_odd.into(), x_reduced);
 
         Ok((signature, Some(recovery_id)))
     }

--- a/ecdsa/src/recovery.rs
+++ b/ecdsa/src/recovery.rs
@@ -285,7 +285,7 @@ where
         let (mut r, s) = signature.split_scalars();
         let z = <Scalar<C> as Reduce<C::Uint>>::reduce_bytes(&bits2field::<C>(prehash)?);
         if recovery_id.is_x_reduced() {
-            r = r + &CurveArithmetic::ORDER;
+            r = r + &C::ORDER;
         };
         let R = AffinePoint::<C>::decompress(&r.to_repr(), u8::from(recovery_id.is_y_odd()).into());
 

--- a/ecdsa/src/recovery.rs
+++ b/ecdsa/src/recovery.rs
@@ -288,10 +288,10 @@ where
 
         let mut r_bytes = r.to_repr();
         if recovery_id.is_x_reduced() {
-            r_bytes = match Option::<C::Uint>::from(
+            match Option::<C::Uint>::from(
                 C::Uint::decode_field_bytes(&r_bytes).checked_add(&C::ORDER),
             ) {
-                Some(restored) => restored.encode_field_bytes(),
+                Some(restored) => r_bytes = restored.encode_field_bytes(),
                 // No reduction should happen here if r was reduced
                 None => return Err(Error::new()),
             };


### PR DESCRIPTION
This PR handles the case where the x-coordinate of r is reduced mod N in both recoverable signing and public key recovery. The chance that the x is reduced during signing with a randomly chosen k is negligible, so the changes to the signing method could be omitted.

Closing #584 