### PR TITLE
ecdsa v0.16.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,6 +157,17 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "644d3b8674a5fc5b929ae435bca85c2323d85ccb013a5509c2ac9ee11a6284ba"
+dependencies = [
+ "der",
+ "elliptic-curve",
+ "signature",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.3"
 dependencies = [
  "der",
  "digest",
@@ -165,17 +176,6 @@ dependencies = [
  "rfc6979",
  "serdect",
  "sha2",
- "signature",
-]
-
-[[package]]
-name = "ecdsa"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644d3b8674a5fc5b929ae435bca85c2323d85ccb013a5509c2ac9ee11a6284ba"
-dependencies = [
- "der",
- "elliptic-curve",
  "signature",
 ]
 
@@ -415,7 +415,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7270da3e5caa82afd3deb054cc237905853813aea3859544bc082c3fe55b8d47"
 dependencies = [
- "ecdsa 0.16.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ecdsa 0.16.2",
  "elliptic-curve",
  "primeorder",
 ]
@@ -426,7 +426,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209"
 dependencies = [
- "ecdsa 0.16.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ecdsa 0.16.2",
  "elliptic-curve",
  "primeorder",
 ]
@@ -560,7 +560,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a6cc493d932a31cd225466b0361bc571f2c9cbb0db5ff06e843b478dc94027b"
 dependencies = [
- "ecdsa 0.16.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ecdsa 0.16.2",
  "ed25519 2.2.0",
  "generic-array",
  "p256",

--- a/ecdsa/CHANGELOG.md
+++ b/ecdsa/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.16.3 (2023-04-04)
+### Added
+- RFC5758 OID support ([#686])
+- `SignatureAlgorithmIdentifier` impls for `SigningKey`/`VerifyingKey` ([#688])
+- `SignatureWithOid` ([#689], [#690])
+- `AssociatedAlgorithmIdentifier` impls for `SigningKey`/`VerifyingKey` ([#698])
+
+### Changed
+- Loosen `signature` bound to `2.0, <2.2` ([#697])
+
+[#686]: https://github.com/RustCrypto/signatures/pull/686
+[#688]: https://github.com/RustCrypto/signatures/pull/688
+[#689]: https://github.com/RustCrypto/signatures/pull/689
+[#690]: https://github.com/RustCrypto/signatures/pull/690
+[#697]: https://github.com/RustCrypto/signatures/pull/697
+[#698]: https://github.com/RustCrypto/signatures/pull/698
+
 ## 0.16.2 (2023-03-28)
 ### Added
 - Handle the reduced R.x case in public key recovery ([#680])

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecdsa"
-version = "0.16.2"
+version = "0.16.3"
 description = """
 Pure Rust implementation of the Elliptic Curve Digital Signature Algorithm
 (ECDSA) as specified in FIPS 186-4 (Digital Signature Standard), providing


### PR DESCRIPTION
### Added
- RFC5758 OID support ([#686])
- `SignatureAlgorithmIdentifier` impls for `SigningKey`/`VerifyingKey` ([#688])
- `SignatureWithOid` ([#689], [#690])
- `AssociatedAlgorithmIdentifier` impls for `SigningKey`/`VerifyingKey` ([#698])

### Changed
- Loosen `signature` bound to `2.0, <2.2` ([#697])

[#686]: https://github.com/RustCrypto/signatures/pull/686
[#688]: https://github.com/RustCrypto/signatures/pull/688
[#689]: https://github.com/RustCrypto/signatures/pull/689
[#690]: https://github.com/RustCrypto/signatures/pull/690
[#697]: https://github.com/RustCrypto/signatures/pull/697
[#698]: https://github.com/RustCrypto/signatures/pull/698
