### PR TITLE
dsa+ecdsa: support `signature` up to v2.2

### DIFF
--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -21,7 +21,7 @@ num-traits = { version = "0.2", default-features = false }
 pkcs8 = { version = "0.10", default-features = false, features = ["alloc"] }
 rfc6979 = { version = "0.4", path = "../rfc6979" }
 sha2 = { version = "0.10", default-features = false }
-signature = { version = "2.0, <2.2", default-features = false, features = ["alloc", "digest", "rand_core"] }
+signature = { version = "2.0, <2.3", default-features = false, features = ["alloc", "digest", "rand_core"] }
 zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.65"
 
 [dependencies]
 elliptic-curve = { version = "0.13.6", default-features = false, features = ["digest", "sec1"] }
-signature = { version = "2.0, <2.2", default-features = false, features = ["rand_core"] }
+signature = { version = "2.0, <2.3", default-features = false, features = ["rand_core"] }
 
 # optional dependencies
 der = { version = "0.7", optional = true }


### PR DESCRIPTION
The v2.2.0 release bumped MSRV to 1.60, however that's still compatible with the MSRV of `dsa` and `ecdsa`, which are both MSRV 1.65.