### PR TITLE
ecdsa: forward `AssociatedAlgorithmIdentifier` impls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea5a92946e8614bb585254898bb7dd1ddad241ace60c52149e3765e34cc039d"
+checksum = "22cdacd4d6ed3f9b98680b679c0e52a823b8a2c7a97358d508fe247f2180c282"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -452,9 +452,9 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d2820d87d2b008616e5c27212dd9e0e694fb4c6b522de06094106813328cb49"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-elliptic-curve = { version = "0.13.2", default-features = false, features = ["digest", "sec1"] }
+elliptic-curve = { version = "0.13.3", default-features = false, features = ["digest", "sec1"] }
 signature = { version = "2.0, <2.2", default-features = false, features = ["rand_core"] }
 
 # optional dependencies

--- a/ecdsa/src/signing.rs
+++ b/ecdsa/src/signing.rs
@@ -36,6 +36,7 @@ use crate::elliptic_curve::{
         self,
         der::AnyRef,
         spki::{AlgorithmIdentifier, AssociatedAlgorithmIdentifier, SignatureAlgorithmIdentifier},
+        ObjectIdentifier,
     },
     sec1::{self, FromEncodedPoint, ToEncodedPoint},
     AffinePoint,
@@ -521,6 +522,19 @@ where
     SignatureSize<C>: ArrayLength<u8>,
 {
     type VerifyingKey = VerifyingKey<C>;
+}
+
+#[cfg(feature = "pkcs8")]
+impl<C> AssociatedAlgorithmIdentifier for SigningKey<C>
+where
+    C: AssociatedOid + CurveArithmetic + PrimeCurve,
+    Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + SignPrimitive<C>,
+    SignatureSize<C>: ArrayLength<u8>,
+{
+    type Params = ObjectIdentifier;
+
+    const ALGORITHM_IDENTIFIER: AlgorithmIdentifier<ObjectIdentifier> =
+        SecretKey::<C>::ALGORITHM_IDENTIFIER;
 }
 
 #[cfg(feature = "pkcs8")]

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -34,7 +34,7 @@ use elliptic_curve::pkcs8::{
     self,
     der::AnyRef,
     spki::{AlgorithmIdentifier, AssociatedAlgorithmIdentifier, SignatureAlgorithmIdentifier},
-    AssociatedOid,
+    AssociatedOid, ObjectIdentifier,
 };
 
 #[cfg(feature = "sha2")]
@@ -382,6 +382,19 @@ where
     fn try_from(bytes: &[u8]) -> Result<Self> {
         Self::from_sec1_bytes(bytes)
     }
+}
+
+#[cfg(feature = "pkcs8")]
+impl<C> AssociatedAlgorithmIdentifier for VerifyingKey<C>
+where
+    C: AssociatedOid + CurveArithmetic + PrimeCurve,
+    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
+    FieldBytesSize<C>: sec1::ModulusSize,
+{
+    type Params = ObjectIdentifier;
+
+    const ALGORITHM_IDENTIFIER: AlgorithmIdentifier<ObjectIdentifier> =
+        PublicKey::<C>::ALGORITHM_IDENTIFIER;
 }
 
 #[cfg(feature = "pkcs8")]


### PR DESCRIPTION
...from the `elliptic-curve` crate, as released in v0.13.3