### PR TITLE
ecdsa: simplify `serde` feature

### DIFF
--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -44,7 +44,7 @@ digest = ["dep:digest", "signature/digest"]
 hazmat = []
 pkcs8 = ["digest", "elliptic-curve/pkcs8", "der"]
 pem = ["elliptic-curve/pem", "pkcs8"]
-serde = ["elliptic-curve/serde", "serdect"]
+serde = ["elliptic-curve/serde", "pkcs8", "serdect"]
 signing = ["arithmetic", "digest", "hazmat", "rfc6979"]
 verifying = ["arithmetic", "digest", "hazmat"]
 

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -37,6 +37,9 @@ use elliptic_curve::pkcs8::{
     AssociatedOid, ObjectIdentifier,
 };
 
+#[cfg(feature = "serde")]
+use serdect::serde::{de, ser, Deserialize, Serialize};
+
 #[cfg(feature = "sha2")]
 use {
     crate::{
@@ -47,9 +50,6 @@ use {
 
 #[cfg(all(feature = "alloc", feature = "pkcs8"))]
 use elliptic_curve::pkcs8::EncodePublicKey;
-
-#[cfg(all(feature = "pem", feature = "serde"))]
-use serdect::serde::{de, ser, Deserialize, Serialize};
 
 /// ECDSA public key used for verifying signatures. Generic over prime order
 /// elliptic curves (e.g. NIST P-curves).
@@ -453,7 +453,7 @@ where
     }
 }
 
-#[cfg(all(feature = "pem", feature = "serde"))]
+#[cfg(feature = "serde")]
 impl<C> Serialize for VerifyingKey<C>
 where
     C: EcdsaCurve + AssociatedOid + CurveArithmetic + PointCompression,
@@ -468,7 +468,7 @@ where
     }
 }
 
-#[cfg(all(feature = "pem", feature = "serde"))]
+#[cfg(feature = "serde")]
 impl<'de, C> Deserialize<'de> for VerifyingKey<C>
 where
     C: EcdsaCurve + AssociatedOid + CurveArithmetic + PointCompression,


### PR DESCRIPTION
To get `serde` support for `VerifyingKey`, confusingly the `pem` feature previously needed to be enabled (even though PEM is not actually used).

This changed the `serde` feature to auto-enable `pkcs8`, similar to what was done in the `elliptic-curve` crate.