### PR TITLE
ed25519: hexify `Debug` impl on `Signature`

### DIFF
--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -57,6 +57,7 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
+mod normalized;
 mod recovery;
 
 #[cfg(feature = "der")]
@@ -70,7 +71,7 @@ mod signing;
 #[cfg(feature = "verifying")]
 mod verifying;
 
-pub use crate::recovery::RecoveryId;
+pub use crate::{normalized::NormalizedSignature, recovery::RecoveryId};
 
 // Re-export the `elliptic-curve` crate (and select types)
 pub use elliptic_curve::{self, sec1::EncodedPoint, PrimeCurve};

--- a/ecdsa/src/normalized.rs
+++ b/ecdsa/src/normalized.rs
@@ -1,0 +1,11 @@
+//! Support for ECDSA signatures with low-S normalization.
+
+use crate::Signature;
+use elliptic_curve::PrimeCurve;
+
+/// ECDSA signature with low-S normalization applied.
+#[derive(Clone, Eq, PartialEq)]
+#[repr(transparent)]
+pub struct NormalizedSignature<C: PrimeCurve> {
+    inner: Signature<C>,
+}

--- a/ed25519/src/hex.rs
+++ b/ed25519/src/hex.rs
@@ -1,8 +1,23 @@
 //! Hexadecimal encoding support
 // TODO(tarcieri): use `base16ct`?
 
-use crate::{Error, Signature};
+use crate::{ComponentBytes, Error, Signature};
 use core::{fmt, str};
+
+/// Format a signature component as hex.
+pub(crate) struct ComponentFormatter<'a>(pub(crate) &'a ComponentBytes);
+
+impl fmt::Debug for ComponentFormatter<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "0x")?;
+
+        for byte in self.0 {
+            write!(f, "{:02x}", byte)?;
+        }
+
+        Ok(())
+    }
+}
 
 impl fmt::LowerHex for Signature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -208,7 +208,7 @@
 //! let mut ed25519_seed = [0u8; 32];
 //! OsRng.fill_bytes(&mut ed25519_seed);
 //!
-//! let signing_key = SigningKey::from_seed(&ed25519_seed).unwrap();
+//! let signing_key = SigningKey::from_bytes(&ed25519_seed);
 //! let verifying_key = signing_key.verifying_key();
 //!
 //! let signer = RingHelloSigner { signing_key };
@@ -406,8 +406,8 @@ impl TryFrom<&[u8]> for Signature {
 impl fmt::Debug for Signature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ed25519::Signature")
-            .field("R", self.r_bytes())
-            .field("s", self.s_bytes())
+            .field("R", &hex::ComponentFormatter(self.r_bytes()))
+            .field("s", &hex::ComponentFormatter(self.s_bytes()))
             .finish()
     }
 }

--- a/ed25519/tests/serde.rs
+++ b/ed25519/tests/serde.rs
@@ -13,6 +13,7 @@ const EXAMPLE_SIGNATURE: SignatureBytes = hex!(
 #[test]
 fn test_serialize() {
     let signature = Signature::try_from(&EXAMPLE_SIGNATURE[..]).unwrap();
+    dbg!(&signature);
     let encoded_signature: Vec<u8> = bincode::serialize(&signature).unwrap();
     assert_eq!(&EXAMPLE_SIGNATURE[..], &encoded_signature[..]);
 }


### PR DESCRIPTION
Formats the `R` and `s` signature components as hexidecimal to make the representation more compact, as requested in #723:

```rust
ed25519::Signature {
    R: 0x3f3e3d3c3b3a393837363534333231302f2e2d2c2b2a29282726252423222120,
    s: 0x1f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100,
}
```