### PR TITLE
ml-dsa: remove `std` feature

### DIFF
--- a/ml-dsa/Cargo.toml
+++ b/ml-dsa/Cargo.toml
@@ -15,8 +15,7 @@ categories = ["cryptography"]
 keywords = ["crypto", "signature"]
 
 [features]
-default = ["std", "rand_core"]
-std = ["sha3/std"]
+default = ["rand_core"]
 zeroize = ["dep:zeroize", "hybrid-array/zeroize"]
 rand_core = ["dep:rand_core", "signature/rand_core"]
 


### PR DESCRIPTION
It doesn't appear this feature actually does anything except transitively activate the `sha3/std` feature, which we likely plan on removing in the next breaking release.

Now that `core::error::Error` is stable, we are generally trying to remove `std` features across the @RustCrypto project, except in cases where libraries do things like e.g. file I/O (for loading/saving keys) and actually have a legitimate `std` dependency that way.