### PR TITLE
ed25519: bump `ed25519-dalek` to v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.0.0-rc.3"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436ace70fc06e06f7f689d2624dc4e2f0ea666efb5aa704215f7249ae6e047a7"
+checksum = "f711ade317dd348950a9910f81c5947e3d8907ebd2b83f76203ff1807e6a2bc2"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -221,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa8e9049d5d72bfc12acbc05914731b5322f79b5e2f195e9f2d705fca22ab4c"
+checksum = "7277392b266383ef8396db7fdeb1e77b6c52fed775f5df15bb24f35b72156980"
 dependencies = [
  "curve25519-dalek",
  "ed25519 2.2.0",

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -27,7 +27,7 @@ zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 bincode = "1"
-ed25519-dalek = { version = "=2.0.0-rc.3", features = ["rand_core"] }
+ed25519-dalek = { version = "2", features = ["rand_core"] }
 hex-literal = "0.4"
 ring-compat = { version = "0.7", default-features = false, features = ["signature"] }
 rand_core = { version = "0.6", features = ["std"] }

--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -79,8 +79,8 @@
 //! instantiate and use the previously defined `HelloSigner` and `HelloVerifier`
 //! types with [`ed25519-dalek`] as the signing/verification provider:
 //!
-//! *NOTE: requires [`ed25519-dalek`] v2.0.0-rc.2 or newer for compatibility
-//! with `ed25519` v2.2.
+//! *NOTE: requires [`ed25519-dalek`] v2 or newer for compatibility with
+//! `ed25519` v2.2+*.
 //!
 //! ```
 //! use ed25519_dalek::{Signer, Verifier, Signature};


### PR DESCRIPTION
This is used as a `dev-dependency` for doctesting rustdoc documentation showing how to use the trait-based API.