### PR TITLE
ml-dsa: encode private key

### DIFF
--- a/ml-dsa/src/lib.rs
+++ b/ml-dsa/src/lib.rs
@@ -18,15 +18,15 @@
 //!
 //! ```
 //! use ml_dsa::{MlDsa65, KeyGen};
-//! use signature::{Signer, Verifier};
+//! use signature::{Keypair, Signer, Verifier};
 //!
 //! let mut rng = rand::thread_rng();
 //! let kp = MlDsa65::key_gen(&mut rng);
 //!
 //! let msg = b"Hello world";
-//! let sig = kp.signing_key.sign(msg);
+//! let sig = kp.signing_key().sign(msg);
 //!
-//! assert!(kp.verifying_key.verify(msg, &sig).is_ok());
+//! assert!(kp.verifying_key().verify(msg, &sig).is_ok());
 //! ```
 
 mod algebra;
@@ -178,10 +178,17 @@ fn message_representative(tr: &[u8], Mp: &[&[u8]]) -> B64 {
 /// An ML-DSA key pair
 pub struct KeyPair<P: MlDsaParams> {
     /// The signing key of the key pair
-    pub signing_key: SigningKey<P>,
+    signing_key: SigningKey<P>,
 
     /// The verifying key of the key pair
-    pub verifying_key: VerifyingKey<P>,
+    verifying_key: VerifyingKey<P>,
+}
+
+impl<P: MlDsaParams> KeyPair<P> {
+    /// The signing key of the key pair
+    pub fn signing_key(&self) -> &SigningKey<P> {
+        &self.signing_key
+    }
 }
 
 impl<P: MlDsaParams> AsRef<VerifyingKey<P>> for KeyPair<P> {

--- a/ml-dsa/tests/key-gen.rs
+++ b/ml-dsa/tests/key-gen.rs
@@ -1,6 +1,7 @@
 use ml_dsa::*;
 
 use hybrid_array::Array;
+use signature::Keypair;
 use std::{fs::read_to_string, path::PathBuf};
 
 #[test]
@@ -32,8 +33,8 @@ fn verify<P: MlDsaParams>(tc: &acvp::TestCase) {
     let sk_bytes = EncodedSigningKey::<P>::try_from(tc.sk.as_slice()).unwrap();
 
     let kp = P::key_gen_internal(&seed);
-    let sk = kp.signing_key;
-    let vk = kp.verifying_key;
+    let sk = kp.signing_key().clone();
+    let vk = kp.verifying_key().clone();
 
     // Verify correctness via serialization
     assert_eq!(sk.encode(), sk_bytes);

--- a/ml-dsa/tests/pkcs8.rs
+++ b/ml-dsa/tests/pkcs8.rs
@@ -5,7 +5,7 @@ use ml_dsa::{KeyPair, MlDsa44, MlDsa65, MlDsa87, MlDsaParams, SigningKey, Verify
 use pkcs8::{
     der::{pem::LineEnding, AnyRef},
     spki::AssociatedAlgorithmIdentifier,
-    DecodePrivateKey, DecodePublicKey, EncodePublicKey,
+    DecodePrivateKey, DecodePublicKey, EncodePrivateKey, EncodePublicKey,
 };
 use signature::Keypair;
 
@@ -19,6 +19,12 @@ fn private_key_serialization() {
         let sk = SigningKey::<P>::from_pkcs8_pem(private_bytes).expect("parse private key");
         let kp = KeyPair::<P>::from_pkcs8_pem(private_bytes).expect("parse private key");
         assert!(sk == *kp.signing_key());
+        assert_eq!(
+            kp.to_pkcs8_pem(LineEnding::LF)
+                .expect("serialize private seed")
+                .deref(),
+            private_bytes
+        );
 
         let pk = VerifyingKey::<P>::from_public_key_pem(public_bytes).expect("parse public key");
         assert_eq!(

--- a/ml-dsa/tests/pkcs8.rs
+++ b/ml-dsa/tests/pkcs8.rs
@@ -18,7 +18,7 @@ fn private_key_serialization() {
     {
         let sk = SigningKey::<P>::from_pkcs8_pem(private_bytes).expect("parse private key");
         let kp = KeyPair::<P>::from_pkcs8_pem(private_bytes).expect("parse private key");
-        assert!(sk == kp.signing_key);
+        assert!(sk == *kp.signing_key());
 
         let pk = VerifyingKey::<P>::from_public_key_pem(public_bytes).expect("parse public key");
         assert_eq!(


### PR DESCRIPTION
Follow up on #891

This reworks the `ml_dsa::KeyPair` to keep the seed along with the `SigningKey` which allows to serialize the private key to the pkcs8 format after that.