### PR TITLE
ecdsa: unpin `der` and `spki` dependencies

### DIFF
--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -21,12 +21,12 @@ elliptic-curve = { version = "=0.14.0-pre.6", default-features = false, features
 signature = { version = "=2.3.0-pre.4", default-features = false, features = ["rand_core"] }
 
 # optional dependencies
-der = { version = "=0.8.0-rc.0", optional = true }
+der = { version = "0.8.0-rc.0", optional = true }
 digest = { version = "=0.11.0-pre.9", optional = true, default-features = false, features = ["oid"] }
 rfc6979 = { version = "=0.5.0-pre.4", optional = true, path = "../rfc6979" }
 serdect = { version = "0.2", optional = true, default-features = false, features = ["alloc"] }
 sha2 = { version = "=0.11.0-pre.4", optional = true, default-features = false, features = ["oid"] }
-spki = { version = "=0.8.0-rc.0", optional = true, default-features = false }
+spki = { version = "0.8.0-rc.0", optional = true, default-features = false }
 
 [dev-dependencies]
 elliptic-curve = { version = "=0.14.0-pre.6", default-features = false, features = ["dev"] }


### PR DESCRIPTION
Removes the leading `=` requirement from these dependencies, since they're both `rc.0`