### PR TITLE
ecdsa: add recover_from_prehash_noverify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,6 +677,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
+name = "ml-dsa"
+version = "0.1.0-pre"
+dependencies = [
+ "signature",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/ecdsa/src/recovery.rs
+++ b/ecdsa/src/recovery.rs
@@ -315,7 +315,7 @@ where
         let u1 = -(r_inv * z);
         let u2 = r_inv * *s;
         let pk = ProjectivePoint::<C>::lincomb(&[(ProjectivePoint::<C>::generator(), u1), (R, u2)]);
-        Ok(Self::from_affine(pk.into())?)
+        Self::from_affine(pk.into())
     }
 }
 


### PR DESCRIPTION
If the recovered public key isn't correct, an error occurs when comparing it to the correct public key or public key hash. Therefore, we can skip this expensive verification.

See discussion in https://github.com/RustCrypto/signatures/issues/751