### PR TITLE
ecdsa v0.16.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.16.3"
+version = "0.16.4"
 dependencies = [
  "der",
  "digest",

--- a/ecdsa/CHANGELOG.md
+++ b/ecdsa/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.16.4 (2023-04-05)
+### Fixed
+- `RecoveryId` computation in `SignPrimitive` ([#702])
+
+[#702]: https://github.com/RustCrypto/signatures/pull/702
+
 ## 0.16.3 (2023-04-04)
 ### Added
 - RFC5758 OID support ([#686])

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecdsa"
-version = "0.16.3"
+version = "0.16.4"
 description = """
 Pure Rust implementation of the Elliptic Curve Digital Signature Algorithm
 (ECDSA) as specified in FIPS 186-4 (Digital Signature Standard), providing


### PR DESCRIPTION
### Fixed
- `RecoveryId` computation in `SignPrimitive` ([#702])

[#702]: https://github.com/RustCrypto/signatures/pull/702
