### PR TITLE
Make ML-DSA signature decoding follow the spec

### DIFF
--- a/ml-dsa/src/algebra.rs
+++ b/ml-dsa/src/algebra.rs
@@ -217,36 +217,45 @@ mod test {
 
     use crate::{MlDsa65, ParameterSet};
 
-    type TwoGamma2 = <MlDsa65 as ParameterSet>::TwoGamma2;
-    const TWO_GAMMA_2: u32 = TwoGamma2::U32;
+    type Mod = <MlDsa65 as ParameterSet>::TwoGamma2;
+    const MOD: u32 = Mod::U32;
+    const MOD_ELEM: Elem = Elem::new(MOD);
 
     #[test]
     fn mod_plus_minus() {
-        for x in 0..BaseField::Q {
+        for x in 0..MOD {
+            // BaseField::Q {
             let x = Elem::new(x);
-            let x0 = x.mod_plus_minus::<TwoGamma2>();
+            let x0 = x.mod_plus_minus::<Mod>();
 
             // Outputs from mod+- should be in the half-open interval (-gamma2, gamma2]
-            let positive_bound = x0.0 <= TWO_GAMMA_2 / 2;
-            let negative_bound = x0.0 > BaseField::Q - TWO_GAMMA_2 / 2;
+            let positive_bound = x0.0 <= MOD / 2;
+            let negative_bound = x0.0 > BaseField::Q - MOD / 2;
             assert!(positive_bound || negative_bound);
+
+            // The output should be equivalent to the input, mod 2 * gamma2.  We add 2 * gamma2
+            // before comparing so that both values are "positive", avoiding interactions between
+            // the mod-Q and mod-M operations.
+            let xn = x + MOD_ELEM;
+            let x0n = x0 + MOD_ELEM;
+            assert_eq!(xn.0 % MOD, x0n.0 % MOD);
         }
     }
 
     #[test]
     fn decompose() {
-        for x in 0..BaseField::Q {
+        for x in 0..MOD {
             let x = Elem::new(x);
-            let (x1, x0) = x.decompose::<TwoGamma2>();
+            let (x1, x0) = x.decompose::<Mod>();
 
             // The low-order output from decompose() is a mod+- output, optionally minus one.  So
             // they should be in the closed interval [-gamma2, gamma2].
-            let positive_bound = x0.0 <= TWO_GAMMA_2 / 2;
-            let negative_bound = x0.0 >= BaseField::Q - TWO_GAMMA_2 / 2;
+            let positive_bound = x0.0 <= MOD / 2;
+            let negative_bound = x0.0 >= BaseField::Q - MOD / 2;
             assert!(positive_bound || negative_bound);
 
-            // The low-order and high-order values
-            let xx = (TWO_GAMMA_2 * x1.0 + x0.0) % BaseField::Q;
+            // The low-order and high-order outputs should combine to form the input.
+            let xx = (MOD * x1.0 + x0.0) % BaseField::Q;
             assert_eq!(xx, x.0);
         }
     }

--- a/ml-dsa/src/hint.rs
+++ b/ml-dsa/src/hint.rs
@@ -26,7 +26,7 @@ fn use_hint<TwoGamma2: Unsigned>(h: bool, r: Elem) -> Elem {
         Elem::new((r1.0 + m - 1) % m)
     } else if h {
         // We use the Elem encoding even for signed integers.  Since r0 is computed
-        // mod+- 2*gamma2, it is guaranteed to be in (gamma2, gamma2].
+        // mod+- 2*gamma2, it is guaranteed to be in (-gamma2, gamma2].
         unreachable!();
     } else {
         r1
@@ -138,7 +138,6 @@ where
             let indices = &indices[start..end];
 
             if !Self::monotonic(indices) {
-                println!("indices not monotonic: {:?}", indices);
                 return None;
             }
 

--- a/ml-dsa/src/hint.rs
+++ b/ml-dsa/src/hint.rs
@@ -22,11 +22,11 @@ fn use_hint<TwoGamma2: Unsigned>(h: bool, r: Elem) -> Elem {
     let gamma2 = TwoGamma2::U32 / 2;
     if h && r0.0 <= gamma2 {
         Elem::new((r1.0 + 1) % m)
-    } else if h && r0.0 > BaseField::Q - gamma2 {
+    } else if h && r0.0 >= BaseField::Q - gamma2 {
         Elem::new((r1.0 + m - 1) % m)
     } else if h {
         // We use the Elem encoding even for signed integers.  Since r0 is computed
-        // mod+- 2*gamma2, it is guaranteed to be in (-gamma2, gamma2].
+        // mod+- 2*gamma2 (possibly minus 1), it is guaranteed to be in [-gamma2, gamma2].
         unreachable!();
     } else {
         r1

--- a/ml-dsa/src/hint.rs
+++ b/ml-dsa/src/hint.rs
@@ -33,7 +33,7 @@ fn use_hint<TwoGamma2: Unsigned>(h: bool, r: Elem) -> Elem {
     }
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct Hint<P>(pub Array<Array<bool, U256>, P::K>)
 where
     P: SignatureParams;
@@ -116,7 +116,7 @@ where
     }
 
     fn monotonic(a: &[usize]) -> bool {
-        a.iter().enumerate().all(|(i, x)| i == 0 || a[i - 1] < *x)
+        a.iter().enumerate().all(|(i, x)| i == 0 || a[i - 1] <= *x)
     }
 
     pub fn bit_unpack(y: &EncodedHint<P>) -> Option<Self> {
@@ -138,6 +138,7 @@ where
             let indices = &indices[start..end];
 
             if !Self::monotonic(indices) {
+                println!("indices not monotonic: {:?}", indices);
                 return None;
             }
 

--- a/ml-dsa/src/lib.rs
+++ b/ml-dsa/src/lib.rs
@@ -927,7 +927,7 @@ mod test {
             let sig_dec = Signature::<P>::decode(&sig_enc).unwrap();
 
             assert_eq!(sig_dec, sig);
-            assert!(vk.verify_internal(&[M], &sig));
+            assert!(vk.verify_internal(&[M], &sig_dec));
         }
     }
 

--- a/ml-dsa/src/lib.rs
+++ b/ml-dsa/src/lib.rs
@@ -1,4 +1,4 @@
-// XXX #![no_std]
+#![no_std]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",

--- a/ml-dsa/src/lib.rs
+++ b/ml-dsa/src/lib.rs
@@ -937,24 +937,4 @@ mod test {
         many_round_trip_test::<MlDsa65>();
         many_round_trip_test::<MlDsa87>();
     }
-
-    #[test]
-    fn encode_decode_fail() {
-        use signature::Signer;
-
-        const SEED: [u8; 32] = [
-            197, 185, 159, 59, 216, 233, 208, 40, 244, 4, 182, 73, 109, 244, 205, 113, 116, 55,
-            206, 145, 214, 205, 247, 130, 41, 113, 93, 14, 140, 194, 191, 232,
-        ];
-        const MESSAGE: &[u8] = b"There seems to be a round tripping issue somewhere in here";
-
-        let mut seed = B32::default();
-        seed.0.copy_from_slice(&SEED);
-
-        let seed = SEED.into();
-        let kp = MlDsa65::key_gen_internal(&seed);
-        let sig = kp.signing_key().sign(MESSAGE);
-        let sig_enc = sig.encode();
-        let _sig = Signature::<MlDsa65>::decode(&sig_enc).unwrap();
-    }
 }


### PR DESCRIPTION
Fixes #894 

This PR also adds a test that runs many random signatures.  I confirmed locally that this produced a failure rate of 0.4-1.1% for ML-DSA-65 and ML-DSA-87, all due to signature decoding, and all for the reasons discussed below.  I never saw any failures for ML-DSA-44, but that seems plausible: The failure condition arises when the high-order bits of the `r` vector don't change, and the threshold $\gamma_2 / 2$ is roughly a factor of 2.75 lower for ML-DSA-44 than the other variants.

It appears that the root of the problem is a one-character fix, allowing repeated values in the monotonicity check in `hint.rs`.  This makes it so that the tests usually pass.  Marking this PR as draft because that same test fails intermittently, reporting `internal error: entered unreachable code` at `hint.rs:30`.  I'll take a look at that tomorrow.

