### PR TITLE
ecdsa: impl `SignatureAlgorithmIdentifier`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
 [[package]]
 name = "base64ct"
 version = "1.6.0"
-source = "git+https://github.com/RustCrypto/formats.git#fd069a6ff7a9f5abfd3d797b51f50ca0a5307e44"
+source = "git+https://github.com/RustCrypto/formats.git#08906a716e16af75e3e7e886972aa09d9b9cf88c"
 
 [[package]]
 name = "bincode"
@@ -167,7 +167,7 @@ dependencies = [
 [[package]]
 name = "der"
 version = "0.7.1"
-source = "git+https://github.com/RustCrypto/formats.git#fd069a6ff7a9f5abfd3d797b51f50ca0a5307e44"
+source = "git+https://github.com/RustCrypto/formats.git#08906a716e16af75e3e7e886972aa09d9b9cf88c"
 dependencies = [
  "const-oid",
  "pem-rfc7468 0.7.0 (git+https://github.com/RustCrypto/formats.git)",
@@ -548,7 +548,7 @@ dependencies = [
 [[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
-source = "git+https://github.com/RustCrypto/formats.git#fd069a6ff7a9f5abfd3d797b51f50ca0a5307e44"
+source = "git+https://github.com/RustCrypto/formats.git#08906a716e16af75e3e7e886972aa09d9b9cf88c"
 dependencies = [
  "base64ct 1.6.0",
 ]
@@ -850,7 +850,7 @@ dependencies = [
 [[package]]
 name = "spki"
 version = "0.7.0"
-source = "git+https://github.com/RustCrypto/formats.git#fd069a6ff7a9f5abfd3d797b51f50ca0a5307e44"
+source = "git+https://github.com/RustCrypto/formats.git#08906a716e16af75e3e7e886972aa09d9b9cf88c"
 dependencies = [
  "base64ct 1.6.0",
  "der 0.7.1",

--- a/ecdsa/src/signing.rs
+++ b/ecdsa/src/signing.rs
@@ -31,7 +31,12 @@ use {
 
 #[cfg(feature = "pkcs8")]
 use crate::elliptic_curve::{
-    pkcs8::{self, AssociatedOid},
+    pkcs8::{
+        self,
+        der::AnyRef,
+        spki::{AlgorithmIdentifier, AssociatedAlgorithmIdentifier, SignatureAlgorithmIdentifier},
+        AssociatedOid,
+    },
     sec1::{self, FromEncodedPoint, ToEncodedPoint},
     AffinePoint,
 };
@@ -364,8 +369,6 @@ where
     SignatureSize<C>: ArrayLength<u8>,
 {
 }
-
-/// Constant-time comparison
 impl<C> PartialEq for SigningKey<C>
 where
     C: PrimeCurve + CurveArithmetic,
@@ -492,6 +495,20 @@ where
     SignatureSize<C>: ArrayLength<u8>,
 {
     type VerifyingKey = VerifyingKey<C>;
+}
+
+#[cfg(feature = "pkcs8")]
+impl<C> SignatureAlgorithmIdentifier for SigningKey<C>
+where
+    C: PrimeCurve + CurveArithmetic,
+    Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + SignPrimitive<C>,
+    SignatureSize<C>: ArrayLength<u8>,
+    Signature<C>: AssociatedAlgorithmIdentifier<Params = AnyRef<'static>>,
+{
+    type Params = AnyRef<'static>;
+
+    const SIGNATURE_ALGORITHM_IDENTIFIER: AlgorithmIdentifier<Self::Params> =
+        Signature::<C>::ALGORITHM_IDENTIFIER;
 }
 
 #[cfg(feature = "pkcs8")]

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -30,7 +30,12 @@ use {
 };
 
 #[cfg(feature = "pkcs8")]
-use elliptic_curve::pkcs8::{self, AssociatedOid};
+use elliptic_curve::pkcs8::{
+    self,
+    der::AnyRef,
+    spki::{AlgorithmIdentifier, AssociatedAlgorithmIdentifier, SignatureAlgorithmIdentifier},
+    AssociatedOid,
+};
 
 #[cfg(all(feature = "pem", feature = "serde"))]
 use serdect::serde::{de, ser, Deserialize, Serialize};
@@ -351,6 +356,20 @@ where
     fn try_from(bytes: &[u8]) -> Result<Self> {
         Self::from_sec1_bytes(bytes)
     }
+}
+
+#[cfg(feature = "pkcs8")]
+impl<C> SignatureAlgorithmIdentifier for VerifyingKey<C>
+where
+    C: PrimeCurve + CurveArithmetic,
+    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
+    FieldBytesSize<C>: sec1::ModulusSize,
+    Signature<C>: AssociatedAlgorithmIdentifier<Params = AnyRef<'static>>,
+{
+    type Params = AnyRef<'static>;
+
+    const SIGNATURE_ALGORITHM_IDENTIFIER: AlgorithmIdentifier<Self::Params> =
+        Signature::<C>::ALGORITHM_IDENTIFIER;
 }
 
 #[cfg(feature = "pkcs8")]


### PR DESCRIPTION
Propagates the `AssociatedAlgorithmIdentifier` from `Signature<C>` to `SigningKey<C>` and `VerifyingKey<C>`.

cc @baloo @lumag