### PR TITLE
Bump `digest`, `elliptic-curve`, and `signature`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,9 +31,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.11.0-pre.4"
+version = "0.11.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0edadbde8e0243b49d434f9a23ec0590af201f400a34d7d51049284e4a77c568"
+checksum = "3ded684142010808eb980d9974ef794da2bcf97d13396143b1515e9f0fb4a10e"
 dependencies = [
  "crypto-common",
 ]
@@ -86,9 +86,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-pre.4"
+version = "0.2.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806e4e3731d44f1340b069551225b44c2056c105cad9e67f0c46266db8a3a6b9"
+checksum = "b7aa2ec04f5120b830272a481e8d9d8ba4dda140d2cda59b0f1110d5eb93c38e"
 dependencies = [
  "getrandom",
  "hybrid-array",
@@ -119,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-pre.7"
+version = "0.11.0-pre.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957713a19ffdda287c63772e607f848512f67ba948f17d8e42cb8d50fd98a786"
+checksum = "065d93ead7c220b85d5b4be4795d8398eac4ff68b5ee63895de0a3c1fb6edf25"
 dependencies = [
  "block-buffer",
  "const-oid 0.10.0-pre.2",
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-pre.3"
+version = "0.14.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a28b26e8b4a94186ac649acffa41ba13ca853bd33e44b00fc1c3bd30bfeebe"
+checksum = "273b02352f5ecba0ae9d0c5a7975bb259ecacec5f7ae324f2e41e4469f2c208a"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -249,18 +249,18 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hmac"
-version = "0.13.0-pre.2"
+version = "0.13.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fac01891f12d968a2737928c9af2532abdc750e56a890fdbcafdfff17017678"
+checksum = "ffd790a0795ee332ed3e8959e5b177beb70d7112eb7d345428ec17427897d5ce"
 dependencies = [
  "digest",
 ]
 
 [[package]]
 name = "hybrid-array"
-version = "0.2.0-rc.3"
+version = "0.2.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8856b3db5eb76328f03589feb25c7a3166bfa0ae3b38b1408d546b097fa7947"
+checksum = "18e63b66aee2df5599ba69b17a48113dfc68d2e143ea387ef836509e433bbd7e"
 dependencies = [
  "typenum",
  "zeroize",
@@ -502,8 +502,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0-pre.2"
-source = "git+https://github.com/RustCrypto/hashes.git#9130e96e88908905e2c1b6afbbd34c27f85adac6"
+version = "0.11.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3885de8cb916f223718c1ccd47a840b91f806333e76002dc5cb3862154b4fed3"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -512,8 +513,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-pre.2"
-source = "git+https://github.com/RustCrypto/hashes.git#9130e96e88908905e2c1b6afbbd34c27f85adac6"
+version = "0.11.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f33549bf3064b62478926aa89cbfc7c109aab66ae8f0d5d2ef839e482cc30d6"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -522,9 +524,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.3.0-pre.2"
+version = "2.3.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "017ea2f120415e4bf9c6177425b40386f207284147564e19d196c7bc90483c08"
+checksum = "1700c22ba9ce32c7b0a1495068a906c3552e7db386af7cf865162e0dea498523"
 dependencies = [
  "digest",
  "rand_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,3 @@ members = [
 
 [profile.dev]
 opt-level = 2
-
-[patch.crates-io]
-sha1 = { git = "https://github.com/RustCrypto/hashes.git" }
-sha2 = { git = "https://github.com/RustCrypto/hashes.git" }

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -15,20 +15,20 @@ keywords = ["crypto", "nist", "signature"]
 rust-version = "1.72"
 
 [dependencies]
-digest = "=0.11.0-pre.7"
+digest = "=0.11.0-pre.8"
 num-bigint = { package = "num-bigint-dig", version = "0.8", default-features = false, features = ["prime", "rand", "zeroize"] }
 num-traits = { version = "0.2", default-features = false }
 pkcs8 = { version = "=0.11.0-pre.0", default-features = false, features = ["alloc"] }
 rfc6979 = { version = "=0.5.0-pre.2", path = "../rfc6979" }
-sha2 = { version = "=0.11.0-pre.2", default-features = false }
-signature = { version = "=2.3.0-pre.2", default-features = false, features = ["alloc", "digest", "rand_core"] }
+sha2 = { version = "=0.11.0-pre.3", default-features = false }
+signature = { version = "=2.3.0-pre.3", default-features = false, features = ["alloc", "digest", "rand_core"] }
 zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]
 pkcs8 = { version = "=0.11.0-pre.0", default-features = false, features = ["pem"] }
 rand = "0.8"
 rand_chacha = "0.3"
-sha1 = "=0.11.0-pre.2"
+sha1 = "=0.11.0-pre.3"
 
 [features]
 std = []

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -16,21 +16,21 @@ edition = "2021"
 rust-version = "1.73"
 
 [dependencies]
-elliptic-curve = { version = "=0.14.0-pre.3", default-features = false, features = ["digest", "sec1"] }
-signature = { version = "=2.3.0-pre.2", default-features = false, features = ["rand_core"] }
+elliptic-curve = { version = "=0.14.0-pre.4", default-features = false, features = ["digest", "sec1"] }
+signature = { version = "=2.3.0-pre.3", default-features = false, features = ["rand_core"] }
 
 # optional dependencies
 der = { version = "=0.8.0-pre.0", optional = true }
-digest = { version = "=0.11.0-pre.7", optional = true, default-features = false, features = ["oid"] }
+digest = { version = "=0.11.0-pre.8", optional = true, default-features = false, features = ["oid"] }
 rfc6979 = { version = "=0.5.0-pre.2", optional = true, path = "../rfc6979" }
 serdect = { version = "0.2", optional = true, default-features = false, features = ["alloc"] }
-sha2 = { version = "=0.11.0-pre.2", optional = true, default-features = false, features = ["oid"] }
+sha2 = { version = "=0.11.0-pre.3", optional = true, default-features = false, features = ["oid"] }
 spki = { version = "=0.8.0-pre.0", optional = true, default-features = false }
 
 [dev-dependencies]
-elliptic-curve = { version = "=0.14.0-pre.3", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "=0.14.0-pre.4", default-features = false, features = ["dev"] }
 hex-literal = "0.4"
-sha2 = { version = "=0.11.0-pre.2", default-features = false }
+sha2 = { version = "=0.11.0-pre.3", default-features = false }
 
 [features]
 default = ["digest"]

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.72"
 
 [dependencies]
 # TODO(tarcieri): relax requirement back to `2` before next release
-signature = { version = "=2.3.0-pre.2", default-features = false }
+signature = { version = "=2.3.0-pre.3", default-features = false }
 
 # optional dependencies
 pkcs8 = { version = "0.10", optional = true }

--- a/ed448/Cargo.toml
+++ b/ed448/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.72"
 
 [dependencies]
 # TODO(tarcieri): relax requirement back to `2` before next release
-signature = { version = "=2.3.0-pre.2", default-features = false }
+signature = { version = "=2.3.0-pre.3", default-features = false }
 
 # optional dependencies
 pkcs8 = { version = "0.10", optional = true }

--- a/rfc6979/Cargo.toml
+++ b/rfc6979/Cargo.toml
@@ -15,9 +15,9 @@ edition = "2021"
 rust-version = "1.72"
 
 [dependencies]
-hmac = { version = "=0.13.0-pre.2", default-features = false, features = ["reset"] }
+hmac = { version = "=0.13.0-pre.3", default-features = false, features = ["reset"] }
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.4"
-sha2 = "=0.11.0-pre.2"
+sha2 = "=0.11.0-pre.3"


### PR DESCRIPTION
Bumps the following dependencies:
- `digest` v0.11.0-pre.8
- `elliptic-curve` v0.14.0-pre.4
- `signature` v2.3.0-pre.3