### PR TITLE
replace the usage of usize with u64 for writing bytes to a byte vector

### DIFF
--- a/ed25519/tests/serde.rs
+++ b/ed25519/tests/serde.rs
@@ -38,7 +38,7 @@ fn test_serialize_bytes() {
     let mut serializer = bincode::Serializer::new(&mut encoded_signature, options);
     serde_bytes::serialize(&signature, &mut serializer).unwrap();
 
-    let mut expected = Vec::from(Signature::BYTE_SIZE.to_le_bytes());
+    let mut expected = Vec::from((Signature::BYTE_SIZE as u64).to_le_bytes());
     expected.extend(&EXAMPLE_SIGNATURE[..]);
     assert_eq!(&expected[..], &encoded_signature[..]);
 }
@@ -48,7 +48,7 @@ fn test_serialize_bytes() {
 fn test_deserialize_bytes() {
     use bincode::Options;
 
-    let mut encoded_signature = Vec::from(Signature::BYTE_SIZE.to_le_bytes());
+    let mut encoded_signature = Vec::from((Signature::BYTE_SIZE as u64).to_le_bytes());
     encoded_signature.extend(&EXAMPLE_SIGNATURE[..]);
 
     let options = bincode::DefaultOptions::new()


### PR DESCRIPTION
as usize have variable size across architectures

Errors on i386:
```
 95s failures:
 95s 
 95s ---- test_deserialize_bytes stdout ----
 95s thread 'test_deserialize_bytes' panicked at 'called `Result::unwrap()` on an `Err` value: Custom("Invalid size 4340694056158888000: sizes must fit in a usize (0 to 4294967295)")', tests/serde.rs:59:76
 95s stack backtrace:
 95s    0: rust_begin_unwind
 95s              at /usr/src/rustc-1.70.0/library/std/src/panicking.rs:578:5
 95s    1: core::panicking::panic_fmt
 95s              at /usr/src/rustc-1.70.0/library/core/src/panicking.rs:67:14
 95s    2: core::result::unwrap_failed
 95s              at /usr/src/rustc-1.70.0/library/core/src/result.rs:1687:5
 95s    3: core::result::Result<T,E>::unwrap
 95s              at /usr/src/rustc-1.70.0/library/core/src/result.rs:1089:23
 95s    4: serde::test_deserialize_bytes
 95s              at ./tests/serde.rs:59:32
 95s    5: serde::test_deserialize_bytes::{{closure}}
 95s              at ./tests/serde.rs:48:29
 95s    6: core::ops::function::FnOnce::call_once
 95s              at /usr/src/rustc-1.70.0/library/core/src/ops/function.rs:250:5
 95s    7: core::ops::function::FnOnce::call_once
 95s              at /usr/src/rustc-1.70.0/library/core/src/ops/function.rs:250:5
 95s note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
 95s 
 95s ---- test_serialize_bytes stdout ----
 95s thread 'test_serialize_bytes' panicked at 'assertion failed: `(left == right)`
 95s   left: `[64, 0, 0, 0, 63, 62, 61, 60, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43, 42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]`,
 95s  right: `[64, 0, 0, 0, 0, 0, 0, 0, 63, 62, 61, 60, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43, 42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]`', tests/serde.rs:43:5
 95s stack backtrace:
 95s    0: rust_begin_unwind
 95s              at /usr/src/rustc-1.70.0/library/std/src/panicking.rs:578:5
 95s    1: core::panicking::panic_fmt
 95s              at /usr/src/rustc-1.70.0/library/core/src/panicking.rs:67:14
 95s    2: core::panicking::assert_failed_inner
 95s    3: core::panicking::assert_failed
 95s              at /usr/src/rustc-1.70.0/library/core/src/panicking.rs:228:5
 95s    4: serde::test_serialize_bytes
 95s              at ./tests/serde.rs:43:5
 95s    5: serde::test_serialize_bytes::{{closure}}
 95s              at ./tests/serde.rs:29:27
 95s    6: core::ops::function::FnOnce::call_once
 95s              at /usr/src/rustc-1.70.0/library/core/src/ops/function.rs:250:5
 95s    7: core::ops::function::FnOnce::call_once
 95s              at /usr/src/rustc-1.70.0/library/core/src/ops/function.rs:250:5
 95s note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```