### PR TITLE
slh-dsa: enable `derive` feature of `zerocopy`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1180,7 +1180,6 @@ dependencies = [
  "signature",
  "typenum",
  "zerocopy",
- "zerocopy-derive",
 ]
 
 [[package]]

--- a/slh-dsa/Cargo.toml
+++ b/slh-dsa/Cargo.toml
@@ -18,8 +18,7 @@ keywords = ["crypto", "signature"]
 hybrid-array = { version = "0.2.0-rc.8", features = ["extra-sizes"] }
 typenum = { version = "1.17.0", features = ["const-generics"] }
 sha3 = { version = "0.10.8", default-features = false }
-zerocopy = "0.7.34"
-zerocopy-derive = "0.7.32"
+zerocopy = { version = "0.7.34", features = ["derive"] }
 rand_core = { version = "0.6.4" }
 signature = { version = "2.3.0-pre.4", features = ["rand_core"] }
 hmac = "0.12.1"

--- a/slh-dsa/src/address.rs
+++ b/slh-dsa/src/address.rs
@@ -20,7 +20,6 @@ use typenum::U22;
 
 use zerocopy::byteorder::big_endian::{U32, U64};
 use zerocopy::AsBytes;
-use zerocopy_derive::AsBytes;
 
 /// `Address` represents a hash address as defined by FIPS-205 section 4.2
 pub trait Address: AsRef<[u8]> {


### PR DESCRIPTION
...rather than directly depending on `zerocopy-derive`.

This fixes problems that arise if the `derive` feature is enabled by other dependencies in the same tree. See #846.