### PR TITLE
ecdsa v0.16.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,17 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.16.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4b1e0c257a9e9f25f90ff76d7a68360ed497ee519c8e428d1825ef0000799d4"
+dependencies = [
+ "der",
+ "elliptic-curve",
+ "signature",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
 dependencies = [
  "der",
  "digest",
@@ -177,17 +188,6 @@ dependencies = [
  "sha2",
  "signature",
  "spki",
-]
-
-[[package]]
-name = "ecdsa"
-version = "0.16.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4b1e0c257a9e9f25f90ff76d7a68360ed497ee519c8e428d1825ef0000799d4"
-dependencies = [
- "der",
- "elliptic-curve",
- "signature",
 ]
 
 [[package]]
@@ -403,7 +403,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
- "ecdsa 0.16.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ecdsa 0.16.8",
  "elliptic-curve",
 ]
 
@@ -413,7 +413,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209"
 dependencies = [
- "ecdsa 0.16.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ecdsa 0.16.8",
  "elliptic-curve",
  "primeorder",
 ]
@@ -536,7 +536,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccce7bae150b815f0811db41b8312fcb74bffa4cab9cee5429ee00f356dd5bd4"
 dependencies = [
- "ecdsa 0.16.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ecdsa 0.16.8",
  "ed25519 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array",
  "p256",

--- a/ecdsa/CHANGELOG.md
+++ b/ecdsa/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.16.9 (2023-11-16)
+### Changed
+- Loosen `signature` bound to `2.0, <2.3` ([#756])
+
+[#756]: https://github.com/RustCrypto/signatures/pull/756
+
 ## 0.16.8 (2023-07-20)
 ### Added
 - `hazmat::{sign_prehashed, verify_prehashed}` ([#731])

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecdsa"
-version = "0.16.8"
+version = "0.16.9"
 description = """
 Pure Rust implementation of the Elliptic Curve Digital Signature Algorithm
 (ECDSA) as specified in FIPS 186-4 (Digital Signature Standard), providing


### PR DESCRIPTION
### Changed
- Loosen `signature` bound to `2.0, <2.3` ([#756])

[#756]: https://github.com/RustCrypto/signatures/pull/756