### PR TITLE
slh-dsa: adds pkcs8 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1095,6 +1095,7 @@ version = "0.2.0-pre"
 dependencies = [
  "aes",
  "cipher",
+ "const-oid",
  "criterion",
  "ctr",
  "digest",
@@ -1104,6 +1105,7 @@ dependencies = [
  "hybrid-array",
  "num-bigint",
  "paste",
+ "pkcs8",
  "proptest",
  "quickcheck",
  "quickcheck_macros",

--- a/slh-dsa/Cargo.toml
+++ b/slh-dsa/Cargo.toml
@@ -24,6 +24,8 @@ signature = { version = "2.3.0-pre.4", features = ["rand_core"] }
 hmac = "=0.13.0-pre.4"
 sha2 = { version = "=0.11.0-pre.4", default-features = false }
 digest = "=0.11.0-pre.9"
+pkcs8 = { version = "=0.11.0-rc.1", default-features = false }
+const-oid = { version = "0.10.0-rc.1", features = ["db"] }
 
 [dev-dependencies]
 hex-literal = "0.4.1"
@@ -41,6 +43,7 @@ paste = "1.0.15"
 rand = "0.8.5"
 serde_json = "1.0.124"
 serde = { version = "1.0.207", features = ["derive"] }
+pkcs8 = { version = "=0.11.0-rc.1", features = ["pem"] }
 
 [lib]
 bench = false
@@ -51,4 +54,4 @@ harness = false
 
 [features]
 alloc = []
-default = ["alloc"]
+default = ["alloc", "pkcs8/alloc"]

--- a/slh-dsa/src/hashes/sha2.rs
+++ b/slh-dsa/src/hashes/sha2.rs
@@ -9,6 +9,7 @@ use crate::{
     xmss::XmssParams, ParameterSet,
 };
 use crate::{PkSeed, SkPrf, SkSeed};
+use const_oid::db::fips205;
 use digest::{Digest, KeyInit, Mac};
 use hmac::Hmac;
 use hybrid_array::{Array, ArraySize};
@@ -169,6 +170,7 @@ impl ForsParams for Sha2_128s {
 }
 impl ParameterSet for Sha2_128s {
     const NAME: &'static str = "SLH-DSA-SHA2-128s";
+    const ALGORITHM_OID: pkcs8::ObjectIdentifier = fips205::ID_SLH_DSA_SHA_2_128_S;
 }
 
 /// SHA2 at L1 security with fast signatures
@@ -191,6 +193,7 @@ impl ForsParams for Sha2_128f {
 }
 impl ParameterSet for Sha2_128f {
     const NAME: &'static str = "SLH-DSA-SHA2-128f";
+    const ALGORITHM_OID: pkcs8::ObjectIdentifier = fips205::ID_SLH_DSA_SHA_2_128_F;
 }
 
 /// Implementation of the component hash functions using SHA2 at Security Category 3 and 5
@@ -330,6 +333,7 @@ impl ForsParams for Sha2_192s {
 }
 impl ParameterSet for Sha2_192s {
     const NAME: &'static str = "SLH-DSA-SHA2-192s";
+    const ALGORITHM_OID: pkcs8::ObjectIdentifier = fips205::ID_SLH_DSA_SHA_2_192_S;
 }
 
 /// SHA2 at L3 security with fast signatures
@@ -352,6 +356,7 @@ impl ForsParams for Sha2_192f {
 }
 impl ParameterSet for Sha2_192f {
     const NAME: &'static str = "SLH-DSA-SHA2-192f";
+    const ALGORITHM_OID: pkcs8::ObjectIdentifier = fips205::ID_SLH_DSA_SHA_2_192_F;
 }
 
 /// SHA2 at L5 security with small signatures
@@ -374,6 +379,7 @@ impl ForsParams for Sha2_256s {
 }
 impl ParameterSet for Sha2_256s {
     const NAME: &'static str = "SLH-DSA-SHA2-256s";
+    const ALGORITHM_OID: pkcs8::ObjectIdentifier = fips205::ID_SLH_DSA_SHA_2_256_S;
 }
 
 /// SHA2 at L5 security with fast signatures
@@ -396,4 +402,5 @@ impl ForsParams for Sha2_256f {
 }
 impl ParameterSet for Sha2_256f {
     const NAME: &'static str = "SLH-DSA-SHA2-256f";
+    const ALGORITHM_OID: pkcs8::ObjectIdentifier = fips205::ID_SLH_DSA_SHA_2_256_F;
 }

--- a/slh-dsa/src/hashes/shake.rs
+++ b/slh-dsa/src/hashes/shake.rs
@@ -7,6 +7,7 @@ use crate::hypertree::HypertreeParams;
 use crate::wots::WotsParams;
 use crate::xmss::XmssParams;
 use crate::{ParameterSet, PkSeed, SkPrf, SkSeed};
+use const_oid::db::fips205;
 use digest::{ExtendableOutput, Update};
 use hybrid_array::typenum::consts::{U16, U30, U32};
 use hybrid_array::typenum::{U24, U34, U39, U42, U47, U49};
@@ -146,6 +147,7 @@ impl ForsParams for Shake128s {
 }
 impl ParameterSet for Shake128s {
     const NAME: &'static str = "SLH-DSA-SHAKE-128s";
+    const ALGORITHM_OID: pkcs8::ObjectIdentifier = fips205::ID_SLH_DSA_SHAKE_128_S;
 }
 
 /// SHAKE256 at L1 security with fast signatures
@@ -168,6 +170,7 @@ impl ForsParams for Shake128f {
 }
 impl ParameterSet for Shake128f {
     const NAME: &'static str = "SLH-DSA-SHAKE-128f";
+    const ALGORITHM_OID: pkcs8::ObjectIdentifier = fips205::ID_SLH_DSA_SHAKE_128_F;
 }
 
 /// SHAKE256 at L3 security with small signatures
@@ -190,6 +193,7 @@ impl ForsParams for Shake192s {
 }
 impl ParameterSet for Shake192s {
     const NAME: &'static str = "SLH-DSA-SHAKE-192s";
+    const ALGORITHM_OID: pkcs8::ObjectIdentifier = fips205::ID_SLH_DSA_SHAKE_192_S;
 }
 
 /// SHAKE256 at L3 security with fast signatures
@@ -212,6 +216,7 @@ impl ForsParams for Shake192f {
 }
 impl ParameterSet for Shake192f {
     const NAME: &'static str = "SLH-DSA-SHAKE-192f";
+    const ALGORITHM_OID: pkcs8::ObjectIdentifier = fips205::ID_SLH_DSA_SHAKE_192_F;
 }
 
 /// SHAKE256 at L5 security with small signatures
@@ -234,6 +239,7 @@ impl ForsParams for Shake256s {
 }
 impl ParameterSet for Shake256s {
     const NAME: &'static str = "SLH-DSA-SHAKE-256s";
+    const ALGORITHM_OID: pkcs8::ObjectIdentifier = fips205::ID_SLH_DSA_SHAKE_256_S;
 }
 
 /// SHAKE256 at L5 security with fast signatures
@@ -256,6 +262,7 @@ impl ForsParams for Shake256f {
 }
 impl ParameterSet for Shake256f {
     const NAME: &'static str = "SLH-DSA-SHAKE-256f";
+    const ALGORITHM_OID: pkcs8::ObjectIdentifier = fips205::ID_SLH_DSA_SHAKE_256_F;
 }
 
 #[cfg(test)]

--- a/slh-dsa/src/lib.rs
+++ b/slh-dsa/src/lib.rs
@@ -73,6 +73,9 @@ pub trait ParameterSet:
 {
     /// Human-readable name for parameter set, matching the FIPS-205 designations
     const NAME: &'static str;
+
+    /// Associated OID with the Parameter
+    const ALGORITHM_OID: pkcs8::ObjectIdentifier;
 }
 
 #[cfg(test)]

--- a/slh-dsa/tests/pkcs8.rs
+++ b/slh-dsa/tests/pkcs8.rs
@@ -1,0 +1,44 @@
+#![cfg(feature = "alloc")]
+
+use hex_literal::hex;
+use pkcs8::{DecodePrivateKey, EncodePrivateKey, EncodePublicKey, LineEnding};
+use slh_dsa::{Sha2_128s, SigningKey, VerifyingKey};
+use std::ops::Deref;
+
+// Serialization of the SLH-DSA keys is still a draft
+// The vectors used here are taken from the draft-ietf-lamps-x509-slhdsa
+// https://github.com/lamps-wg/x509-slhdsa/commit/128c68b6b141e109e3e0ec8f3f47c832a4baaa30
+#[test]
+fn pkcs8_output() {
+    let signing = SigningKey::<Sha2_128s>::try_from(&hex!("A2263BCA45860836523160049523D621677FAD90D51EB6067A327E0D1E64A5012B8109EC777CAA4E1F024CCFCF9497D99180509280F4256AF2B07AF80289B494")[..]).unwrap();
+
+    let out = signing.to_pkcs8_pem(LineEnding::LF).unwrap();
+
+    // https://github.com/lamps-wg/x509-slhdsa/blob/main/id-slh-dsa-sha2-128s.priv
+    assert_eq!(
+        out.deref(),
+        r#"-----BEGIN PRIVATE KEY-----
+MFICAQAwCwYJYIZIAWUDBAMUBECiJjvKRYYINlIxYASVI9YhZ3+tkNUetgZ6Mn4N
+HmSlASuBCex3fKpOHwJMz8+Ul9mRgFCSgPQlavKwevgCibSU
+-----END PRIVATE KEY-----
+"#
+    );
+
+    let parsed = SigningKey::<Sha2_128s>::from_pkcs8_pem(out.deref()).unwrap();
+
+    assert_eq!(parsed, signing);
+
+    let public: VerifyingKey<Sha2_128s> = parsed.as_ref().clone();
+
+    let out = public.to_public_key_pem(LineEnding::LF).unwrap();
+
+    // https://github.com/lamps-wg/x509-slhdsa/blob/main/id-slh-dsa-sha2-128s.pub
+    assert_eq!(
+        out.deref(),
+        r#"-----BEGIN PUBLIC KEY-----
+MDAwCwYJYIZIAWUDBAMUAyEAK4EJ7Hd8qk4fAkzPz5SX2ZGAUJKA9CVq8rB6+AKJ
+tJQ=
+-----END PUBLIC KEY-----
+"#
+    );
+}


### PR DESCRIPTION
Made a demo w/ x509 over in https://github.com/baloo/playground-x509-slh-dsa

I guess this effectively implements a [draft RFC](https://datatracker.ietf.org/doc/draft-ietf-lamps-cms-sphincs-plus/)