### PR TITLE
ecdsa v0.16.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.16.7"
+version = "0.16.8"
 dependencies = [
  "der",
  "digest",

--- a/ecdsa/CHANGELOG.md
+++ b/ecdsa/CHANGELOG.md
@@ -4,8 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.16.7 (2023-05-11)
+## 0.16.8 (2023-07-20)
+### Added
+- `hazmat::{sign_prehashed, verify_prehashed}` ([#731])
 
+### Changed
+- Refactor `Signature` constructors and improve docs ([#730])
+
+[#730]: https://github.com/RustCrypto/signatures/pull/730
+[#731]: https://github.com/RustCrypto/signatures/pull/731
+
+## 0.16.7 (2023-05-11)
 ### Added
 - RFC5480 citation for `der::Signature` ([#710])
 - support for the `SignatureBitStringEncoding` trait ([#716])

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecdsa"
-version = "0.16.7"
+version = "0.16.8"
 description = """
 Pure Rust implementation of the Elliptic Curve Digital Signature Algorithm
 (ECDSA) as specified in FIPS 186-4 (Digital Signature Standard), providing


### PR DESCRIPTION
### Added
- `hazmat::{sign_prehashed, verify_prehashed}` ([#731])

### Changed
- Refactor `Signature` constructors and improve docs ([#730])

[#730]: https://github.com/RustCrypto/signatures/pull/730
[#731]: https://github.com/RustCrypto/signatures/pull/731