### PR TITLE
ecdsa: fixup `unnecessary qualification` warnings

### DIFF
--- a/ecdsa/src/der.rs
+++ b/ecdsa/src/der.rs
@@ -124,7 +124,7 @@ where
         writer
             .finish()?
             .try_into()
-            .map_err(|_| der::Tag::Sequence.value_error())
+            .map_err(|_| Tag::Sequence.value_error())
     }
 
     /// Borrow this signature as a byte slice
@@ -360,7 +360,7 @@ where
 fn decode_der(der_bytes: &[u8]) -> der::Result<(UintRef<'_>, UintRef<'_>)> {
     let mut reader = der::SliceReader::new(der_bytes)?;
     let header = der::Header::decode(&mut reader)?;
-    header.tag.assert_eq(der::Tag::Sequence)?;
+    header.tag.assert_eq(Tag::Sequence)?;
 
     let ret = reader.read_nested::<_, _, der::Error>(header.length, |reader| {
         let r = UintRef::decode(reader)?;

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -31,7 +31,9 @@ use {core::str::FromStr, elliptic_curve::pkcs8::DecodePublicKey};
 use elliptic_curve::pkcs8::{
     self,
     der::AnyRef,
-    spki::{AlgorithmIdentifier, AssociatedAlgorithmIdentifier, SignatureAlgorithmIdentifier},
+    spki::{
+        self, AlgorithmIdentifier, AssociatedAlgorithmIdentifier, SignatureAlgorithmIdentifier,
+    },
     AssociatedOid, ObjectIdentifier,
 };
 
@@ -419,9 +421,9 @@ where
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     FieldBytesSize<C>: sec1::ModulusSize,
 {
-    type Error = pkcs8::spki::Error;
+    type Error = spki::Error;
 
-    fn try_from(spki: pkcs8::SubjectPublicKeyInfoRef<'_>) -> pkcs8::spki::Result<Self> {
+    fn try_from(spki: pkcs8::SubjectPublicKeyInfoRef<'_>) -> spki::Result<Self> {
         PublicKey::try_from(spki).map(|inner| Self { inner })
     }
 }
@@ -433,7 +435,7 @@ where
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     FieldBytesSize<C>: sec1::ModulusSize,
 {
-    fn to_public_key_der(&self) -> pkcs8::spki::Result<pkcs8::Document> {
+    fn to_public_key_der(&self) -> spki::Result<pkcs8::Document> {
         self.inner.to_public_key_der()
     }
 }


### PR DESCRIPTION
rust 1.78 introduced new unnecessary qualification warnings.