### PR TITLE
ed25519 v2.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "bincode",
  "ed25519-dalek",

--- a/ed25519/CHANGELOG.md
+++ b/ed25519/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.2.2 (2023-08-13)
+### Changed
+- Bump `ed25519-dalek` to v2 ([#738])
+
+[#738]: https://github.com/RustCrypto/signatures/pull/738
+
 ## 2.2.1 (2023-04-03)
 ### Changed
 - Bump `ring-compat` dev-dependency to v0.7 ([#692])

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed25519"
-version = "2.2.1"
+version = "2.2.2"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """


### PR DESCRIPTION
### Changed
- Bump `ed25519-dalek` to v2 ([#738])

[#738]: https://github.com/RustCrypto/signatures/pull/738