### PR TITLE
Remove unnecessary DigestPrimitive bound on PrehashVerifier

### DIFF
--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -219,7 +219,7 @@ where
 #[cfg(feature = "der")]
 impl<C> PrehashVerifier<der::Signature<C>> for VerifyingKey<C>
 where
-    C: EcdsaCurve + CurveArithmetic + DigestPrimitive,
+    C: EcdsaCurve + CurveArithmetic,
     SignatureSize<C>: ArraySize,
     der::MaxSize<C>: ArraySize,
     <FieldBytesSize<C> as Add>::Output: Add<der::MaxOverhead> + ArraySize,


### PR DESCRIPTION
>I am using verify_prehash() with P521 curve to verify a der::Signature and find that I cannot compile the codes because that DigestPrimitive is not implemented for NistP521.
>
>I think there is no need to add this trait bound after I invested the codes. I wonder If this is something forget to be removed.
> 
> -- From [Zulip topic](https://rustcrypto.zulipchat.com/#narrow/stream/260048-signatures/topic/Do.20.60PrehashVerifier.60.20really.20need.20.60C.3A.20DigestPrimitive.60.3F)