### PR TITLE
Bump `hybrid-array` to v0.2.0-pre.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,9 +559,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.2.0-rc.8"
+version = "0.2.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53668f5da5a41d9eaf4bf7064be46d1ebe6a4e1ceed817f387587b18f2b51047"
+checksum = "4d306b679262030ad8813a82d4915fc04efff97776e4db7f8eb5137039d56400"
 dependencies = [
  "typenum",
  "zeroize",

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -223,9 +223,9 @@ where
     /// - `Err(err)` if the `r` and/or `s` component of the signature is
     ///   out-of-range when interpreted as a big endian integer.
     pub fn from_bytes(bytes: &SignatureBytes<C>) -> Result<Self> {
-        let (r_bytes, s_bytes) = bytes.split_at(C::FieldBytesSize::USIZE);
-        let r = FieldBytes::<C>::clone_from_slice(r_bytes);
-        let s = FieldBytes::<C>::clone_from_slice(s_bytes);
+        let chunks = FieldBytes::<C>::slice_as_chunks(bytes).0;
+        let r = chunks[0].clone();
+        let s = chunks[1].clone();
         Self::from_scalars(r, s)
     }
 

--- a/slh-dsa/src/fors.rs
+++ b/slh-dsa/src/fors.rs
@@ -52,6 +52,7 @@ impl<P: ForsParams> TryFrom<&[u8]> for ForsMTSig<P> {
         if slice.len() != ForsMTSig::<P>::SIZE {
             return Err(());
         }
+        #[allow(deprecated)]
         let sk = Array::clone_from_slice(&slice[..P::N::USIZE]);
         let mut auth: Array<Array<u8, P::N>, P::A> = Array::default();
         for i in 0..P::A::USIZE {

--- a/slh-dsa/src/hashes/sha2.rs
+++ b/slh-dsa/src/hashes/sha2.rs
@@ -1,3 +1,6 @@
+// TODO(tarcieri): fix `hybrid-array` deprecation warnings
+#![allow(deprecated)]
+
 use core::fmt::Debug;
 
 use crate::hashes::HashSuite;

--- a/slh-dsa/src/signature_encoding.rs
+++ b/slh-dsa/src/signature_encoding.rs
@@ -59,6 +59,7 @@ impl<P: ParameterSet> TryFrom<&[u8]> for Signature<P> {
         }
 
         let (rand_bytes, rest) = bytes.split_at(P::N::USIZE);
+        #[allow(deprecated)]
         let randomizer = Array::clone_from_slice(rand_bytes);
 
         let (fors_bytes, ht_bytes) = rest.split_at(ForsSignature::<P>::SIZE);

--- a/slh-dsa/src/signing_key.rs
+++ b/slh-dsa/src/signing_key.rs
@@ -17,6 +17,7 @@ impl<N: ArraySize> AsRef<[u8]> for SkSeed<N> {
 }
 impl<N: ArraySize> From<&[u8]> for SkSeed<N> {
     fn from(slice: &[u8]) -> Self {
+        #[allow(deprecated)]
         Self(Array::clone_from_slice(slice))
     }
 }
@@ -37,6 +38,7 @@ impl<N: ArraySize> AsRef<[u8]> for SkPrf<N> {
 }
 impl<N: ArraySize> From<&[u8]> for SkPrf<N> {
     fn from(slice: &[u8]) -> Self {
+        #[allow(deprecated)]
         Self(Array::clone_from_slice(slice))
     }
 }

--- a/slh-dsa/src/util.rs
+++ b/slh-dsa/src/util.rs
@@ -25,6 +25,7 @@ pub fn base_2b<OutLen: ArraySize, B: Unsigned>(x: &[u8]) -> Array<u16, OutLen> {
 
 /// Separates the digest into the FORS message, the Xmss tree index, and the Xmss leaf index.
 pub fn split_digest<P: ForsParams>(digest: &Array<u8, P::M>) -> (&Array<u8, P::MD>, u64, u32) {
+    #[allow(deprecated)]
     let m = Array::from_slice(&digest[..P::MD::USIZE]);
     let idx_tree_size = (P::H::USIZE - P::HPrime::USIZE).div_ceil(8);
     let idx_leaf_size = P::HPrime::USIZE.div_ceil(8);

--- a/slh-dsa/src/verifying_key.rs
+++ b/slh-dsa/src/verifying_key.rs
@@ -24,6 +24,7 @@ impl<N: ArraySize> AsRef<[u8]> for PkSeed<N> {
 }
 impl<N: ArraySize> From<&[u8]> for PkSeed<N> {
     fn from(slice: &[u8]) -> Self {
+        #[allow(deprecated)]
         Self(Array::clone_from_slice(slice))
     }
 }
@@ -79,6 +80,7 @@ impl<P: ParameterSet> From<&VerifyingKey<P>> for Array<u8, P::VkLen> {
 }
 
 impl<P: ParameterSet> From<Array<u8, P::VkLen>> for VerifyingKey<P> {
+    #[allow(deprecated)] // clone_from_slice
     fn from(bytes: Array<u8, P::VkLen>) -> VerifyingKey<P> {
         debug_assert!(P::VkLen::USIZE == 2 * P::N::USIZE);
         let pk_seed = PkSeed(Array::clone_from_slice(&bytes[..P::N::USIZE]));
@@ -90,6 +92,7 @@ impl<P: ParameterSet> From<Array<u8, P::VkLen>> for VerifyingKey<P> {
 impl<P: ParameterSet> TryFrom<&[u8]> for VerifyingKey<P> {
     type Error = Error;
 
+    #[allow(deprecated)] // clone_from_slice
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
         if bytes.len() != P::N::USIZE * 2 {
             return Err(Error::new());


### PR DESCRIPTION
Fixes deprecation warnings