### PR TITLE
slh-dsa: fix no_std

### DIFF
--- a/slh-dsa/Cargo.toml
+++ b/slh-dsa/Cargo.toml
@@ -17,13 +17,13 @@ keywords = ["crypto", "signature"]
 [dependencies]
 hybrid-array = { version = "0.2.0-rc.8", features = ["extra-sizes"] }
 typenum = { version = "1.17.0", features = ["const-generics"] }
-sha3 = "0.10.8"
+sha3 = { version = "0.10.8", default-features = false }
 zerocopy = "0.7.34"
 zerocopy-derive = "0.7.32"
 rand_core = { version = "0.6.4" }
 signature = { version = "2.3.0-pre.4", features = ["rand_core"] }
 hmac = "0.12.1"
-sha2 = "0.10.8"
+sha2 = { version = "0.10.8", default-features = false }
 digest = "0.10.7"
 
 [dev-dependencies]


### PR DESCRIPTION
This patch fixes slh-dsa build for non-std targets.

Without this patch, `cargo build --target thumbv7m-none-eabi --no-default-features` fails due to std usage in `crypto-common`.