### PR TITLE
ecdsa: gate `pkcs8::Encode*Key` impls under `alloc`+`pkcs8`

### DIFF
--- a/ecdsa/src/signing.rs
+++ b/ecdsa/src/signing.rs
@@ -25,10 +25,7 @@ use signature::{
 use {crate::der, core::ops::Add, elliptic_curve::FieldBytesSize};
 
 #[cfg(feature = "pem")]
-use {
-    core::str::FromStr,
-    elliptic_curve::pkcs8::{DecodePrivateKey, EncodePrivateKey, SecretDocument},
-};
+use {core::str::FromStr, elliptic_curve::pkcs8::DecodePrivateKey};
 
 #[cfg(feature = "pkcs8")]
 use crate::elliptic_curve::{
@@ -44,6 +41,9 @@ use crate::elliptic_curve::{
 
 #[cfg(feature = "verifying")]
 use {crate::VerifyingKey, elliptic_curve::PublicKey, signature::KeypairRef};
+
+#[cfg(all(feature = "alloc", feature = "pkcs8"))]
+use elliptic_curve::pkcs8::{EncodePrivateKey, SecretDocument};
 
 /// ECDSA secret key used for signing. Generic over prime order elliptic curves
 /// (e.g. NIST P-curves)
@@ -567,7 +567,7 @@ where
     }
 }
 
-#[cfg(feature = "pem")]
+#[cfg(all(feature = "alloc", feature = "pkcs8"))]
 impl<C> EncodePrivateKey for SigningKey<C>
 where
     C: AssociatedOid + PrimeCurve + CurveArithmetic,

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -24,10 +24,7 @@ use alloc::boxed::Box;
 use {crate::der, core::ops::Add};
 
 #[cfg(feature = "pem")]
-use {
-    core::str::FromStr,
-    elliptic_curve::pkcs8::{DecodePublicKey, EncodePublicKey},
-};
+use {core::str::FromStr, elliptic_curve::pkcs8::DecodePublicKey};
 
 #[cfg(feature = "pkcs8")]
 use elliptic_curve::pkcs8::{
@@ -44,6 +41,9 @@ use {
     },
     sha2::{Sha224, Sha256, Sha384, Sha512},
 };
+
+#[cfg(all(feature = "alloc", feature = "pkcs8"))]
+use elliptic_curve::pkcs8::EncodePublicKey;
 
 #[cfg(all(feature = "pem", feature = "serde"))]
 use serdect::serde::{de, ser, Deserialize, Serialize};
@@ -425,7 +425,7 @@ where
     }
 }
 
-#[cfg(feature = "pem")]
+#[cfg(all(feature = "alloc", feature = "pkcs8"))]
 impl<C> EncodePublicKey for VerifyingKey<C>
 where
     C: PrimeCurve + AssociatedOid + CurveArithmetic + PointCompression,


### PR DESCRIPTION
...rather than `pem`, as these can be used to encode DER without having full `pem` support enabled.

Closes #721