### PR TITLE
Bump `digest`, `elliptic-curve`, and `signature`

### DIFF
--- a/.github/workflows/dsa.yml
+++ b/.github/workflows/dsa.yml
@@ -24,7 +24,7 @@ jobs:
           - thumbv7em-none-eabi
           - wasm32-unknown-unknown
         toolchain:
-          - 1.71.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
           - macos-latest
           - windows-latest
         toolchain:
-          - 1.71.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/ed25519.yml
+++ b/.github/workflows/ed25519.yml
@@ -24,7 +24,7 @@ jobs:
           - thumbv7em-none-eabi
           - wasm32-unknown-unknown
         toolchain:
-          - 1.71.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.71.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ed448.yml
+++ b/.github/workflows/ed448.yml
@@ -24,7 +24,7 @@ jobs:
           - thumbv7em-none-eabi
           - wasm32-unknown-unknown
         toolchain:
-          - 1.71.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.71.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rfc6979.yml
+++ b/.github/workflows/rfc6979.yml
@@ -24,7 +24,7 @@ jobs:
           - thumbv7em-none-eabi
           - wasm32-unknown-unknown
         rust:
-          - 1.71.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.71.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -29,6 +29,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.73.0
+          toolchain: 1.75.0
           components: clippy
       - run: cargo clippy --all-features -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,9 +73,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.6.0-pre.10"
+version = "0.6.0-pre.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12979c1e0771d68f02c2fb93fb0ad54e597f82d608fb569db792d99ebd0bb3c5"
+checksum = "1943d7beadd9ce2b25f3bae73b9e9336fccc1edf38bdec1ed58d3aa183989e11"
 dependencies = [
  "hybrid-array",
  "num-traits",
@@ -119,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-pre.4"
+version = "0.11.0-pre.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b429fb535b92bad18c86f1d7ee7584a175c2810800c7ac5b75b9408b13981979"
+checksum = "957713a19ffdda287c63772e607f848512f67ba948f17d8e42cb8d50fd98a786"
 dependencies = [
  "block-buffer",
  "const-oid 0.10.0-pre.2",
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-pre.2"
+version = "0.14.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c5ff6cab3de51acc7aa1b7ed79e85d4ac92dc718f18899d7622cf9dc0fae94"
+checksum = "b5a28b26e8b4a94186ac649acffa41ba13ca853bd33e44b00fc1c3bd30bfeebe"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -249,18 +249,18 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hmac"
-version = "0.13.0-pre.1"
+version = "0.13.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad9bdb2c4daa57033321e5e64c7a8cab02086ee130f8702f72b5c164893026a"
+checksum = "1fac01891f12d968a2737928c9af2532abdc750e56a890fdbcafdfff17017678"
 dependencies = [
  "digest",
 ]
 
 [[package]]
 name = "hybrid-array"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c5517ac29f08e88170b9647d85cc5f21c2596de177b4867232e20b214b8da1"
+checksum = "7b700a69c9d992339e82b6cda619873ee17768be06e80ed5ef07c50c50d499ab"
 dependencies = [
  "typenum",
  "zeroize",
@@ -502,9 +502,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0-pre.1"
+version = "0.11.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731912b869ff1fb4c6432ad4737a5951d5388fbdda0417163a29638206935fe6"
+checksum = "301ed48dd873557d86a1843ebcdd511b628f13ec5401a0efa7007dc5a595eb1f"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -513,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-pre.1"
+version = "0.11.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9daa731ca112bb569b34b41775363a461422813d8ed1ea6dba352eb58ec4e684"
+checksum = "e18b939d4051b69874cbdb8f55de6a14ae44b357ccb94bdbd0a2122f8f875a46"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -524,9 +524,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.3.0-pre.1"
+version = "2.3.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d40c007df8d40a44d464726cc639e1b48c1894ad074eb4168ff91e62d94b53a"
+checksum = "017ea2f120415e4bf9c6177425b40386f207284147564e19d196c7bc90483c08"
 dependencies = [
  "digest",
  "rand_core",

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -12,23 +12,23 @@ readme = "README.md"
 repository = "https://github.com/RustCrypto/signatures/tree/master/dsa"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "nist", "signature"]
-rust-version = "1.71"
+rust-version = "1.72"
 
 [dependencies]
-digest = "=0.11.0-pre.4"
+digest = "=0.11.0-pre.7"
 num-bigint = { package = "num-bigint-dig", version = "0.8", default-features = false, features = ["prime", "rand", "zeroize"] }
 num-traits = { version = "0.2", default-features = false }
 pkcs8 = { version = "=0.11.0-pre.0", default-features = false, features = ["alloc"] }
 rfc6979 = { version = "=0.5.0-pre.1", path = "../rfc6979" }
-sha2 = { version = "=0.11.0-pre.1", default-features = false }
-signature = { version = "=2.3.0-pre.1", default-features = false, features = ["alloc", "digest", "rand_core"] }
+sha2 = { version = "=0.11.0-pre.2", default-features = false }
+signature = { version = "=2.3.0-pre.2", default-features = false, features = ["alloc", "digest", "rand_core"] }
 zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]
 pkcs8 = { version = "=0.11.0-pre.0", default-features = false, features = ["pem"] }
 rand = "0.8"
 rand_chacha = "0.3"
-sha1 = "=0.11.0-pre.1"
+sha1 = "=0.11.0-pre.2"
 
 [features]
 std = []

--- a/dsa/README.md
+++ b/dsa/README.md
@@ -30,7 +30,7 @@ USE AT YOUR OWN RISK!
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.71** at a minimum.
+This crate requires **Rust 1.72** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -59,7 +59,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/signatures/actions/workflows/dsa.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/signatures/actions/workflows/dsa.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.71+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.72+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260048-signatures
 

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -16,21 +16,21 @@ edition = "2021"
 rust-version = "1.73"
 
 [dependencies]
-elliptic-curve = { version = "=0.14.0-pre.2", default-features = false, features = ["digest", "sec1"] }
-signature = { version = "=2.3.0-pre.1", default-features = false, features = ["rand_core"] }
+elliptic-curve = { version = "=0.14.0-pre.3", default-features = false, features = ["digest", "sec1"] }
+signature = { version = "=2.3.0-pre.2", default-features = false, features = ["rand_core"] }
 
 # optional dependencies
 der = { version = "=0.8.0-pre.0", optional = true }
-digest = { version = "=0.11.0-pre.4", optional = true, default-features = false, features = ["oid"] }
+digest = { version = "=0.11.0-pre.7", optional = true, default-features = false, features = ["oid"] }
 rfc6979 = { version = "=0.5.0-pre.1", optional = true, path = "../rfc6979" }
 serdect = { version = "0.2", optional = true, default-features = false, features = ["alloc"] }
-sha2 = { version = "=0.11.0-pre.1", optional = true, default-features = false, features = ["oid"] }
+sha2 = { version = "=0.11.0-pre.2", optional = true, default-features = false, features = ["oid"] }
 spki = { version = "=0.8.0-pre.0", optional = true, default-features = false }
 
 [dev-dependencies]
-elliptic-curve = { version = "=0.14.0-pre.2", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "=0.14.0-pre.3", default-features = false, features = ["dev"] }
 hex-literal = "0.4"
-sha2 = { version = "=0.11.0-pre.1", default-features = false }
+sha2 = { version = "=0.11.0-pre.2", default-features = false }
 
 [features]
 default = ["digest"]

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -345,7 +345,6 @@ impl<C> SignatureEncoding for Signature<C>
 where
     C: PrimeCurve,
     SignatureSize<C>: ArraySize,
-    SignatureBytes<C>: Send + Sync,
 {
     type Repr = SignatureBytes<C>;
 }
@@ -656,7 +655,6 @@ where
     C: hazmat::DigestPrimitive,
     C::Digest: AssociatedOid,
     SignatureSize<C>: ArraySize,
-    SignatureBytes<C>: Send + Sync,
 {
     type Repr = SignatureBytes<C>;
 }

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -14,11 +14,11 @@ readme = "README.md"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "curve25519", "ecc", "signature", "signing"]
 edition = "2021"
-rust-version = "1.71"
+rust-version = "1.72"
 
 [dependencies]
 # TODO(tarcieri): relax requirement back to `2` before next release
-signature = { version = "=2.3.0-pre.1", default-features = false }
+signature = { version = "=2.3.0-pre.2", default-features = false }
 
 # optional dependencies
 pkcs8 = { version = "0.10", optional = true }

--- a/ed25519/README.md
+++ b/ed25519/README.md
@@ -26,7 +26,7 @@ Ed25519 implementations, including HSMs or Cloud KMS services.
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.71** at a minimum.
+This crate requires **Rust 1.72** at a minimum.
 
 Our policy is to allow MSRV to be raised in future released without that
 qualifing as a SemVer-breaking change, but it will be accompanied by a minor
@@ -64,7 +64,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/signatures/actions/workflows/ed25519.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/signatures/actions/workflows/ed25519.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.71+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.72+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260048-signatures
 

--- a/ed448/Cargo.toml
+++ b/ed448/Cargo.toml
@@ -14,11 +14,11 @@ repository = "https://github.com/RustCrypto/signatures/tree/master/ed448"
 readme = "README.md"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "curve448", "ecc", "signature", "signing"]
