### PR TITLE
dsa+ecdsa: loosen `signature` bound to `2.0, <2.2`

### DIFF
--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -21,8 +21,8 @@ num-traits = { version = "0.2", default-features = false }
 pkcs8 = { version = "0.10", default-features = false, features = ["alloc"] }
 rfc6979 = { version = "0.4", path = "../rfc6979" }
 sha2 = { version = "0.10", default-features = false }
-signature = { version = "2.0, <2.1", default-features = false, features = ["alloc", "digest", "rand_core"] }
-zeroize = { version = "1.6", default-features = false }
+signature = { version = "2.0, <2.2", default-features = false, features = ["alloc", "digest", "rand_core"] }
+zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]
 pkcs8 = { version = "0.10", default-features = false, features = ["pem"] }

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.65"
 
 [dependencies]
 elliptic-curve = { version = "0.13.2", default-features = false, features = ["digest", "sec1"] }
-signature = { version = "2.0, <2.1", default-features = false, features = ["rand_core"] }
+signature = { version = "2.0, <2.2", default-features = false, features = ["rand_core"] }
 
 # optional dependencies
 der = { version = "0.7", optional = true }


### PR DESCRIPTION
`signature` v2.1.0 is out and only adds features. It does not change the `digest` or `rand_core` dependencies (there are SemVer exceptions for these crates, hence the non-SemVer requirement)

Because those deps are unchanged in v2.1.0, we can relax the requirement to support v2.0 and v2.1 releases.