### PR TITLE
Remove allocation in slh-dsa

### DIFF
--- a/slh-dsa/src/hashes.rs
+++ b/slh-dsa/src/hashes.rs
@@ -23,7 +23,7 @@ pub(crate) trait HashSuite: Sized + Clone + Debug + PartialEq + Eq {
     fn prf_msg(
         sk_prf: &SkPrf<Self::N>,
         opt_rand: &Array<u8, Self::N>,
-        msg: impl AsRef<[u8]>,
+        msg: &[impl AsRef<[u8]>],
     ) -> Array<u8, Self::N>;
 
     /// Hashes a message using a given randomizer
@@ -31,7 +31,7 @@ pub(crate) trait HashSuite: Sized + Clone + Debug + PartialEq + Eq {
         rand: &Array<u8, Self::N>,
         pk_seed: &PkSeed<Self::N>,
         pk_root: &Array<u8, Self::N>,
-        msg: impl AsRef<[u8]>,
+        msg: &[impl AsRef<[u8]>],
     ) -> Array<u8, Self::M>;
 
     /// PRF that is used to generate the secret values in WOTS+ and FORS private keys.
@@ -76,7 +76,7 @@ mod tests {
         let opt_rand = Array::<u8, H::N>::from_fn(|_| 1);
         let msg = [2u8; 32];
 
-        let result = H::prf_msg(&sk_prf, &opt_rand, msg);
+        let result = H::prf_msg(&sk_prf, &opt_rand, &[msg]);
 
         assert_eq!(result.as_slice(), expected);
     }
@@ -87,7 +87,7 @@ mod tests {
         let pk_root = Array::<u8, H::N>::from_fn(|_| 2);
         let msg = [3u8; 32];
 
-        let result = H::h_msg(&rand, &pk_seed, &pk_root, msg);
+        let result = H::h_msg(&rand, &pk_seed, &pk_root, &[msg]);
 
         assert_eq!(result.as_slice(), expected);
     }

--- a/slh-dsa/src/hashes/sha2.rs
+++ b/slh-dsa/src/hashes/sha2.rs
@@ -60,11 +60,11 @@ where
     fn prf_msg(
         sk_prf: &SkPrf<Self::N>,
         opt_rand: &Array<u8, Self::N>,
-        msg: impl AsRef<[u8]>,
+        msg: &[impl AsRef<[u8]>],
     ) -> Array<u8, Self::N> {
         let mut mac = Hmac::<Sha256>::new_from_slice(sk_prf.as_ref()).unwrap();
         mac.update(opt_rand.as_slice());
-        mac.update(msg.as_ref());
+        msg.iter().for_each(|msg_part| mac.update(msg_part.as_ref()));
         let result = mac.finalize().into_bytes();
         Array::clone_from_slice(&result[..Self::N::USIZE])
     }
@@ -73,13 +73,13 @@ where
         rand: &Array<u8, Self::N>,
         pk_seed: &PkSeed<Self::N>,
         pk_root: &Array<u8, Self::N>,
-        msg: impl AsRef<[u8]>,
+        msg: &[impl AsRef<[u8]>],
     ) -> Array<u8, Self::M> {
         let mut h = Sha256::new();
         h.update(rand);
         h.update(pk_seed);
         h.update(pk_root);
-        h.update(msg.as_ref());
+        msg.iter().for_each(|msg_part| h.update(msg_part.as_ref()));
         let result = Array(h.finalize().into());
         let seed = rand.clone().concat(pk_seed.0.clone()).concat(result);
         mgf1::<Sha256, Self::M>(&seed)
@@ -220,11 +220,11 @@ where
     fn prf_msg(
         sk_prf: &SkPrf<Self::N>,
         opt_rand: &Array<u8, Self::N>,
-        msg: impl AsRef<[u8]>,
+        msg: &[impl AsRef<[u8]>],
     ) -> Array<u8, Self::N> {
         let mut mac = Hmac::<Sha512>::new_from_slice(sk_prf.as_ref()).unwrap();
         mac.update(opt_rand.as_slice());
-        mac.update(msg.as_ref());
+        msg.iter().for_each(|msg_part| mac.update(msg_part.as_ref()));
         let result = mac.finalize().into_bytes();
         Array::clone_from_slice(&result[..Self::N::USIZE])
     }
@@ -233,13 +233,13 @@ where
         rand: &Array<u8, Self::N>,
         pk_seed: &PkSeed<Self::N>,
         pk_root: &Array<u8, Self::N>,
-        msg: impl AsRef<[u8]>,
+        msg: &[impl AsRef<[u8]>],
     ) -> Array<u8, Self::M> {
         let mut h = Sha512::new();
         h.update(rand);
         h.update(pk_seed);
         h.update(pk_root);
-        h.update(msg.as_ref());
+        msg.iter().for_each(|msg_part| h.update(msg_part.as_ref()));
         let result = Array(h.finalize().into());
         let seed = rand.clone().concat(pk_seed.0.clone()).concat(result);
         mgf1::<Sha512, Self::M>(&seed)

--- a/slh-dsa/src/hashes/sha2.rs
+++ b/slh-dsa/src/hashes/sha2.rs
@@ -64,7 +64,8 @@ where
     ) -> Array<u8, Self::N> {
         let mut mac = Hmac::<Sha256>::new_from_slice(sk_prf.as_ref()).unwrap();
         mac.update(opt_rand.as_slice());
-        msg.iter().for_each(|msg_part| mac.update(msg_part.as_ref()));
+        msg.iter()
+            .for_each(|msg_part| mac.update(msg_part.as_ref()));
         let result = mac.finalize().into_bytes();
         Array::clone_from_slice(&result[..Self::N::USIZE])
     }
