### PR TITLE
ecdsa: remove `OutputSize` bounds on `DigestPrimitive`

### DIFF
--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -138,9 +138,9 @@ where
     #[cfg(feature = "digest")]
     fn verify_digest<D>(&self, msg_digest: D, sig: &Signature<C>) -> Result<()>
     where
-        D: FixedOutput<OutputSize = FieldBytesSize<C>>,
+        D: FixedOutput,
     {
-        self.verify_prehashed(&msg_digest.finalize_fixed(), sig)
+        self.verify_prehashed(&bits2field::<C>(&msg_digest.finalize_fixed())?, sig)
     }
 }
 
@@ -158,10 +158,7 @@ where
 pub trait DigestPrimitive: PrimeCurve {
     /// Preferred digest to use when computing ECDSA signatures for this
     /// elliptic curve. This is typically a member of the SHA-2 family.
-    type Digest: BlockSizeUser
-        + Digest
-        + FixedOutput<OutputSize = FieldBytesSize<Self>>
-        + FixedOutputReset;
+    type Digest: BlockSizeUser + Digest + FixedOutput + FixedOutputReset;
 }
 
 #[cfg(feature = "digest")]

--- a/ecdsa/src/signing.rs
+++ b/ecdsa/src/signing.rs
@@ -13,7 +13,7 @@ use elliptic_curve::{
     ops::Invert,
     subtle::{Choice, ConstantTimeEq, CtOption},
     zeroize::{Zeroize, ZeroizeOnDrop},
-    CurveArithmetic, FieldBytes, FieldBytesSize, NonZeroScalar, PrimeCurve, Scalar, SecretKey,
+    CurveArithmetic, FieldBytes, NonZeroScalar, PrimeCurve, Scalar, SecretKey,
 };
 use signature::{
     hazmat::{PrehashSigner, RandomizedPrehashSigner},
@@ -22,12 +22,12 @@ use signature::{
 };
 
 #[cfg(feature = "der")]
-use {crate::der, core::ops::Add};
+use {crate::der, core::ops::Add, elliptic_curve::FieldBytesSize};
 
 #[cfg(feature = "pem")]
 use {
-    crate::elliptic_curve::pkcs8::{DecodePrivateKey, EncodePrivateKey, SecretDocument},
     core::str::FromStr,
+    elliptic_curve::pkcs8::{DecodePrivateKey, EncodePrivateKey, SecretDocument},
 };
 
 #[cfg(feature = "pkcs8")]
@@ -136,7 +136,7 @@ where
 impl<C, D> DigestSigner<D, Signature<C>> for SigningKey<C>
 where
     C: PrimeCurve + CurveArithmetic + DigestPrimitive,
-    D: Digest + FixedOutput<OutputSize = FieldBytesSize<C>>,
+    D: Digest + FixedOutput,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + SignPrimitive<C>,
     SignatureSize<C>: ArraySize,
 {
@@ -182,7 +182,7 @@ where
 impl<C, D> RandomizedDigestSigner<D, Signature<C>> for SigningKey<C>
 where
     C: PrimeCurve + CurveArithmetic + DigestPrimitive,
-    D: Digest + FixedOutput<OutputSize = FieldBytesSize<C>>,
+    D: Digest + FixedOutput,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + SignPrimitive<C>,
     SignatureSize<C>: ArraySize,
 {
@@ -231,7 +231,7 @@ where
 impl<C, D> DigestSigner<D, SignatureWithOid<C>> for SigningKey<C>
 where
     C: PrimeCurve + CurveArithmetic + DigestPrimitive,
-    D: AssociatedOid + Digest + FixedOutput<OutputSize = FieldBytesSize<C>>,
+    D: AssociatedOid + Digest + FixedOutput,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + SignPrimitive<C>,
     SignatureSize<C>: ArraySize,
 {
@@ -286,7 +286,7 @@ where
 impl<C, D> RandomizedDigestSigner<D, der::Signature<C>> for SigningKey<C>
 where
     C: PrimeCurve + CurveArithmetic + DigestPrimitive,
-    D: Digest + FixedOutput<OutputSize = FieldBytesSize<C>>,
+    D: Digest + FixedOutput,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + SignPrimitive<C>,
     SignatureSize<C>: ArraySize,
     der::MaxSize<C>: ArraySize,

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -145,7 +145,7 @@ where
 impl<C, D> DigestVerifier<D, Signature<C>> for VerifyingKey<C>
 where
     C: PrimeCurve + CurveArithmetic,
-    D: Digest + FixedOutput<OutputSize = FieldBytesSize<C>>,
+    D: Digest + FixedOutput,
     AffinePoint<C>: VerifyPrimitive<C>,
     SignatureSize<C>: ArraySize,
 {
@@ -199,7 +199,7 @@ where
 impl<C, D> DigestVerifier<D, der::Signature<C>> for VerifyingKey<C>
 where
     C: PrimeCurve + CurveArithmetic,
-    D: Digest + FixedOutput<OutputSize = FieldBytesSize<C>>,
+    D: Digest + FixedOutput,
     AffinePoint<C>: VerifyPrimitive<C>,
     SignatureSize<C>: ArraySize,
     der::MaxSize<C>: ArraySize,


### PR DESCRIPTION
Notably for curves like P-521, the digest used to compute the signature is smaller than a serialized field element (SHA-512 w\ 64-byte output vs 66-byte serialized field elements).

To support such curves, we need to remove this bound.

The already implemented `bits2field` function as defined in RFC6979 § 2.3.2 and SEC1 § 2.3.8 handles producing a serialized field element from an input which may be a different size.