### PR TITLE
dsa v0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "dsa"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "digest",
  "num-bigint-dig",

--- a/dsa/CHANGELOG.md
+++ b/dsa/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.1 (2023-04-04)
+### Changed
+- Loosen `signature` bound to `2.0, <2.2` ([#697])
+
+[#697]: https://github.com/RustCrypto/signatures/pull/697
+
 ## 0.6.0 (2023-03-01)
 ### Changed
 - Bump `rfc6979` dependency to v0.4 ([#662])

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsa"
-version = "0.6.0"
+version = "0.6.1"
 description = """
 Pure Rust implementation of the Digital Signature Algorithm (DSA) as specified
 in FIPS 186-4 (Digital Signature Standard), providing RFC6979 deterministic


### PR DESCRIPTION
### Changed
- Loosen `signature` bound to `2.0, <2.2` ([#697])

[#697]: https://github.com/RustCrypto/signatures/pull/697