### PR TITLE
Bump `signature` to v2.3.0-pre.0; MSRV 1.71

### DIFF
--- a/.github/workflows/dsa.yml
+++ b/.github/workflows/dsa.yml
@@ -24,7 +24,7 @@ jobs:
           - thumbv7em-none-eabi
           - wasm32-unknown-unknown
         toolchain:
-          - 1.65.0 # MSRV
+          - 1.71.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
           - macos-latest
           - windows-latest
         toolchain:
-          - 1.65.0 # MSRV
+          - 1.71.0 # MSRV
           - stable
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/ecdsa.yml
+++ b/.github/workflows/ecdsa.yml
@@ -26,7 +26,7 @@ jobs:
           - thumbv7em-none-eabi
           - wasm32-unknown-unknown
         rust:
-          - 1.65.0 # MSRV
+          - 1.73.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.73.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ed25519.yml
+++ b/.github/workflows/ed25519.yml
@@ -24,7 +24,7 @@ jobs:
           - thumbv7em-none-eabi
           - wasm32-unknown-unknown
         toolchain:
-          - 1.60.0 # MSRV
+          - 1.71.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4
@@ -34,16 +34,15 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
-      # TODO(tarcieri): re-enable the following when MSRV is 1.65
-      #- run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pem
-      #- run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pkcs8
-      #- run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,pem,pkcs8
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pem
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pkcs8
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,pem,pkcs8
 
   test:
     strategy:
       matrix:
         toolchain:
-          - 1.65.0 # Technically MSRV is 1.60, but we have 1.65 dev-dependencies (i.e. ring-compat)
+          - 1.71.0 # MSRV
           - stable
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ed448.yml
+++ b/.github/workflows/ed448.yml
@@ -24,7 +24,7 @@ jobs:
           - thumbv7em-none-eabi
           - wasm32-unknown-unknown
         toolchain:
-          - 1.60.0 # MSRV
+          - 1.71.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4
@@ -34,16 +34,15 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
-      # TODO(tarcieri): re-enable the following when MSRV is 1.65
-      #- run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pem
-      #- run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pkcs8
-      #- run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,pem,pkcs8
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pem
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features pkcs8
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,pem,pkcs8
 
   test:
     strategy:
       matrix:
         toolchain:
-          - 1.65.0 # Technically MSRV is 1.60, but we have 1.65 dev-dependencies (i.e. ring-compat)
+          - 1.71.0 # MSRV
           - stable
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rfc6979.yml
+++ b/.github/workflows/rfc6979.yml
@@ -24,7 +24,7 @@ jobs:
           - thumbv7em-none-eabi
           - wasm32-unknown-unknown
         rust:
-          - 1.61.0 # MSRV
+          - 1.71.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.61.0 # MSRV
+          - 1.71.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -29,6 +29,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.66.0
+          toolchain: 1.73.0
           components: clippy
       - run: cargo clippy --all-features -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,11 +31,11 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.11.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "72bc448e41b30773616b4f51a23f1a51634d41ce0d06a9bf6c3065ee85e227a1"
 dependencies = [
- "generic-array",
+ "crypto-common",
 ]
 
 [[package]]
@@ -43,15 +43,6 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
-name = "cc"
-version = "1.0.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "cfg-if"
@@ -66,6 +57,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
 
 [[package]]
+name = "const-oid"
+version = "0.10.0-pre.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7e3352a27098ba6b09546e5f13b15165e6a88b5c2723afecb3ea9576b27e3ea"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,11 +73,12 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.4"
+version = "0.6.0-pre.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28f85c3514d2a6e64160359b45a3918c3b4178bcbf4ae5d03ab2d02e521c479a"
+checksum = "7f83f24a157ad881f072a0ba6b4950dc0d1fbbea38df4dcc271d9a4a1501b96e"
 dependencies = [
- "generic-array",
+ "hybrid-array",
+ "num-traits",
  "rand_core",
  "subtle",
  "zeroize",
@@ -88,40 +86,13 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.2.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "cc17eb697364b18256ec92675ebe6b7b153d2f1041e568d74533c5d0fc1ca162"
 dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "curve25519-dalek"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "curve25519-dalek-derive",
- "digest",
- "fiat-crypto",
- "platforms",
- "rustc_version",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "getrandom",
+ "hybrid-array",
+ "rand_core",
 ]
 
 [[package]]
