### PR TITLE
dsa v0.6.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "dsa"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "digest",
  "num-bigint-dig",

--- a/dsa/CHANGELOG.md
+++ b/dsa/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.3 (2024-01-28)
+### Added
+- `SigningKey::sign_prehashed_rfc6979 ([#798])
+
+[#798]: https://github.com/RustCrypto/signatures/pull/798
+
 ## 0.6.2 (2023-11-16)
 ### Changed
 - Loosen `signature` bound to `2.0, <2.3` ([#756])

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsa"
-version = "0.6.2"
+version = "0.6.3"
 description = """
 Pure Rust implementation of the Digital Signature Algorithm (DSA) as specified
 in FIPS 186-4 (Digital Signature Standard), providing RFC6979 deterministic


### PR DESCRIPTION
NOTE: backport not for merge, just to have a public PR associated with this release

### Added
- `SigningKey::sign_prehashed_rfc6979 ([#798])

[#798]: https://github.com/RustCrypto/signatures/pull/798

