### PR TITLE
ecdsa: fix `dev` macros

### DIFF
--- a/ecdsa/src/dev.rs
+++ b/ecdsa/src/dev.rs
@@ -89,8 +89,8 @@ macro_rules! new_verification_test {
         fn ecdsa_verify_success() {
             for vector in $vectors {
                 let q_encoded = EncodedPoint::<$curve>::from_affine_coordinates(
-                    Array::from_slice(vector.q_x),
-                    Array::from_slice(vector.q_y),
+                    Array::ref_from_slice(vector.q_x),
+                    Array::ref_from_slice(vector.q_y),
                     false,
                 );
 
@@ -112,8 +112,8 @@ macro_rules! new_verification_test {
         fn ecdsa_verify_invalid_s() {
             for vector in $vectors {
                 let q_encoded = EncodedPoint::<$curve>::from_affine_coordinates(
-                    Array::from_slice(vector.q_x),
-                    Array::from_slice(vector.q_y),
+                    Array::ref_from_slice(vector.q_x),
+                    Array::ref_from_slice(vector.q_y),
                     false,
                 );
 


### PR DESCRIPTION
The method changed from `GenericArray::from_slice` to `Array::ref_from_slice`.

This has been renamed back upstream in `hybrid-array` to simplify people's upgrades, but for now we need to rename it until we can upgrade `hybrid-array` again.

Longer term the method will be deprecated, so this is temporary anyway.