### PR TITLE
ecdsa: fix `RecoveryId` computation in `SignPrimitive`

### DIFF
--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -95,7 +95,7 @@ where
         // Lift x-coordinate of 𝑹 (element of base field) into a serialized big
         // integer, then reduce it into an element of the scalar field
         let r = Self::reduce_bytes(&R.x());
-        let x_reduced = r.to_repr() != R.x();
+        let x_is_reduced = r.to_repr() != R.x();
 
         // Compute 𝒔 as a signature over 𝒓 and 𝒛.
         let s = k_inv * (z + (r * self));
@@ -105,12 +105,7 @@ where
         }
 
         let signature = Signature::from_scalars(r, s)?;
-        let is_r_odd = R.y_is_odd();
-        let is_s_high = s.is_high();
-        let is_y_odd = is_r_odd ^ is_s_high;
-
-        let recovery_id = RecoveryId::new(is_y_odd.into(), x_reduced);
-
+        let recovery_id = RecoveryId::new(R.y_is_odd().into(), x_is_reduced);
         Ok((signature, Some(recovery_id)))
     }
 


### PR DESCRIPTION
The implementation was adapted from `k256`, which produces signatures with low-S normalization.

However, the provided implementation does not low-S normalize signatures, so it should not be considered in the `RecoveryId` computation.