### PR TITLE
ed25519: enable `pkcs8/std` feature when `std` is enabled

### DIFF
--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -37,7 +37,7 @@ default = ["std"]
 alloc = ["pkcs8?/alloc"]
 pem = ["alloc", "pkcs8/pem"]
 serde_bytes = ["serde", "dep:serde_bytes"]
-std = ["signature/std"]
+std = ["pkcs8?/std", "signature/std"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
When we enable the `std` feature and the `pkcs8` dependency is enabled (by the `pem` feature), enable the `std` feature of `pkcs8`.

This makes it easier to work with the re-exported `pkcs8::Error` type because without the `std` feature it does not impl the  `std::error::Error` marker trait.