### PR TITLE
slh-dsa v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "slh-dsa"
-version = "0.0.2"
+version = "0.1.0"
 dependencies = [
  "aes",
  "cipher",

--- a/slh-dsa/CHANGELOG.md
+++ b/slh-dsa/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.0.2 (2024-05-31)
+## 0.1.0 (2024-08-18)
+### Changed
+- Implement changes from FIP 205 Initial Public Draft -> FIPS 205 Final ([#844])
 
+### Fixed
+- `no_std` support ([#845])
+- Enable `derive` feature of `zerocopy` ([#847])
+
+[#844]: https://github.com/RustCrypto/signatures/pull/844
+[#845]: https://github.com/RustCrypto/signatures/pull/845
+[#847]: https://github.com/RustCrypto/signatures/pull/847
+
+## 0.0.2 (2024-05-31)
 - Initial release

--- a/slh-dsa/Cargo.toml
+++ b/slh-dsa/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Pure Rust implementation of SLH-DSA (aka SPHINCS+) as described in the
 FIPS-205 standard
 """
-version = "0.0.2"
+version = "0.1.0"
 edition = "2021"
 rust-version = "1.75"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
### Changed
- Implement changes from FIP 205 Initial Public Draft -> FIPS 205 Final ([#844])

### Fixed
- `no_std` support ([#845])
- Enable `derive` feature of `zerocopy` ([#847])

[#844]: https://github.com/RustCrypto/signatures/pull/844
[#845]: https://github.com/RustCrypto/signatures/pull/845
[#847]: https://github.com/RustCrypto/signatures/pull/847