### PR TITLE
ecdsa: don't feature-gate `EcdsaCurve`

### DIFF
--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -44,7 +44,6 @@ use elliptic_curve::{FieldBytesEncoding, ScalarPrimitive};
 use crate::{elliptic_curve::array::ArraySize, Signature};
 
 /// Marker trait for elliptic curves intended for use with ECDSA.
-#[cfg(feature = "arithmetic")]
 pub trait EcdsaCurve: PrimeCurve {
     /// Does this curve use low-S normalized signatures?
     ///


### PR DESCRIPTION
There's no reason for it to be gated on `arithmetic`. It can be provided in all use cases.