### PR TITLE
ecdsa: implement AssociatedAlgorithmIdentifier support

### DIFF
--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -34,6 +34,7 @@ default = ["digest"]
 alloc = ["elliptic-curve/alloc", "signature/alloc"]
 std = ["alloc", "elliptic-curve/std", "signature/std"]
 
+algorithm-identifier = ["elliptic-curve/pkcs8"]
 arithmetic = ["elliptic-curve/arithmetic"]
 dev = ["arithmetic", "digest", "elliptic-curve/dev", "hazmat"]
 digest = ["signature/digest"]

--- a/ecdsa/src/signing.rs
+++ b/ecdsa/src/signing.rs
@@ -20,6 +20,9 @@ use signature::{
     DigestSigner, RandomizedDigestSigner, RandomizedSigner, Signer,
 };
 
+#[cfg(feature = "algorithm-identifier")]
+use elliptic_curve::pkcs8::spki::{AlgorithmIdentifierRef, AssociatedAlgorithmIdentifier};
+
 #[cfg(feature = "der")]
 use {crate::der, core::ops::Add};
 
@@ -538,4 +541,14 @@ where
     fn from_str(s: &str) -> Result<Self> {
         Self::from_pkcs8_pem(s).map_err(|_| Error::new())
     }
+}
+
+#[cfg(feature = "algorithm-identifier")]
+impl<C> AssociatedAlgorithmIdentifier for SigningKey<C>
+where
+    C: PrimeCurve + AssociatedAlgorithmIdentifier + CurveArithmetic,
+    Scalar<C>: SignPrimitive<C>,
+    SignatureSize<C>: ArrayLength<u8>,
+{
+    const ALGORITHM_IDENTIFIER: AlgorithmIdentifierRef<'static> = C::ALGORITHM_IDENTIFIER;
 }


### PR DESCRIPTION
Implement AssociatedAlgorithmIdentifier support for the SigningKey if the curve supports this trait.