@@ -130,31 +101,42 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
 dependencies = [
- "const-oid",
- "pem-rfc7468",
+ "const-oid 0.9.5",
+ "pem-rfc7468 0.7.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b489fd2221710c1dd46637d66b984161fb66134f81437a8489800306bcc2ecea"
+dependencies = [
+ "const-oid 0.10.0-pre.2",
+ "pem-rfc7468 1.0.0-pre.0",
  "zeroize",
 ]
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "eb3be3c52e023de5662dc05a32f747d09a1d6024fdd1f64b0850e373269efb43"
 dependencies = [
  "block-buffer",
- "const-oid",
+ "const-oid 0.10.0-pre.2",
  "crypto-common",
  "subtle",
 ]
 
 [[package]]
 name = "dsa"
-version = "0.6.2"
+version = "0.7.0-pre"
 dependencies = [
  "digest",
  "num-bigint-dig",
  "num-traits",
- "pkcs8",
+ "pkcs8 0.11.0-pre.0",
  "rand",
  "rand_chacha",
  "rfc6979",
@@ -166,28 +148,17 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.16.9"
+version = "0.17.0-pre"
 dependencies = [
- "der",
+ "der 0.8.0-pre.0",
  "digest",
  "elliptic-curve",
  "hex-literal",
  "rfc6979",
- "serdect",
+ "serdect 0.2.0",
  "sha2",
  "signature",
- "spki",
-]
-
-[[package]]
-name = "ecdsa"
-version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
-dependencies = [
- "der",
- "elliptic-curve",
- "signature",
+ "spki 0.8.0-pre.0",
 ]
 
 [[package]]
@@ -195,11 +166,9 @@ name = "ed25519"
 version = "2.2.3"
 dependencies = [
  "bincode",
- "ed25519-dalek",
  "hex-literal",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core",
- "ring-compat",
  "serde",
  "serde_bytes",
  "signature",
@@ -207,37 +176,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "ed25519"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
-dependencies = [
- "pkcs8",
- "signature",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f628eaec48bfd21b865dc2950cfa014450c01d2fa2b69a86c2fd5844ec523c0"
-dependencies = [
- "curve25519-dalek",
- "ed25519 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core",
- "serde",
- "sha2",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "ed448-signature"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "bincode",
  "hex-literal",
- "pkcs8",
+ "pkcs8 0.10.2",
  "serde",
  "serde_bytes",
  "signature",
@@ -245,22 +189,22 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.8"
+version = "0.14.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+checksum = "123fbdce8736a188bcc6594ce08e5eb89bccc5ebd72258b4bac3c9fd0638423a"
 dependencies = [
  "base16ct",
  "crypto-bigint",
  "digest",
  "ff",
- "generic-array",
  "group",
  "hex-literal",
- "pem-rfc7468",
- "pkcs8",
+ "hybrid-array",
+ "pem-rfc7468 1.0.0-pre.0",
+ "pkcs8 0.11.0-pre.0",
  "rand_core",
  "sec1",
- "serdect",
+ "serdect 0.3.0-pre.0",
  "subtle",
  "zeroize",
 ]
@@ -273,23 +217,6 @@ checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
  "rand_core",
  "subtle",
-]
-
-[[package]]
-name = "fiat-crypto"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53a56f0780318174bad1c127063fd0c5fdfb35398e3cd79ffaab931a6c79df80"
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -322,11 +249,21 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "e22cb0183a745c3444af57c24aa1293e1f3e538717acce39a9d3b271c999b24f"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.2.0-pre.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27fbaf242418fe980caf09ed348d5a6aeabe71fc1bd8bebad641f4591ae0a46d"
+dependencies = [
+ "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -335,7 +272,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
- "spin 0.5.2",
+ "spin",
 ]
 
 [[package]]
@@ -398,31 +335,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "p256"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
-dependencies = [
- "ecdsa 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "elliptic-curve",
-]
-
-[[package]]
-name = "p384"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209"
-dependencies = [
- "ecdsa 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "elliptic-curve",
- "primeorder",
-]
-
-[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a65e1c27d1680f8805b3f8c9949f08d6aa5d6cbd088c9896e64a53821dc27d"
 dependencies = [
  "base64ct",
 ]
@@ -433,30 +358,25 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.8",
+ "spki 0.7.3",
 ]
 
 [[package]]
-name = "platforms"
-version = "3.2.0"
+name = "pkcs8"
+version = "0.11.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14e6ab3f592e6fb464fc9712d8d6e6912de6473954635fd76a589d832cffcbb0"
+checksum = "935c09e0aecb0cb8f8907b57438b19a068cb74a25189b06724f061170b2465ff"
+dependencies = [
+ "der 0.8.0-pre.0",
+ "spki 0.8.0-pre.0",
+]
 
 [[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
-name = "primeorder"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
-dependencies = [
- "elliptic-curve",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -508,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.4.0"
+version = "0.5.0-pre"
 dependencies = [
  "hex-literal",
  "hmac",
@@ -517,64 +437,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "ring"
-version = "0.17.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b"
-dependencies = [
- "cc",
- "getrandom",
- "libc",
- "spin 0.9.8",
- "untrusted",
- "windows-sys",
-]
-
-[[package]]
-name = "ring-compat"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccce7bae150b815f0811db41b8312fcb74bffa4cab9cee5429ee00f356dd5bd4"
-dependencies = [
- "ecdsa 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "ed25519 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "generic-array",
- "p256",
- "p384",
- "pkcs8",
- "ring",
- "signature",
-]
-
-[[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "sec1"
-version = "0.7.3"
+version = "0.8.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+checksum = "5ccf9d914303f6606a4fa47933f65b92ce13991573a3c61118a458ec5b5ca6cb"
 dependencies = [
  "base16ct",
- "der",
- "generic-array",
- "pkcs8",
- "serdect",
+ "der 0.8.0-pre.0",
+ "hybrid-array",
+ "pkcs8 0.11.0-pre.0",
+ "serdect 0.3.0-pre.0",
  "subtle",
  "zeroize",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
@@ -616,10 +491,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.6"
+name = "serdect"
+version = "0.3.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "791ef964bfaba6be28a5c3f0c56836e17cb711ac009ca1074b9c735a3ebf240a"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c14486028be4486a46aa8c4131ef865ec85b221c1e1327af76f10b6981e06850"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -628,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.11.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "de0628cd6fd8219612c2d71ad52ab8c2014a18cbdbedbde17de04d400df65997"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -639,9 +524,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.2.0"
+version = "2.3.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+checksum = "68a9b544e1447a755027450a51bc29aa51772e071bd839aca18136a7dab1b93e"
 dependencies = [
  "digest",
  "rand_core",
@@ -660,19 +545,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.8",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb2b56670f5ef52934c97efad30bf42585de0c33ec3e2a886e38b80d2db67243"
+dependencies = [
+ "base64ct",
+ "der 0.8.0-pre.0",
 ]
 
 [[package]]
@@ -705,88 +594,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "zeroize"

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsa"
-version = "0.6.2"
+version = "0.7.0-pre"
 description = """
 Pure Rust implementation of the Digital Signature Algorithm (DSA) as specified
 in FIPS 186-4 (Digital Signature Standard), providing RFC6979 deterministic
@@ -12,23 +12,23 @@ readme = "README.md"
 repository = "https://github.com/RustCrypto/signatures/tree/master/dsa"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "nist", "signature"]
-rust-version = "1.65"
+rust-version = "1.71"
 
 [dependencies]
-digest = "0.10"
+digest = "=0.11.0-pre.3"
 num-bigint = { package = "num-bigint-dig", version = "0.8", default-features = false, features = ["prime", "rand", "zeroize"] }
 num-traits = { version = "0.2", default-features = false }
-pkcs8 = { version = "0.10", default-features = false, features = ["alloc"] }
-rfc6979 = { version = "0.4", path = "../rfc6979" }
-sha2 = { version = "0.10", default-features = false }
-signature = { version = "2.0, <2.3", default-features = false, features = ["alloc", "digest", "rand_core"] }
+pkcs8 = { version = "=0.11.0-pre.0", default-features = false, features = ["alloc"] }
+rfc6979 = { version = "=0.5.0-pre", path = "../rfc6979" }
+sha2 = { version = "=0.11.0-pre.0", default-features = false }
+signature = { version = "=2.3.0-pre.0", default-features = false, features = ["alloc", "digest", "rand_core"] }
 zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]
-pkcs8 = { version = "0.10", default-features = false, features = ["pem"] }
+pkcs8 = { version = "=0.11.0-pre.0", default-features = false, features = ["pem"] }
 rand = "0.8"
 rand_chacha = "0.3"
-sha1 = "0.10"
+sha1 = "=0.11.0-pre.0"
 
 [features]
 std = []

--- a/dsa/README.md
+++ b/dsa/README.md
@@ -30,7 +30,7 @@ USE AT YOUR OWN RISK!
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.65** at a minimum.
+This crate requires **Rust 1.71** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -59,7 +59,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/signatures/actions/workflows/dsa.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/signatures/actions/workflows/dsa.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.71+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260048-signatures
 

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecdsa"
-version = "0.16.9"
+version = "0.17.0-pre"
 description = """
 Pure Rust implementation of the Elliptic Curve Digital Signature Algorithm
 (ECDSA) as specified in FIPS 186-4 (Digital Signature Standard), providing
@@ -13,24 +13,24 @@ readme = "README.md"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "ecc", "nist", "secp256k1", "signature"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.73"
 
 [dependencies]
-elliptic-curve = { version = "0.13.8", default-features = false, features = ["digest", "sec1"] }
-signature = { version = "2.0, <2.3", default-features = false, features = ["rand_core"] }
+elliptic-curve = { version = "=0.14.0-pre.0", default-features = false, features = ["digest", "sec1"] }
+signature = { version = "=2.3.0-pre.0", default-features = false, features = ["rand_core"] }
 
 # optional dependencies
-der = { version = "0.7", optional = true }
-digest = { version = "0.10.7", optional = true, default-features = false, features = ["oid"] }
-rfc6979 = { version = "0.4", optional = true, path = "../rfc6979" }
+der = { version = "=0.8.0-pre.0", optional = true }
+digest = { version = "=0.11.0-pre.3", optional = true, default-features = false, features = ["oid"] }
+rfc6979 = { version = "=0.5.0-pre", optional = true, path = "../rfc6979" }
 serdect = { version = "0.2", optional = true, default-features = false, features = ["alloc"] }
-sha2 = { version = "0.10", optional = true, default-features = false, features = ["oid"] }
-spki = { version = "0.7.3", optional = true, default-features = false }
+sha2 = { version = "=0.11.0-pre.0", optional = true, default-features = false, features = ["oid"] }
+spki = { version = "=0.8.0-pre.0", optional = true, default-features = false }
 
 [dev-dependencies]
-elliptic-curve = { version = "0.13", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "=0.14.0-pre.0", default-features = false, features = ["dev"] }
 hex-literal = "0.4"
-sha2 = { version = "0.10", default-features = false }
+sha2 = { version = "=0.11.0-pre.0", default-features = false }
 
 [features]
 default = ["digest"]

--- a/ecdsa/README.md
+++ b/ecdsa/README.md
@@ -41,7 +41,7 @@ USE AT YOUR OWN RISK!
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.65** at a minimum.
+This crate requires **Rust 1.73** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -70,7 +70,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/signatures/actions/workflows/ecdsa.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/signatures/actions/workflows/ecdsa.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.73+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260048-signatures
 

--- a/ecdsa/src/der.rs
+++ b/ecdsa/src/der.rs
@@ -10,8 +10,8 @@ use core::{
 };
 use der::{asn1::UintRef, Decode, Encode, FixedTag, Length, Reader, Tag, Writer};
 use elliptic_curve::{
+    array::{typenum::Unsigned, Array, ArraySize},
     consts::U9,
-    generic_array::{typenum::Unsigned, ArrayLength, GenericArray},
     FieldBytesSize, PrimeCurve,
 };
 
@@ -45,7 +45,7 @@ pub type MaxOverhead = U9;
 pub type MaxSize<C> = <<FieldBytesSize<C> as Add>::Output as Add<MaxOverhead>>::Output;
 
 /// Byte array containing a serialized ASN.1 signature
-type SignatureBytes<C> = GenericArray<u8, MaxSize<C>>;
+type SignatureBytes<C> = Array<u8, MaxSize<C>>;
 
 /// ASN.1 DER-encoded signature as specified in [RFC5912 Appendix A]:
 ///
@@ -60,8 +60,8 @@ type SignatureBytes<C> = GenericArray<u8, MaxSize<C>>;
 pub struct Signature<C>
 where
     C: PrimeCurve,
-    MaxSize<C>: ArrayLength<u8>,
-    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
+    MaxSize<C>: ArraySize,
+    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArraySize,
 {
     /// ASN.1 DER-encoded signature data
     bytes: SignatureBytes<C>,
@@ -77,8 +77,8 @@ where
 impl<C> Signature<C>
 where
     C: PrimeCurve,
-    MaxSize<C>: ArrayLength<u8>,
-    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
+    MaxSize<C>: ArraySize,
+    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArraySize,
 {
     /// Parse signature from DER-encoded bytes.
     pub fn from_bytes(input: &[u8]) -> Result<Self> {
@@ -157,8 +157,8 @@ where
 impl<C> AsRef<[u8]> for Signature<C>
 where
     C: PrimeCurve,
-    MaxSize<C>: ArrayLength<u8>,
-    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
+    MaxSize<C>: ArraySize,
+    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArraySize,
 {
     fn as_ref(&self) -> &[u8] {
         self.as_bytes()
@@ -168,8 +168,8 @@ where
 impl<C> Clone for Signature<C>
 where
     C: PrimeCurve,
-    MaxSize<C>: ArrayLength<u8>,
-    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
+    MaxSize<C>: ArraySize,
+    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArraySize,
 {
     fn clone(&self) -> Self {
         Self {
@@ -183,8 +183,8 @@ where
 impl<C> Debug for Signature<C>
 where
     C: PrimeCurve,
-    MaxSize<C>: ArrayLength<u8>,
-    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
+    MaxSize<C>: ArraySize,
+    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArraySize,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "ecdsa::der::Signature<{:?}>(", C::default())?;
@@ -200,8 +200,8 @@ where
 impl<'a, C> Decode<'a> for Signature<C>
 where
     C: PrimeCurve,
-    MaxSize<C>: ArrayLength<u8>,
-    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
+    MaxSize<C>: ArraySize,
+    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArraySize,
 {
     fn decode<R: Reader<'a>>(reader: &mut R) -> der::Result<Self> {
         let header = reader.peek_header()?;
@@ -221,8 +221,8 @@ where
 impl<C> Encode for Signature<C>
 where
     C: PrimeCurve,
-    MaxSize<C>: ArrayLength<u8>,
-    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
+    MaxSize<C>: ArraySize,
+    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArraySize,
 {
     fn encoded_len(&self) -> der::Result<Length> {
         Length::try_from(self.len())
@@ -236,8 +236,8 @@ where
 impl<C> FixedTag for Signature<C>
 where
     C: PrimeCurve,
-    MaxSize<C>: ArrayLength<u8>,
-    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
+    MaxSize<C>: ArraySize,
+    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArraySize,
 {
     const TAG: Tag = Tag::Sequence;
 }
@@ -245,8 +245,8 @@ where
 impl<C> From<crate::Signature<C>> for Signature<C>
 where
     C: PrimeCurve,
-    MaxSize<C>: ArrayLength<u8>,
-    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
+    MaxSize<C>: ArraySize,
+    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArraySize,
 {
     fn from(sig: crate::Signature<C>) -> Signature<C> {
         sig.to_der()
@@ -256,8 +256,8 @@ where
 impl<C> TryFrom<&[u8]> for Signature<C>
 where
     C: PrimeCurve,
-    MaxSize<C>: ArrayLength<u8>,
-    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
+    MaxSize<C>: ArraySize,
+    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArraySize,
 {
     type Error = Error;
 
@@ -269,8 +269,8 @@ where
 impl<C> TryFrom<Signature<C>> for crate::Signature<C>
 where
     C: PrimeCurve,
-    MaxSize<C>: ArrayLength<u8>,
-    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
+    MaxSize<C>: ArraySize,
+    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArraySize,
 {
     type Error = Error;
 
@@ -288,8 +288,8 @@ where
 impl<C> From<Signature<C>> for Box<[u8]>
 where
     C: PrimeCurve,
-    MaxSize<C>: ArrayLength<u8>,
-    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
+    MaxSize<C>: ArraySize,
+    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArraySize,
 {
     fn from(signature: Signature<C>) -> Box<[u8]> {
         signature.to_vec().into_boxed_slice()
@@ -300,8 +300,8 @@ where
 impl<C> SignatureEncoding for Signature<C>
 where
     C: PrimeCurve,
-    MaxSize<C>: ArrayLength<u8>,
-    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
+    MaxSize<C>: ArraySize,
+    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArraySize,
 {
     type Repr = Box<[u8]>;
 
@@ -314,8 +314,8 @@ where
 impl<C> SignatureBitStringEncoding for Signature<C>
 where
     C: PrimeCurve,
-    MaxSize<C>: ArrayLength<u8>,
-    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
+    MaxSize<C>: ArraySize,
+    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArraySize,
 {
     fn to_bitstring(&self) -> der::Result<BitString> {
         BitString::new(0, self.to_vec())
@@ -326,8 +326,8 @@ where
 impl<C> Serialize for Signature<C>
 where
     C: PrimeCurve,
-    MaxSize<C>: ArrayLength<u8>,
-    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
+    MaxSize<C>: ArraySize,
+    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArraySize,
 {
     fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
@@ -341,8 +341,8 @@ where
 impl<'de, C> Deserialize<'de> for Signature<C>
 where
     C: PrimeCurve,
-    MaxSize<C>: ArrayLength<u8>,
-    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
+    MaxSize<C>: ArraySize,
+    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArraySize,
 {
     fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
@@ -384,8 +384,8 @@ fn find_scalar_range(outer: &[u8], inner: &[u8]) -> Result<Range<usize>> {
 impl<C> signature::PrehashSignature for Signature<C>
 where
     C: PrimeCurve + crate::hazmat::DigestPrimitive,
-    MaxSize<C>: ArrayLength<u8>,
-    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
+    MaxSize<C>: ArraySize,
+    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArraySize,
 {
     type Digest = C::Digest;
 }

--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -12,7 +12,7 @@
 
 use crate::{Error, Result};
 use core::cmp;
-use elliptic_curve::{generic_array::typenum::Unsigned, FieldBytes, PrimeCurve};
+use elliptic_curve::{array::typenum::Unsigned, FieldBytes, PrimeCurve};
 
 #[cfg(feature = "arithmetic")]
 use {
@@ -41,7 +41,7 @@ use {
 use elliptic_curve::{FieldBytesEncoding, ScalarPrimitive};
 
 #[cfg(any(feature = "arithmetic", feature = "digest"))]
-use crate::{elliptic_curve::generic_array::ArrayLength, Signature};
+use crate::{elliptic_curve::array::ArraySize, Signature};
 
 /// Try to sign the given prehashed message using ECDSA.
 ///
@@ -57,7 +57,7 @@ pub trait SignPrimitive<C>:
     + Sized
 where
     C: PrimeCurve + CurveArithmetic<Scalar = Self>,
-    SignatureSize<C>: ArrayLength<u8>,
+    SignatureSize<C>: ArraySize,
 {
     /// Try to sign the prehashed message.
     ///
@@ -121,7 +121,7 @@ where
 pub trait VerifyPrimitive<C>: AffineCoordinates<FieldRepr = FieldBytes<C>> + Copy + Sized
 where
     C: PrimeCurve + CurveArithmetic<AffinePoint = Self>,
-    SignatureSize<C>: ArrayLength<u8>,
+    SignatureSize<C>: ArraySize,
 {
     /// Verify the prehashed message against the provided ECDSA signature.
     ///
@@ -168,7 +168,7 @@ pub trait DigestPrimitive: PrimeCurve {
 impl<C> PrehashSignature for Signature<C>
 where
     C: DigestPrimitive,
-    <FieldBytesSize<C> as core::ops::Add>::Output: ArrayLength<u8>,
+    <FieldBytesSize<C> as core::ops::Add>::Output: ArraySize,
 {
     type Digest = C::Digest;
 }
@@ -229,7 +229,7 @@ pub fn sign_prehashed<C, K>(
 where
     C: PrimeCurve + CurveArithmetic,
     K: AsRef<Scalar<C>> + Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArrayLength<u8>,
+    SignatureSize<C>: ArraySize,
 {
     // TODO(tarcieri): use `NonZeroScalar<C>` for `k`.
     if k.as_ref().is_zero().into() {
@@ -274,7 +274,7 @@ pub fn verify_prehashed<C>(
 ) -> Result<()>
 where
     C: PrimeCurve + CurveArithmetic,
-    SignatureSize<C>: ArrayLength<u8>,
+    SignatureSize<C>: ArraySize,
 {
     let z = Scalar::<C>::reduce_bytes(z);
     let (r, s) = sig.split_scalars();

--- a/ecdsa/src/recovery.rs
+++ b/ecdsa/src/recovery.rs
@@ -28,9 +28,7 @@ use {
         hazmat::{bits2field, DigestPrimitive},
         Signature, SignatureSize,
     },
-    elliptic_curve::{
-        generic_array::ArrayLength, ops::Invert, CurveArithmetic, PrimeCurve, Scalar,
-    },
+    elliptic_curve::{array::ArraySize, ops::Invert, CurveArithmetic, PrimeCurve, Scalar},
     signature::digest::Digest,
 };
 
@@ -102,7 +100,7 @@ impl RecoveryId {
         AffinePoint<C>:
             DecompressPoint<C> + FromEncodedPoint<C> + ToEncodedPoint<C> + VerifyPrimitive<C>,
         FieldBytesSize<C>: sec1::ModulusSize,
-        SignatureSize<C>: ArrayLength<u8>,
+        SignatureSize<C>: ArraySize,
     {
         Self::trial_recovery_from_digest(verifying_key, C::Digest::new_with_prefix(msg), signature)
     }
@@ -121,7 +119,7 @@ impl RecoveryId {
         AffinePoint<C>:
             DecompressPoint<C> + FromEncodedPoint<C> + ToEncodedPoint<C> + VerifyPrimitive<C>,
         FieldBytesSize<C>: sec1::ModulusSize,
-        SignatureSize<C>: ArrayLength<u8>,
+        SignatureSize<C>: ArraySize,
     {
         Self::trial_recovery_from_prehash(verifying_key, &digest.finalize(), signature)
     }
@@ -139,7 +137,7 @@ impl RecoveryId {
         AffinePoint<C>:
             DecompressPoint<C> + FromEncodedPoint<C> + ToEncodedPoint<C> + VerifyPrimitive<C>,
         FieldBytesSize<C>: sec1::ModulusSize,
-        SignatureSize<C>: ArrayLength<u8>,
+        SignatureSize<C>: ArraySize,
     {
         for id in 0..=Self::MAX {
             let recovery_id = RecoveryId(id);
@@ -174,7 +172,7 @@ impl<C> SigningKey<C>
 where
     C: PrimeCurve + CurveArithmetic + DigestPrimitive,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + SignPrimitive<C>,
-    SignatureSize<C>: ArrayLength<u8>,
+    SignatureSize<C>: ArraySize,
 {
     /// Sign the given message prehash, returning a signature and recovery ID.
     pub fn sign_prehash_recoverable(&self, prehash: &[u8]) -> Result<(Signature<C>, RecoveryId)> {
@@ -207,7 +205,7 @@ where
     C: PrimeCurve + CurveArithmetic + DigestPrimitive,
     D: Digest,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + SignPrimitive<C>,
-    SignatureSize<C>: ArrayLength<u8>,
+    SignatureSize<C>: ArraySize,
 {
     fn try_sign_digest(&self, msg_digest: D) -> Result<(Signature<C>, RecoveryId)> {
         self.sign_digest_recoverable(msg_digest)
@@ -219,7 +217,7 @@ impl<C> PrehashSigner<(Signature<C>, RecoveryId)> for SigningKey<C>
 where
     C: PrimeCurve + CurveArithmetic + DigestPrimitive,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + SignPrimitive<C>,
-    SignatureSize<C>: ArrayLength<u8>,
+    SignatureSize<C>: ArraySize,
 {
     fn sign_prehash(&self, prehash: &[u8]) -> Result<(Signature<C>, RecoveryId)> {
         self.sign_prehash_recoverable(prehash)
@@ -231,7 +229,7 @@ impl<C> Signer<(Signature<C>, RecoveryId)> for SigningKey<C>
 where
     C: PrimeCurve + CurveArithmetic + DigestPrimitive,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + SignPrimitive<C>,
-    SignatureSize<C>: ArrayLength<u8>,
+    SignatureSize<C>: ArraySize,
 {
     fn try_sign(&self, msg: &[u8]) -> Result<(Signature<C>, RecoveryId)> {
         self.sign_recoverable(msg)
@@ -245,7 +243,7 @@ where
     AffinePoint<C>:
         DecompressPoint<C> + FromEncodedPoint<C> + ToEncodedPoint<C> + VerifyPrimitive<C>,
     FieldBytesSize<C>: sec1::ModulusSize,
-    SignatureSize<C>: ArrayLength<u8>,
+    SignatureSize<C>: ArraySize,
 {
     /// Recover a [`VerifyingKey`] from the given message, signature, and
     /// [`RecoveryId`].

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use core::{cmp::Ordering, fmt::Debug};
 use elliptic_curve::{
-    generic_array::ArrayLength,
+    array::ArraySize,
     point::PointCompression,
     sec1::{self, CompressedPoint, EncodedPoint, FromEncodedPoint, ToEncodedPoint},
     AffinePoint, CurveArithmetic, FieldBytesSize, PrimeCurve, PublicKey,
@@ -147,7 +147,7 @@ where
     C: PrimeCurve + CurveArithmetic,
     D: Digest + FixedOutput<OutputSize = FieldBytesSize<C>>,
     AffinePoint<C>: VerifyPrimitive<C>,
-    SignatureSize<C>: ArrayLength<u8>,
+    SignatureSize<C>: ArraySize,
 {
     fn verify_digest(&self, msg_digest: D, signature: &Signature<C>) -> Result<()> {
         self.inner.as_affine().verify_digest(msg_digest, signature)
@@ -158,7 +158,7 @@ impl<C> PrehashVerifier<Signature<C>> for VerifyingKey<C>
 where
     C: PrimeCurve + CurveArithmetic,
     AffinePoint<C>: VerifyPrimitive<C>,
-    SignatureSize<C>: ArrayLength<u8>,
+    SignatureSize<C>: ArraySize,
 {
     fn verify_prehash(&self, prehash: &[u8], signature: &Signature<C>) -> Result<()> {
         let field = bits2field::<C>(prehash)?;
@@ -170,7 +170,7 @@ impl<C> Verifier<Signature<C>> for VerifyingKey<C>
 where
     C: PrimeCurve + CurveArithmetic + DigestPrimitive,
     AffinePoint<C>: VerifyPrimitive<C>,
-    SignatureSize<C>: ArrayLength<u8>,
+    SignatureSize<C>: ArraySize,
 {
     fn verify(&self, msg: &[u8], signature: &Signature<C>) -> Result<()> {
         self.verify_digest(C::Digest::new_with_prefix(msg), signature)
@@ -182,7 +182,7 @@ impl<C> Verifier<SignatureWithOid<C>> for VerifyingKey<C>
 where
     C: PrimeCurve + CurveArithmetic + DigestPrimitive,
     AffinePoint<C>: VerifyPrimitive<C>,
-    SignatureSize<C>: ArrayLength<u8>,
+    SignatureSize<C>: ArraySize,
 {
     fn verify(&self, msg: &[u8], sig: &SignatureWithOid<C>) -> Result<()> {
         match sig.oid() {
@@ -201,9 +201,9 @@ where
     C: PrimeCurve + CurveArithmetic,
     D: Digest + FixedOutput<OutputSize = FieldBytesSize<C>>,
     AffinePoint<C>: VerifyPrimitive<C>,
-    SignatureSize<C>: ArrayLength<u8>,
-    der::MaxSize<C>: ArrayLength<u8>,
-    <FieldBytesSize<C> as Add>::Output: Add<der::MaxOverhead> + ArrayLength<u8>,
+    SignatureSize<C>: ArraySize,
+    der::MaxSize<C>: ArraySize,
+    <FieldBytesSize<C> as Add>::Output: Add<der::MaxOverhead> + ArraySize,
 {
     fn verify_digest(&self, msg_digest: D, signature: &der::Signature<C>) -> Result<()> {
         let signature = Signature::<C>::try_from(signature.clone())?;
@@ -216,9 +216,9 @@ impl<C> PrehashVerifier<der::Signature<C>> for VerifyingKey<C>
 where
     C: PrimeCurve + CurveArithmetic + DigestPrimitive,
     AffinePoint<C>: VerifyPrimitive<C>,
-    SignatureSize<C>: ArrayLength<u8>,
-    der::MaxSize<C>: ArrayLength<u8>,
-    <FieldBytesSize<C> as Add>::Output: Add<der::MaxOverhead> + ArrayLength<u8>,
+    SignatureSize<C>: ArraySize,
+    der::MaxSize<C>: ArraySize,
+    <FieldBytesSize<C> as Add>::Output: Add<der::MaxOverhead> + ArraySize,
 {
     fn verify_prehash(&self, prehash: &[u8], signature: &der::Signature<C>) -> Result<()> {
         let signature = Signature::<C>::try_from(signature.clone())?;
@@ -231,9 +231,9 @@ impl<C> Verifier<der::Signature<C>> for VerifyingKey<C>
 where
     C: PrimeCurve + CurveArithmetic + DigestPrimitive,
     AffinePoint<C>: VerifyPrimitive<C>,
-    SignatureSize<C>: ArrayLength<u8>,
-    der::MaxSize<C>: ArrayLength<u8>,
-    <FieldBytesSize<C> as Add>::Output: Add<der::MaxOverhead> + ArrayLength<u8>,
+    SignatureSize<C>: ArraySize,
+    der::MaxSize<C>: ArraySize,
+    <FieldBytesSize<C> as Add>::Output: Add<der::MaxOverhead> + ArraySize,
 {
     fn verify(&self, msg: &[u8], signature: &der::Signature<C>) -> Result<()> {
         let signature = Signature::<C>::try_from(signature.clone())?;
@@ -356,7 +356,7 @@ where
     FieldBytesSize<C>: sec1::ModulusSize,
 {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.inner.partial_cmp(&other.inner)
+        Some(self.cmp(other))
     }
 }
 

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -14,10 +14,11 @@ readme = "README.md"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "curve25519", "ecc", "signature", "signing"]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.71"
 
 [dependencies]
-signature = { version = "2", default-features = false }
+# TODO(tarcieri): relax requirement back to `2` before next release
+signature = { version = "=2.3.0-pre.0", default-features = false }
 
 # optional dependencies
 pkcs8 = { version = "0.10", optional = true }
@@ -27,9 +28,9 @@ zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 bincode = "1"
-ed25519-dalek = { version = "2", features = ["rand_core"] }
+#ed25519-dalek = { version = "2", features = ["rand_core"] }
 hex-literal = "0.4"
-ring-compat = { version = "0.8", default-features = false, features = ["signature"] }
+#ring-compat = { version = "0.8", default-features = false, features = ["signature"] }
 rand_core = { version = "0.6", features = ["std"] }
 
 [features]

--- a/ed25519/README.md
+++ b/ed25519/README.md
@@ -26,7 +26,7 @@ Ed25519 implementations, including HSMs or Cloud KMS services.
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.60** at a minimum.
+This crate requires **Rust 1.71** at a minimum.
 
 Our policy is to allow MSRV to be raised in future released without that
 qualifing as a SemVer-breaking change, but it will be accompanied by a minor
@@ -64,7 +64,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/signatures/actions/workflows/ed25519.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/signatures/actions/workflows/ed25519.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.71+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260048-signatures
 

--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -82,7 +82,7 @@
 //! *NOTE: requires [`ed25519-dalek`] v2 or newer for compatibility with
 //! `ed25519` v2.2+*.
 //!
-//! ```
+//! ```ignore
 //! use ed25519_dalek::{Signer, Verifier, Signature};
 //! #
 //! # pub struct HelloSigner<S>
@@ -154,7 +154,7 @@
 //! instantiate and use the previously defined `HelloSigner` and `HelloVerifier`
 //! types with [`ring-compat`] as the signing/verification provider:
 //!
-//! ```
+//! ```ignore
 //! use ring_compat::signature::{
 //!     ed25519::{Signature, SigningKey, VerifyingKey},
 //!     Signer, Verifier

--- a/ed448/Cargo.toml
+++ b/ed448/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed448-signature"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
@@ -14,9 +14,11 @@ repository = "https://github.com/RustCrypto/signatures/tree/master/ed448"
 readme = "README.md"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "curve448", "ecc", "signature", "signing"]
+rust-version = "1.71"
 
 [dependencies]
-signature = { version = "2", default-features = false }
+# TODO(tarcieri): relax requirement back to `2` before next release
+signature = { version = "=2.3.0-pre.0", default-features = false }
 
 # optional dependencies
 pkcs8 = { version = "0.10", optional = true }

--- a/ed448/README.md
+++ b/ed448/README.md
@@ -26,7 +26,7 @@ Ed448 implementations, including HSMs or Cloud KMS services.
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.60** at a minimum.
+This crate requires **Rust 1.71** at a minimum.
 
 Our policy is to allow MSRV to be raised in future released without that
 qualifing as a SemVer-breaking change, but it will be accompanied by a minor
@@ -64,7 +64,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/signatures/actions/workflows/ed448.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/signatures/actions/workflows/ed448.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.71+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260048-signatures
 

--- a/rfc6979/Cargo.toml
+++ b/rfc6979/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rfc6979"
-version = "0.4.0"
+version = "0.5.0-pre"
 description = """
 Pure Rust implementation of RFC6979: Deterministic Usage of the
 Digital Signature Algorithm (DSA) and Elliptic Curve Digital Signature Algorithm (ECDSA)
@@ -12,12 +12,12 @@ readme = "README.md"
 categories = ["cryptography", "no-std"]
 keywords = ["dsa", "ecdsa", "signature"]
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.71"
 
 [dependencies]
-hmac = { version = "0.12", default-features = false, features = ["reset"] }
+hmac = { version = "=0.13.0-pre.0", default-features = false, features = ["reset"] }
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.4"
-sha2 = "0.10"
+sha2 = "=0.11.0-pre.0"

--- a/rfc6979/README.md
+++ b/rfc6979/README.md
@@ -17,7 +17,7 @@ Algorithm described in RFC 6979 § 3.2:
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.61** at a minimum.
+This crate requires **Rust 1.71** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -46,7 +46,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/signatures/actions/workflows/rfc6979.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/signatures/actions/workflows/rfc6979.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.61+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.71+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260048-signatures
 

--- a/rfc6979/src/ct_cmp.rs
+++ b/rfc6979/src/ct_cmp.rs
@@ -1,10 +1,10 @@
 //! Constant-time comparison helpers for [`ByteArray`].
 
-use crate::{ArrayLength, ByteArray};
+use crate::{ArraySize, ByteArray};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 /// Constant-time equals.
-pub(crate) fn ct_eq<N: ArrayLength<u8>>(a: &ByteArray<N>, b: &ByteArray<N>) -> Choice {
+pub(crate) fn ct_eq<N: ArraySize>(a: &ByteArray<N>, b: &ByteArray<N>) -> Choice {
     let mut ret = Choice::from(1);
 
     for (a, b) in a.iter().zip(b.iter()) {
@@ -17,7 +17,7 @@ pub(crate) fn ct_eq<N: ArrayLength<u8>>(a: &ByteArray<N>, b: &ByteArray<N>) -> C
 /// Constant-time less than.
 ///
 /// Inputs are interpreted as big endian integers.
-pub(crate) fn ct_lt<N: ArrayLength<u8>>(a: &ByteArray<N>, b: &ByteArray<N>) -> Choice {
+pub(crate) fn ct_lt<N: ArraySize>(a: &ByteArray<N>, b: &ByteArray<N>) -> Choice {
     let mut borrow = 0;
 
     // Perform subtraction with borrow a byte-at-a-time, interpreting a

--- a/rfc6979/src/lib.rs
+++ b/rfc6979/src/lib.rs
@@ -39,19 +39,19 @@
 
 mod ct_cmp;
 
-pub use hmac::digest::generic_array::typenum::consts;
+pub use hmac::digest::array::typenum::consts;
 
 use hmac::{
     digest::{
+        array::{Array, ArraySize},
         core_api::BlockSizeUser,
-        generic_array::{ArrayLength, GenericArray},
-        Digest, FixedOutput, FixedOutputReset, Mac,
+        Digest, FixedOutput, FixedOutputReset, KeyInit, Mac,
     },
     SimpleHmac,
 };
 
 /// Array of bytes representing a scalar serialized as a big endian integer.
-pub type ByteArray<Size> = GenericArray<u8, Size>;
+pub type ByteArray<Size> = Array<u8, Size>;
 
 /// Deterministically generate ephemeral scalar `k`.
 ///
@@ -70,7 +70,7 @@ pub fn generate_k<D, N>(
 ) -> ByteArray<N>
 where
     D: Digest + BlockSizeUser + FixedOutput<OutputSize = N> + FixedOutputReset,
-    N: ArrayLength<u8>,
+    N: ArraySize,
 {
     let mut hmac_drbg = HmacDrbg::<D>::new(x, h, data);
 
@@ -99,7 +99,7 @@ where
     k: SimpleHmac<D>,
 
     /// Chaining value `V` (see RFC 6979 Section 3.2.c)
-    v: GenericArray<u8, D::OutputSize>,
+    v: Array<u8, D::OutputSize>,
 }
 
 impl<D> HmacDrbg<D>
@@ -109,7 +109,7 @@ where
     /// Initialize `HMAC_DRBG`
     pub fn new(entropy_input: &[u8], nonce: &[u8], personalization_string: &[u8]) -> Self {
         let mut k = SimpleHmac::new(&Default::default());
-        let mut v = GenericArray::default();
+        let mut v = Array::default();
 
         for b in &mut v {
             *b = 0x01;


### PR DESCRIPTION
For `ecdsa` crate: MSRV is 1.73 due to a bump of `elliptic-curve` to v0.14.0-pre.0.

This commit begins the next round of breaking changes and bumps all crates to prerelease versions.

The main change in `signature` is an upgrade of the `digest` crate to v0.11.0-pre.3, which is what brings the new MSRV 1.71 requirement.