### PR TITLE
ecdsa: use `NonZeroScalar` arguments to `sign_prehashed`

### DIFF
--- a/ecdsa/src/dev.rs
+++ b/ecdsa/src/dev.rs
@@ -43,14 +43,14 @@ macro_rules! new_signing_test {
                 array::{typenum::Unsigned, Array},
                 bigint::Encoding,
                 group::ff::PrimeField,
-                Curve, CurveArithmetic, FieldBytes, Scalar,
+                Curve, CurveArithmetic, FieldBytes, NonZeroScalar, Scalar,
             },
             hazmat::sign_prehashed,
         };
 
-        fn decode_scalar(bytes: &[u8]) -> Option<Scalar<$curve>> {
+        fn decode_scalar(bytes: &[u8]) -> Option<NonZeroScalar<$curve>> {
             if bytes.len() == <$curve as Curve>::FieldBytesSize::USIZE {
-                Scalar::<$curve>::from_repr(bytes.try_into().unwrap()).into()
+                NonZeroScalar::<$curve>::from_repr(bytes.try_into().unwrap()).into()
             } else {
                 None
             }

--- a/ecdsa/src/signing.rs
+++ b/ecdsa/src/signing.rs
@@ -157,7 +157,7 @@ where
 {
     fn sign_prehash(&self, prehash: &[u8]) -> Result<Signature<C>> {
         let z = bits2field::<C>(prehash)?;
-        Ok(sign_prehashed_rfc6979::<C, C::Digest>(self.secret_scalar.as_ref(), &z, &[])?.0)
+        Ok(sign_prehashed_rfc6979::<C, C::Digest>(&self.secret_scalar, &z, &[])?.0)
     }
 }
 
@@ -206,7 +206,7 @@ where
         let z = bits2field::<C>(prehash)?;
         let mut ad = FieldBytes::<C>::default();
         rng.fill_bytes(&mut ad);
-        Ok(sign_prehashed_rfc6979::<C, C::Digest>(self.secret_scalar.as_ref(), &z, &ad)?.0)
+        Ok(sign_prehashed_rfc6979::<C, C::Digest>(&self.secret_scalar, &z, &ad)?.0)
     }
 }
 


### PR DESCRIPTION
Provides type-level enforcement that these parameters are non-zero