@@ -224,7 +225,8 @@ where
     ) -> Array<u8, Self::N> {
         let mut mac = Hmac::<Sha512>::new_from_slice(sk_prf.as_ref()).unwrap();
         mac.update(opt_rand.as_slice());
-        msg.iter().for_each(|msg_part| mac.update(msg_part.as_ref()));
+        msg.iter()
+            .for_each(|msg_part| mac.update(msg_part.as_ref()));
         let result = mac.finalize().into_bytes();
         Array::clone_from_slice(&result[..Self::N::USIZE])
     }

--- a/slh-dsa/src/hashes/shake.rs
+++ b/slh-dsa/src/hashes/shake.rs
@@ -39,7 +39,8 @@ where
         let mut hasher = Shake256::default();
         hasher.update(sk_prf.as_ref());
         hasher.update(opt_rand.as_slice());
-        msg.iter().for_each(|msg_part| hasher.update(msg_part.as_ref()));
+        msg.iter()
+            .for_each(|msg_part| hasher.update(msg_part.as_ref()));
         let mut output = Array::<u8, Self::N>::default();
         hasher.finalize_xof_into(&mut output);
         output
@@ -55,7 +56,8 @@ where
         hasher.update(rand.as_slice());
         hasher.update(pk_seed.as_ref());
         hasher.update(pk_root.as_ref());
-        msg.iter().for_each(|msg_part| hasher.update(msg_part.as_ref()));
+        msg.iter()
+            .for_each(|msg_part| hasher.update(msg_part.as_ref()));
         let mut output = Array::<u8, Self::M>::default();
         hasher.finalize_xof_into(&mut output);
         output

