### PR TITLE
ecdsa: use `C::FieldBytesSize` over `C::Uint::BYTES`

### DIFF
--- a/ecdsa/src/der.rs
+++ b/ecdsa/src/der.rs
@@ -7,9 +7,8 @@ use core::{
 };
 use der::{asn1::UintRef, Decode, Encode, FixedTag, Length, Reader, Tag, Writer};
 use elliptic_curve::{
-    bigint::Integer,
     consts::U9,
-    generic_array::{ArrayLength, GenericArray},
+    generic_array::{typenum::Unsigned, ArrayLength, GenericArray},
     FieldBytesSize, PrimeCurve,
 };
 
@@ -74,7 +73,9 @@ where
     pub fn from_bytes(input: &[u8]) -> Result<Self> {
         let (r, s) = decode_der(input).map_err(|_| Error::new())?;
 
-        if r.as_bytes().len() > C::Uint::BYTES || s.as_bytes().len() > C::Uint::BYTES {
+        if r.as_bytes().len() > C::FieldBytesSize::USIZE
+            || s.as_bytes().len() > C::FieldBytesSize::USIZE
+        {
             return Err(Error::new());
         }
 
@@ -264,9 +265,9 @@ where
 
     fn try_from(sig: Signature<C>) -> Result<super::Signature<C>> {
         let mut bytes = super::SignatureBytes::<C>::default();
-        let r_begin = C::Uint::BYTES.saturating_sub(sig.r().len());
+        let r_begin = C::FieldBytesSize::USIZE.saturating_sub(sig.r().len());
         let s_begin = bytes.len().saturating_sub(sig.s().len());
-        bytes[r_begin..C::Uint::BYTES].copy_from_slice(sig.r());
+        bytes[r_begin..C::FieldBytesSize::USIZE].copy_from_slice(sig.r());
         bytes[s_begin..].copy_from_slice(sig.s());
         Self::try_from(bytes.as_slice())
     }

--- a/ecdsa/src/dev.rs
+++ b/ecdsa/src/dev.rs
@@ -149,7 +149,7 @@ macro_rules! new_wycheproof_test {
             fn element_from_padded_slice<C: elliptic_curve::Curve>(
                 data: &[u8],
             ) -> elliptic_curve::FieldBytes<C> {
-                let point_len = C::Uint::BYTES;
+                let point_len = C::FieldBytesSize::USIZE;
                 if data.len() >= point_len {
                     let offset = data.len() - point_len;
                     for v in data.iter().take(offset) {

--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -12,7 +12,7 @@
 
 use crate::{Error, Result};
 use core::cmp;
-use elliptic_curve::{bigint::Integer, FieldBytes, PrimeCurve};
+use elliptic_curve::{generic_array::typenum::Unsigned, FieldBytes, PrimeCurve};
 
 #[cfg(feature = "arithmetic")]
 use {
@@ -229,21 +229,21 @@ where
 /// [SEC1]: https://www.secg.org/sec1-v2.pdf
 pub fn bits2field<C: PrimeCurve>(bits: &[u8]) -> Result<FieldBytes<C>> {
     // Minimum allowed bits size is half the field size
-    if bits.len() < C::Uint::BYTES / 2 {
+    if bits.len() < C::FieldBytesSize::USIZE / 2 {
         return Err(Error::new());
     }
 
     let mut field_bytes = FieldBytes::<C>::default();
 
-    match bits.len().cmp(&C::Uint::BYTES) {
+    match bits.len().cmp(&C::FieldBytesSize::USIZE) {
         cmp::Ordering::Equal => field_bytes.copy_from_slice(bits),
         cmp::Ordering::Less => {
             // If bits is smaller than the field size, pad with zeroes on the left
-            field_bytes[(C::Uint::BYTES - bits.len())..].copy_from_slice(bits);
+            field_bytes[(C::FieldBytesSize::USIZE - bits.len())..].copy_from_slice(bits);
         }
         cmp::Ordering::Greater => {
             // If bits is larger than the field size, truncate
-            field_bytes.copy_from_slice(&bits[..C::Uint::BYTES]);
+            field_bytes.copy_from_slice(&bits[..C::FieldBytesSize::USIZE]);
         }
     }
 

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -88,7 +88,6 @@ use core::{
     ops::Add,
 };
 use elliptic_curve::{
-    bigint::Integer,
     generic_array::{sequence::Concat, typenum::Unsigned, ArrayLength, GenericArray},
     FieldBytes, FieldBytesSize, ScalarPrimitive,
 };
@@ -208,7 +207,7 @@ where
 {
     /// Parse a signature from fixed-with bytes.
     pub fn from_bytes(bytes: &SignatureBytes<C>) -> Result<Self> {
-        let (r_bytes, s_bytes) = bytes.split_at(C::Uint::BYTES);
+        let (r_bytes, s_bytes) = bytes.split_at(C::FieldBytesSize::USIZE);
         let r = ScalarPrimitive::from_slice(r_bytes).map_err(|_| Error::new())?;
         let s = ScalarPrimitive::from_slice(s_bytes).map_err(|_| Error::new())?;
 
@@ -252,7 +251,7 @@ where
     /// Serialize this signature as bytes.
     pub fn to_bytes(&self) -> SignatureBytes<C> {
         let mut bytes = SignatureBytes::<C>::default();
-        let (r_bytes, s_bytes) = bytes.split_at_mut(C::Uint::BYTES);
+        let (r_bytes, s_bytes) = bytes.split_at_mut(C::FieldBytesSize::USIZE);
         r_bytes.copy_from_slice(&self.r.to_bytes());
         s_bytes.copy_from_slice(&self.s.to_bytes());
         bytes
@@ -413,7 +412,7 @@ where
     type Err = Error;
 
     fn from_str(hex: &str) -> Result<Self> {
-        if hex.as_bytes().len() != C::Uint::BYTES * 4 {
+        if hex.as_bytes().len() != C::FieldBytesSize::USIZE * 4 {
             return Err(Error::new());
         }
 
@@ -426,7 +425,7 @@ where
             return Err(Error::new());
         }
 
-        let (r_hex, s_hex) = hex.split_at(C::Uint::BYTES * 2);
+        let (r_hex, s_hex) = hex.split_at(C::FieldBytesSize::USIZE * 2);
 
         let r = r_hex
             .parse::<NonZeroScalar<C>>()


### PR DESCRIPTION
This is needed to make curves like P-224 and P-521 work, since the size of the `C::Uint` may not match the size of an integer serialization of a field element (since `C::Uint::MAX` may be much larger than the field modulus)