### PR TITLE
SLH-DSA: Fix tests with `--no-default-features` and enable CI

### DIFF
--- a/.github/workflows/slh-dsa.yml
+++ b/.github/workflows/slh-dsa.yml
@@ -30,6 +30,6 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - run: cargo check --all-features
-      # - run: cargo test --no-default-features TODO
+      - run: cargo test --no-default-features TODO
       - run: cargo test
       - run: cargo test --all-features

--- a/slh-dsa/src/fors.rs
+++ b/slh-dsa/src/fors.rs
@@ -219,12 +219,13 @@ mod tests {
     use rand::{thread_rng, Rng, RngCore};
 
     use super::*;
-    use hex_literal::hex;
 
     #[test]
     #[cfg(feature = "alloc")]
     #[allow(clippy::too_many_lines)] // KAT is long
     fn fors_sign_kat() {
+        use hex_literal::hex;
+
         let sk_seed = SkSeed(Array([1; 16]));
         let pk_seed = PkSeed(Array([2; 16]));
         let adrs = ForsTree::new(3, 5);

--- a/slh-dsa/src/hypertree.rs
+++ b/slh-dsa/src/hypertree.rs
@@ -131,10 +131,8 @@ pub trait HypertreeParams: XmssParams + Sized {
 mod tests {
     use super::*;
     use crate::{hashes::Shake128f, util::macros::test_parameter_sets, PkSeed};
-    use hex_literal::hex;
     use hybrid_array::Array;
     use rand::{thread_rng, Rng};
-    use sha3::{digest::ExtendableOutput, Shake256};
 
     fn test_ht_sign_verify<HTMode: HypertreeParams>() {
         let mut rng = thread_rng();
@@ -207,6 +205,9 @@ mod tests {
     #[test]
     #[cfg(feature = "alloc")]
     fn test_ht_sign_kat() {
+        use hex_literal::hex;
+        use sha3::{digest::ExtendableOutput, Shake256};
+
         let sk_seed = SkSeed(Array([1; 16]));
         let pk_seed = PkSeed(Array([2; 16]));
         let m = Array([3; 16]);

--- a/slh-dsa/src/signature_encoding.rs
+++ b/slh-dsa/src/signature_encoding.rs
@@ -196,6 +196,7 @@ mod tests {
         assert_eq!(sig, sig2);
     }
 
+    #[cfg(feature = "alloc")]
     test_parameter_sets!(test_serialize_deserialize_vec);
 
     #[test]

--- a/slh-dsa/tests/known_answer_tests.rs
+++ b/slh-dsa/tests/known_answer_tests.rs
@@ -121,8 +121,8 @@ where
         let sk = SigningKey::<P>::new(&mut seed_rng);
         let pk = sk.verifying_key();
 
-        writeln!(resp, "pk = {}", hex::encode_upper(&pk.to_vec())).unwrap();
-        writeln!(resp, "sk = {}", hex::encode_upper(&sk.to_vec())).unwrap();
+        writeln!(resp, "pk = {}", hex::encode_upper(&pk.to_bytes())).unwrap();
+        writeln!(resp, "sk = {}", hex::encode_upper(&sk.to_bytes())).unwrap();
 
         let sig = sk.sign_with_rng(&mut rng, msg).to_bytes();
         writeln!(resp, "smlen = {}", sig.as_slice().len() + msg.len()).unwrap();


### PR DESCRIPTION
* Fully guard alloc tests with feature flags, make KATs no-alloc
* Move imports used only in alloc tests into the test functions to avoid clippy lints
* Enable CI tests with `--no-default-features`

