### PR TITLE
ecdsa: bump `elliptic-curve` to v0.14.0-pre.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-pre.4"
+version = "0.14.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "273b02352f5ecba0ae9d0c5a7975bb259ecacec5f7ae324f2e41e4469f2c208a"
+checksum = "4a1775af172997a40c14854c3a9fde9e03e5772084b334b6a0bb18bf7f93ac16"
 dependencies = [
  "base16ct",
  "crypto-bigint",

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 rust-version = "1.73"
 
 [dependencies]
-elliptic-curve = { version = "=0.14.0-pre.4", default-features = false, features = ["digest", "sec1"] }
+elliptic-curve = { version = "=0.14.0-pre.5", default-features = false, features = ["digest", "sec1"] }
 signature = { version = "=2.3.0-pre.3", default-features = false, features = ["rand_core"] }
 
 # optional dependencies
@@ -28,7 +28,7 @@ sha2 = { version = "=0.11.0-pre.3", optional = true, default-features = false, f
 spki = { version = "=0.8.0-pre.0", optional = true, default-features = false }
 
 [dev-dependencies]
-elliptic-curve = { version = "=0.14.0-pre.4", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "=0.14.0-pre.5", default-features = false, features = ["dev"] }
 hex-literal = "0.4"
 sha2 = { version = "=0.11.0-pre.3", default-features = false }
 

--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -224,7 +224,7 @@ where
     let s_inv = *s.invert_vartime();
     let u1 = z * s_inv;
     let u2 = *r * s_inv;
-    let x = ProjectivePoint::<C>::lincomb(&ProjectivePoint::<C>::generator(), &u1, q, &u2)
+    let x = ProjectivePoint::<C>::lincomb(&[(ProjectivePoint::<C>::generator(), u1), (*q, u2)])
         .to_affine()
         .x();
 

--- a/ecdsa/src/recovery.rs
+++ b/ecdsa/src/recovery.rs
@@ -295,7 +295,7 @@ where
         let r_inv = *r.invert();
         let u1 = -(r_inv * z);
         let u2 = r_inv * *s;
-        let pk = ProjectivePoint::<C>::lincomb(&ProjectivePoint::<C>::generator(), &u1, &R, &u2);
+        let pk = ProjectivePoint::<C>::lincomb(&[(ProjectivePoint::<C>::generator(), u1), (R, u2)]);
         let vk = Self::from_affine(pk.into())?;
 
         // Ensure signature verifies with the recovered key


### PR DESCRIPTION
Notably this includes the newly refactored `LinearCombination` trait