### PR TITLE
rfc6979: add `generate_k_mut`; remove digest bounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-pre.1"
+version = "0.17.0-pre.2"
 dependencies = [
  "der 0.8.0-pre.0",
  "digest",

--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -98,7 +98,7 @@ where
     ) -> Result<(Signature<C>, Option<RecoveryId>)>
     where
         Self: From<ScalarPrimitive<C>> + Invert<Output = CtOption<Self>>,
-        D: Digest + BlockSizeUser + FixedOutput<OutputSize = FieldBytesSize<C>> + FixedOutputReset,
+        D: Digest + BlockSizeUser + FixedOutput + FixedOutputReset,
     {
         let k = Scalar::<C>::from_repr(rfc6979::generate_k::<D, _>(
             &self.to_repr(),


### PR DESCRIPTION
Adds an API which writes `k` into an output buffer rather than allocating and returning it, which also accepts slices as inputs. This makes it possible to use `rfc6979` to implement the `dsa` crate.

Also removes output size bounds on the underlying digest function, which aren't actually relevant to the implementation at all since HMAC-DRBG writes a variable-sized amount of output. This makes it possible to use `rfc6979` + `ecdsa` in conjunction with `p521`, which has unusually sized scalars (66-bytes) which don't match the output size of the underlying digest function (SHA-512, which has a 64-byte output).