### PR TITLE
ecdsa: fix `new_wycheproof_test!` macro

### DIFF
--- a/ecdsa/src/dev.rs
+++ b/ecdsa/src/dev.rs
@@ -169,7 +169,7 @@ macro_rules! new_wycheproof_test {
                     let iter = core::iter::repeat(0)
                         .take(point_len - data.len())
                         .chain(data.iter().cloned());
-                    elliptic_curve::FieldBytes::<C>::from_exact_iter(iter).unwrap()
+                    elliptic_curve::FieldBytes::<C>::from_iter(iter)
                 }
             }
 


### PR DESCRIPTION
Updates `from_exact_iter` => `from_iter`