### PR TITLE
slh-dsa: fix lint

### DIFF
--- a/slh-dsa/src/util.rs
+++ b/slh-dsa/src/util.rs
@@ -49,6 +49,7 @@ pub fn split_digest<P: ForsParams>(digest: &Array<u8, P::M>) -> (&Array<u8, P::M
 
 #[cfg(test)]
 pub mod macros {
+    /// Generate a test case
     #[macro_export]
     macro_rules! gen_test {
         ($name:ident, $t:ty) => {


### PR DESCRIPTION
The build is failing because of a lint failure due to an undocumented macro which is only used for tests.

This adds a simple comment so the lint succeeds.