### PR TITLE
A few optimizations on RFC6979 `generate_k_mut`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,11 +31,20 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.11.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ded684142010808eb980d9974ef794da2bcf97d13396143b1515e9f0fb4a10e"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.2.0-pre.5",
 ]
 
 [[package]]
@@ -80,6 +89,16 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "crypto-common"
 version = "0.2.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7aa2ec04f5120b830272a481e8d9d8ba4dda140d2cda59b0f1110d5eb93c38e"
@@ -101,13 +120,23 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.6",
+]
+
+[[package]]
+name = "digest"
 version = "0.11.0-pre.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "065d93ead7c220b85d5b4be4795d8398eac4ff68b5ee63895de0a3c1fb6edf25"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.11.0-pre.5",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.2.0-pre.5",
  "subtle",
 ]
 
@@ -115,7 +144,7 @@ dependencies = [
 name = "dsa"
 version = "0.7.0-pre"
 dependencies = [
- "digest",
+ "digest 0.11.0-pre.8",
  "num-bigint-dig",
  "num-traits",
  "pkcs8",
@@ -123,7 +152,7 @@ dependencies = [
  "rand_chacha",
  "rfc6979",
  "sha1",
- "sha2",
+ "sha2 0.11.0-pre.3",
  "signature",
  "zeroize",
 ]
@@ -133,12 +162,12 @@ name = "ecdsa"
 version = "0.17.0-pre.5"
 dependencies = [
  "der",
- "digest",
+ "digest 0.11.0-pre.8",
  "elliptic-curve",
  "hex-literal",
  "rfc6979",
  "serdect 0.2.0",
- "sha2",
+ "sha2 0.11.0-pre.3",
  "signature",
  "spki",
 ]
@@ -177,7 +206,7 @@ checksum = "4a1775af172997a40c14854c3a9fde9e03e5772084b334b6a0bb18bf7f93ac16"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.11.0-pre.8",
  "ff",
  "group",
  "hex-literal",
@@ -199,6 +228,17 @@ checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
  "rand_core",
  "subtle",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -224,6 +264,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hex-literal"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,7 +281,7 @@ version = "0.13.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffd790a0795ee332ed3e8959e5b177beb70d7112eb7d345428ec17427897d5ce"
 dependencies = [
- "digest",
+ "digest 0.11.0-pre.8",
 ]
 
 [[package]]
@@ -268,6 +314,23 @@ name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
+name = "lms-signature"
+version = "0.0.0"
+dependencies = [
+ "digest 0.10.7",
+ "generic-array",
+ "hex",
+ "hex-literal",
+ "rand",
+ "rand_core",
+ "sha2 0.10.8",
+ "signature",
+ "static_assertions",
+ "typenum",
+ "zeroize",
+]
 
 [[package]]
 name = "num-bigint-dig"
@@ -404,7 +467,7 @@ version = "0.5.0-pre.3"
 dependencies = [
  "hex-literal",
  "hmac",
- "sha2",
+ "sha2 0.11.0-pre.3",
  "subtle",
 ]
 
@@ -479,7 +542,18 @@ checksum = "3885de8cb916f223718c1ccd47a840b91f806333e76002dc5cb3862154b4fed3"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.11.0-pre.8",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -490,7 +564,7 @@ checksum = "8f33549bf3064b62478926aa89cbfc7c109aab66ae8f0d5d2ef839e482cc30d6"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.11.0-pre.8",
 ]
 
 [[package]]
@@ -499,7 +573,7 @@ version = "2.3.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1700c22ba9ce32c7b0a1495068a906c3552e7db386af7cf865162e0dea498523"
 dependencies = [
- "digest",
+ "digest 0.11.0-pre.8",
  "rand_core",
 ]
 
@@ -523,6 +597,12 @@ dependencies = [
  "base64ct",
  "der",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "subtle"
@@ -552,6 +632,12 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"

--- a/rfc6979/src/lib.rs
+++ b/rfc6979/src/lib.rs
@@ -90,20 +90,21 @@ pub fn generate_k_mut<D>(x: &[u8], q: &[u8], h: &[u8], data: &[u8], k: &mut [u8]
 where
     D: Digest + BlockSizeUser + FixedOutput + FixedOutputReset,
 {
-    assert_eq!(k.len(), x.len());
-    assert_eq!(k.len(), q.len());
-    assert_eq!(k.len(), h.len());
+    let k_len = k.len();
+    assert_eq!(k_len, x.len());
+    assert_eq!(k_len, q.len());
+    assert_eq!(k_len, h.len());
     debug_assert!(bool::from(ct::lt(h, q)));
 
-    let rlen = q.len() as u32 * 8;
-    let qlen = rlen - ct::leading_zeros(q);
+    let q_leading_zeros = ct::leading_zeros(q);
+    let q_has_leading_zeros = q_leading_zeros != 0;
     let mut hmac_drbg = HmacDrbg::<D>::new(x, h, data);
 
     loop {
         hmac_drbg.fill_bytes(k);
 
-        if qlen != rlen {
-            ct::rshift(k, rlen - qlen);
+        if q_has_leading_zeros {
+            ct::rshift(k, q_leading_zeros);
         }
 
         if (!ct::is_zero(k) & ct::lt(k, q)).into() {


### PR DESCRIPTION
The part about the right shift can be simplified and most of the calculations can be extracted out of the loop to avoid overhead.