### PR TITLE
ecdsa: refactor `Signature` constructors and improve docs

### DIFF
--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -100,10 +100,7 @@ where
         // Compute 𝒔 as a signature over 𝒓 and 𝒛.
         let s = k_inv * (z + (r * self));
 
-        if s.is_zero().into() {
-            return Err(Error::new());
-        }
-
+        // NOTE: `Signature::from_scalars` checks that both `r` and `s` are non-zero.
         let signature = Signature::from_scalars(r, s)?;
         let recovery_id = RecoveryId::new(R.y_is_odd().into(), x_is_reduced);
         Ok((signature, Some(recovery_id)))


### PR DESCRIPTION
Implements `from_bytes` in terms of `from_scalars`, rather than the other way around.

This places the logic for checking that `r` and `s` are nonzero inside of the `from_scalars` method.

Additionally improves the documentation to note the various failure cases, i.e. if `r` and/or `s` is out of the range `1..n`, where `n` is the scalar modulus.