### PR TITLE
ecdsa: add `SignatureWithOid` verification support

### DIFF
--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -24,6 +24,7 @@ der = { version = "0.7", optional = true }
 digest = { version = "0.10.6", optional = true, default-features = false, features = ["oid"] }
 rfc6979 = { version = "0.4", optional = true, path = "../rfc6979" }
 serdect = { version = "0.2", optional = true, default-features = false, features = ["alloc"] }
+sha2 = { version = "0.10", optional = true, default-features = false, features = ["oid"] }
 
 [dev-dependencies]
 elliptic-curve = { version = "0.13", default-features = false, features = ["dev"] }


### PR DESCRIPTION
Gated under a newly added `sha2` feature.

This implementation dispatches based on RFC5758 OIDs, selecting the appropriate hash function to use at runtime based on the OID.

cc @baloo @lumag