### PR TITLE
ecdsa v0.16.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "der 0.7.1",
  "elliptic-curve 0.13.2",

--- a/ecdsa/CHANGELOG.md
+++ b/ecdsa/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.16.2 (2023-03-28)
+### Added
+- Handle the reduced R.x case in public key recovery ([#680])
+- `Signature::{from_bytes, from_slice}` methods ([#684])
+
+[#680]: https://github.com/RustCrypto/signatures/pull/680
+[#684]: https://github.com/RustCrypto/signatures/pull/684
+
 ## 0.16.1 (2023-03-09)
 ### Added
 - `VerifyingKey::to_sec1_bytes` + more conversions ([#675])

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecdsa"
-version = "0.16.1"
+version = "0.16.2"
 description = """
 Pure Rust implementation of the Elliptic Curve Digital Signature Algorithm
 (ECDSA) as specified in FIPS 186-4 (Digital Signature Standard), providing


### PR DESCRIPTION
### Added
- Handle the reduced `R.x` case in public key recovery ([#680])
- `Signature::{from_bytes, from_slice}` methods ([#684])

[#680]: https://github.com/RustCrypto/signatures/pull/680
[#684]: https://github.com/RustCrypto/signatures/pull/684