--- a/slh-dsa/src/hashes/shake.rs
+++ b/slh-dsa/src/hashes/shake.rs
@@ -34,12 +34,12 @@ where
     fn prf_msg(
         sk_prf: &SkPrf<Self::N>,
         opt_rand: &Array<u8, Self::N>,
-        msg: impl AsRef<[u8]>,
+        msg: &[impl AsRef<[u8]>],
     ) -> Array<u8, Self::N> {
         let mut hasher = Shake256::default();
         hasher.update(sk_prf.as_ref());
         hasher.update(opt_rand.as_slice());
-        hasher.update(msg.as_ref());
+        msg.iter().for_each(|msg_part| hasher.update(msg_part.as_ref()));
         let mut output = Array::<u8, Self::N>::default();
         hasher.finalize_xof_into(&mut output);
         output
@@ -49,13 +49,13 @@ where
         rand: &Array<u8, Self::N>,
         pk_seed: &PkSeed<Self::N>,
         pk_root: &Array<u8, Self::N>,
-        msg: impl AsRef<[u8]>,
+        msg: &[impl AsRef<[u8]>],
     ) -> Array<u8, Self::M> {
         let mut hasher = Shake256::default();
         hasher.update(rand.as_slice());
         hasher.update(pk_seed.as_ref());
         hasher.update(pk_root.as_ref());
-        hasher.update(msg.as_ref());
+        msg.iter().for_each(|msg_part| hasher.update(msg_part.as_ref()));
         let mut output = Array::<u8, Self::M>::default();
         hasher.finalize_xof_into(&mut output);
         output
@@ -267,7 +267,7 @@ mod tests {
 
         let expected = hex!("bc5c062307df0a41aeeae19ad655f7b2");
 
-        let result = H::prf_msg(&sk_prf, &opt_rand, msg);
+        let result = H::prf_msg(&sk_prf, &opt_rand, &[msg]);
 
         assert_eq!(result.as_slice(), expected);
     }

--- a/slh-dsa/src/signing_key.rs
+++ b/slh-dsa/src/signing_key.rs
@@ -103,7 +103,7 @@ impl<P: ParameterSet> SigningKey<P> {
     /// Implements [slh_sign_internal] as defined in FIPS-205.
     /// Published for KAT validation purposes but not intended for general use.
     /// opt_rand must be a P::N length slice, panics otherwise.
-    pub fn slh_sign_internal(&self, msg: &[u8], opt_rand: Option<&[u8]>) -> Signature<P> {
+    pub fn slh_sign_internal(&self, msg: &[&[u8]], opt_rand: Option<&[u8]>) -> Signature<P> {
         let rand = opt_rand
             .unwrap_or(&self.verifying_key.pk_seed.0)
             .try_into()
@@ -142,8 +142,7 @@ impl<P: ParameterSet> SigningKey<P> {
         let ctx_len = u8::try_from(ctx.len()).map_err(|_| Error::new())?;
         let ctx_len_bytes = ctx_len.to_be_bytes();
 
-        // TODO - figure out what to do about this allocation. Maybe pass a chained iterator to slh_sign_internal?
-        let ctx_msg = [&[0], &ctx_len_bytes, ctx, msg].concat();
+        let ctx_msg = [&[0], &ctx_len_bytes, ctx, msg];
         Ok(self.slh_sign_internal(&ctx_msg, opt_rand))
     }
 

--- a/slh-dsa/src/verifying_key.rs
+++ b/slh-dsa/src/verifying_key.rs
@@ -50,7 +50,7 @@ impl<P: ParameterSet + VerifyingKeyLen> VerifyingKey<P> {
     /// Verify a raw message (without context).
     /// Implements [slh_verify_internal] as defined in FIPS-205.
     /// Published for KAT validation purposes but not intended for general use.
-    pub fn slh_verify_internal(&self, msg: &[u8], signature: &Signature<P>) -> Result<(), Error> {
+    pub fn slh_verify_internal(&self, msg: &[&[u8]], signature: &Signature<P>) -> Result<(), Error> {
         let pk_seed = &self.pk_seed;
         let randomizer = &signature.randomizer;
         let fors_sig = &signature.fors_sig;
@@ -79,8 +79,7 @@ impl<P: ParameterSet + VerifyingKeyLen> VerifyingKey<P> {
         let ctx_len = u8::try_from(ctx.len()).map_err(|_| Error::new())?;
         let ctx_len_bytes = ctx_len.to_be_bytes();
 
-        // TODO - figure out what to do about this allocation. Maybe pass a chained iterator to slh_sign_internal?
-        let ctx_msg = [&[0], &ctx_len_bytes, ctx, msg].concat();
+        let ctx_msg = [&[0], &ctx_len_bytes, ctx, msg];
         self.slh_verify_internal(&ctx_msg, signature) // TODO - context processing
     }
 

--- a/slh-dsa/src/verifying_key.rs
+++ b/slh-dsa/src/verifying_key.rs
@@ -50,7 +50,11 @@ impl<P: ParameterSet + VerifyingKeyLen> VerifyingKey<P> {
     /// Verify a raw message (without context).
     /// Implements [slh_verify_internal] as defined in FIPS-205.
     /// Published for KAT validation purposes but not intended for general use.
-    pub fn slh_verify_internal(&self, msg: &[&[u8]], signature: &Signature<P>) -> Result<(), Error> {
+    pub fn slh_verify_internal(
+        &self,
+        msg: &[&[u8]],
+        signature: &Signature<P>,
+    ) -> Result<(), Error> {
         let pk_seed = &self.pk_seed;
         let randomizer = &signature.randomizer;
         let fors_sig = &signature.fors_sig;

--- a/slh-dsa/tests/acvp_sig.rs
+++ b/slh-dsa/tests/acvp_sig.rs
@@ -39,7 +39,7 @@ macro_rules! parameter_case {
             .additionalRandomness
             .as_ref()
             .map(|x| x.data.as_slice());
-        let sig = sk.slh_sign_internal($test_case.message.data.as_slice(), opt_rand);
+        let sig = sk.slh_sign_internal(&[$test_case.message.data.as_slice()], opt_rand);
         assert_eq!(sig.to_vec(), $test_case.signature.data);
     }};
 }

--- a/slh-dsa/tests/acvp_ver.rs
+++ b/slh-dsa/tests/acvp_ver.rs
@@ -36,7 +36,7 @@ macro_rules! parameter_case {
     ($param:ident, $test_case:expr) => {{
         let sk = VerifyingKey::<$param>::try_from($test_case.pk.data.as_slice()).unwrap();
         if let Ok(sig) = $test_case.signature.data.as_slice().try_into() {
-            let success = sk.slh_verify_internal($test_case.message.data.as_slice(), &sig);
+            let success = sk.slh_verify_internal(&[$test_case.message.data.as_slice()], &sig);
             assert_eq!($test_case.testPassed, success.is_ok());
         } else {
             assert!(!$test_case.testPassed);

--- a/slh-dsa/tests/known_answer_tests.rs
+++ b/slh-dsa/tests/known_answer_tests.rs
@@ -133,7 +133,7 @@ where
         let mut opt_rand = vec![0; P::VkLen::USIZE / 2];
         rng.fill_bytes(opt_rand.as_mut());
 
-        let sig = sk.slh_sign_internal(msg, Some(&opt_rand)).to_bytes();
+        let sig = sk.slh_sign_internal(&[msg], Some(&opt_rand)).to_bytes();
         writeln!(resp, "smlen = {}", sig.as_slice().len() + msg.len()).unwrap();
         writeln!(
             resp,


### PR DESCRIPTION
This PR takes care of some TODO's in the sign and verify functions in the slh-dsa crate, thereby resolving #854

I'm passing the new messages parts on the stack as slice references down into the functions h_msg and prf_msg so that each part can be .update()'ed into the digest without having to copy them into new memory. I think it could be improved with some type system wizardry to enforce the layout specified in FIPS 205, but that's a bit beyond my abilities.