### PR TITLE
ecdsa: move `EcdsaCurve` trait to toplevel

### DIFF
--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -43,14 +43,6 @@ use elliptic_curve::{FieldBytesEncoding, ScalarPrimitive};
 #[cfg(any(feature = "arithmetic", feature = "digest"))]
 use crate::{elliptic_curve::array::ArraySize, Signature};
 
-/// Marker trait for elliptic curves intended for use with ECDSA.
-pub trait EcdsaCurve: PrimeCurve {
-    /// Does this curve use low-S normalized signatures?
-    ///
-    /// This is typically `false`. See [`Signature::normalize_s`] for more information.
-    const NORMALIZE_S: bool;
-}
-
 /// Try to sign the given prehashed message using ECDSA.
 ///
 /// This trait is intended to be implemented on a type with access to the

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -166,6 +166,14 @@ const SHA384_OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("2.16.840.1.10
 #[cfg(feature = "digest")]
 const SHA512_OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("2.16.840.1.101.3.4.2.3");
 
+/// Marker trait for elliptic curves intended for use with ECDSA.
+pub trait EcdsaCurve: PrimeCurve {
+    /// Does this curve use low-S normalized signatures?
+    ///
+    /// This is typically `false`. See [`Signature::normalize_s`] for more information.
+    const NORMALIZE_S: bool;
+}
+
 /// Size of a fixed sized signature for the given elliptic curve.
 pub type SignatureSize<C> = <FieldBytesSize<C> as Add>::Output;
 


### PR DESCRIPTION
Moves the trait added in #787 out of the `hazmat` module and into the toplevel, so it's available regardless of whether or not the `hazmat` feature has been enabled.