### PR TITLE
CI: fix security audit

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,10 +1,14 @@
 name: Security Audit
 on:
   pull_request:
-    paths: Cargo.lock
+    paths:
+      - .github/workflows/security-audit.yml
+      - Cargo.lock
   push:
     branches: master
-    paths: Cargo.lock
+    paths:
+      - .github/workflows/security-audit.yml
+      - Cargo.lock
   schedule:
     - cron: "0 0 * * *"
 
@@ -20,7 +24,7 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ~/.cargo/bin
-          key: ${{ runner.os }}-cargo-audit-v0.17.4
+          key: ${{ runner.os }}-cargo-audit-v0.21.1
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Busts the cache key so we use a newer version of `cargo-audit`