### PR TITLE
workspace: limit duplicate dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,15 @@ members = [
 
 [profile.dev]
 opt-level = 2
+
+[patch.crates-io]
+# A global patch crates-io block is used to avoid duplicate dependencies
+# when pulling a member crate through git
+dsa             = { path = "./dsa" }
+ecdsa           = { path = "./ecdsa" }
+ed448-signature = { path = "./ed448" }
+ed25519         = { path = "./ed25519" }
+lms-signature   = { path = "./lms" }
+ml-dsa          = { path = "./ml-dsa" }
+rfc6979         = { path = "./rfc6979" }
+slh-dsa         = { path = "./slh-dsa" }

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -20,7 +20,7 @@ digest = "=0.11.0-pre.9"
 num-bigint = { package = "num-bigint-dig", version = "0.8", default-features = false, features = ["prime", "rand", "zeroize"] }
 num-traits = { version = "0.2", default-features = false }
 pkcs8 = { version = "=0.11.0-rc.1", default-features = false, features = ["alloc"] }
-rfc6979 = { version = "=0.5.0-pre.4", path = "../rfc6979" }
+rfc6979 = { version = "=0.5.0-pre.4" }
 sha2 = { version = "=0.11.0-pre.4", default-features = false }
 signature = { version = "=2.3.0-pre.4", default-features = false, features = ["alloc", "digest", "rand_core"] }
 zeroize = { version = "1", default-features = false }

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -23,7 +23,7 @@ signature = { version = "=2.3.0-pre.4", default-features = false, features = ["r
 # optional dependencies
 der = { version = "0.8.0-rc.1", optional = true }
 digest = { version = "=0.11.0-pre.9", optional = true, default-features = false, features = ["oid"] }
-rfc6979 = { version = "=0.5.0-pre.4", optional = true, path = "../rfc6979" }
+rfc6979 = { version = "=0.5.0-pre.4", optional = true }
 serdect = { version = "0.3.0-rc.0", optional = true, default-features = false, features = ["alloc"] }
 sha2 = { version = "=0.11.0-pre.4", optional = true, default-features = false, features = ["oid"] }
 spki = { version = "0.8.0-rc.0", optional = true, default-features = false }


### PR DESCRIPTION
This makes use of a global `patch.crates-io` instead of local `path =` attributes in the dependencies.

When pulling dependencies through git to try unreleased crates, the dependency in `path` will get duplicated. Which makes for twice the definition of types incompatible with each other.