### PR TITLE
slh-dsa: fix --no-default-features tests

### DIFF
--- a/.github/workflows/slh-dsa.yml
+++ b/.github/workflows/slh-dsa.yml
@@ -30,6 +30,6 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - run: cargo check --all-features
-      - run: cargo test --no-default-features TODO
+      - run: cargo test --no-default-features
       - run: cargo test
       - run: cargo test --all-features


### PR DESCRIPTION
I found a strange "TODO" in Github Actions configuration: `cargo test --no-default-features TODO` in https://github.com/RustCrypto/signatures/commit/e210572c680719150536aac57b188b4840c35447#diff-4acab2ad5eb2aac73476e0b62aab80ddcfc7b6f97d8750c0263f77e12952eb34L33. Is this normal?

Due to this "TODO", slh-dsa tests seem to be skipped in `--no-default-features` mode.