-rust-version = "1.71"
+rust-version = "1.72"
 
 [dependencies]
 # TODO(tarcieri): relax requirement back to `2` before next release
-signature = { version = "=2.3.0-pre.1", default-features = false }
+signature = { version = "=2.3.0-pre.2", default-features = false }
 
 # optional dependencies
 pkcs8 = { version = "0.10", optional = true }

--- a/ed448/README.md
+++ b/ed448/README.md
@@ -26,7 +26,7 @@ Ed448 implementations, including HSMs or Cloud KMS services.
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.71** at a minimum.
+This crate requires **Rust 1.72** at a minimum.
 
 Our policy is to allow MSRV to be raised in future released without that
 qualifing as a SemVer-breaking change, but it will be accompanied by a minor
@@ -64,7 +64,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/signatures/actions/workflows/ed448.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/signatures/actions/workflows/ed448.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.71+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.712-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260048-signatures
 

--- a/rfc6979/Cargo.toml
+++ b/rfc6979/Cargo.toml
@@ -12,12 +12,12 @@ readme = "README.md"
 categories = ["cryptography", "no-std"]
 keywords = ["dsa", "ecdsa", "signature"]
 edition = "2021"
-rust-version = "1.71"
+rust-version = "1.72"
 
 [dependencies]
-hmac = { version = "=0.13.0-pre.1", default-features = false, features = ["reset"] }
+hmac = { version = "=0.13.0-pre.2", default-features = false, features = ["reset"] }
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.4"
-sha2 = "=0.11.0-pre.1"
+sha2 = "=0.11.0-pre.2"

--- a/rfc6979/README.md
+++ b/rfc6979/README.md
@@ -17,7 +17,7 @@ Algorithm described in RFC 6979 § 3.2:
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.71** at a minimum.
+This crate requires **Rust 1.72** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -46,7 +46,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/signatures/actions/workflows/rfc6979.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/signatures/actions/workflows/rfc6979.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.71+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.72+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260048-signatures
 


### PR DESCRIPTION
Bumps the following dependencies:
- `digest` v0.11.0-pre.7
- `elliptic-curve` v0.14.0-pre.3
- `signature` v2.3.0-pre.2