### PR TITLE
ed25519 v2.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "bincode",
  "ed25519-dalek",

--- a/ed25519/CHANGELOG.md
+++ b/ed25519/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.2.3 (2023-10-15)
+### Changed
+- Bump `ring-compat` from 0.7 to 0.8 ([#744])
+- Enable `pkcs8/std` feature when `std` feature is enabled ([#746])
+- Hex-format `Signature` components in `Debug` impl ([#747])
+
+[#744]: https://github.com/RustCrypto/signatures/pull/744
+[#746]: https://github.com/RustCrypto/signatures/pull/746
+[#747]: https://github.com/RustCrypto/signatures/pull/747
+
 ## 2.2.2 (2023-08-13)
 ### Changed
 - Bump `ed25519-dalek` to v2 ([#738])

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed25519"
-version = "2.2.2"
+version = "2.2.3"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """


### PR DESCRIPTION
### Changed
- Bump `ring-compat` from 0.7 to 0.8 ([#744])
- Enable `pkcs8/std` feature when `std` feature is enabled ([#746])
- Hex-format `Signature` components in `Debug` impl ([#747])

[#744]: https://github.com/RustCrypto/signatures/pull/744
[#746]: https://github.com/RustCrypto/signatures/pull/746
[#747]: https://github.com/RustCrypto/signatures/pull/747