### PR TITLE
ml-dsa v0.1.0-pre.2

### DIFF
--- a/ml-dsa/Cargo.lock
+++ b/ml-dsa/Cargo.lock
@@ -433,7 +433,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "ml-dsa"
-version = "0.1.0-pre.1"
+version = "0.1.0-pre.2"
 dependencies = [
  "const-oid",
  "criterion",

--- a/ml-dsa/Cargo.toml
+++ b/ml-dsa/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Pure Rust implementation of ML-DSA (formerly known as CRYSTALS-Dilithium) as
 described in FIPS-204 (final)
 """
-version = "0.1.0-pre.1"
+version = "0.1.0-pre.2"
 edition = "2021"
 rust-version = "1.81"
 license = "Apache-2.0 OR MIT"

--- a/ml-dsa/LICENSE-MIT
+++ b/ml-dsa/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2024 RustCrypto Developers
+Copyright (c) 2024-2025 RustCrypto Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated


### PR DESCRIPTION
Bumps `rand_core` to v0.9