### PR TITLE
Update signing method signatures to match upstream traits

### DIFF
--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -17,8 +17,8 @@ edition = "2021"
 rust-version = "1.81"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.1", default-features = false, features = ["digest", "sec1"] }
-signature = { version = "=2.3.0-pre.4", default-features = false, features = ["rand_core"] }
+elliptic-curve = { path = "../../traits/elliptic-curve", default-features = false, features = ["digest", "sec1"] }
+signature = { path = "../../traits/signature", default-features = false, features = ["rand_core"] }
 
 # optional dependencies
 der = { version = "0.8.0-rc.1", optional = true }
@@ -29,7 +29,7 @@ sha2 = { version = "=0.11.0-pre.4", optional = true, default-features = false, f
 spki = { version = "0.8.0-rc.0", optional = true, default-features = false }
 
 [dev-dependencies]
-elliptic-curve = { version = "0.14.0-rc.1", default-features = false, features = ["dev"] }
+elliptic-curve = { path = "../../traits/elliptic-curve", default-features = false, features = ["dev"] }
 hex-literal = "0.4"
 sha2 = { version = "=0.11.0-pre.4", default-features = false }
 

--- a/ecdsa/src/recovery.rs
+++ b/ecdsa/src/recovery.rs
@@ -9,7 +9,7 @@ use {
     signature::{
         digest::FixedOutput,
         hazmat::{PrehashSigner, RandomizedPrehashSigner},
-        rand_core::CryptoRngCore,
+        rand_core::TryCryptoRng,
         DigestSigner, RandomizedDigestSigner, Signer,
     },
 };
@@ -187,12 +187,12 @@ where
     /// data", returning a signature and recovery ID.
     pub fn sign_prehash_recoverable_with_rng(
         &self,
-        rng: &mut impl CryptoRngCore,
+        rng: &mut impl TryCryptoRng,
         prehash: &[u8],
     ) -> Result<(Signature<C>, RecoveryId)> {
         let z = bits2field::<C>(prehash)?;
         let mut ad = FieldBytes::<C>::default();
-        rng.fill_bytes(&mut ad);
+        rng.try_fill_bytes(&mut ad).expect("failed to obtain randomness");
         sign_prehashed_rfc6979::<C, C::Digest>(self.as_nonzero_scalar(), &z, &ad)
     }
 
@@ -237,9 +237,9 @@ where
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
     SignatureSize<C>: ArraySize,
 {
-    fn sign_prehash_with_rng(
+    fn sign_prehash_with_rng<R: TryCryptoRng>(
         &self,
-        rng: &mut impl CryptoRngCore,
+        rng: &mut R,
         prehash: &[u8],
     ) -> Result<(Signature<C>, RecoveryId)> {
         self.sign_prehash_recoverable_with_rng(rng, prehash)
@@ -254,9 +254,9 @@ where
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
     SignatureSize<C>: ArraySize,
 {
-    fn try_sign_digest_with_rng(
+    fn try_sign_digest_with_rng<R: TryCryptoRng>(
         &self,
-        rng: &mut impl CryptoRngCore,
+        rng: &mut R,
         msg_digest: D,
     ) -> Result<(Signature<C>, RecoveryId)> {
         self.sign_prehash_with_rng(rng, &msg_digest.finalize_fixed())

--- a/ecdsa/src/signing.rs
+++ b/ecdsa/src/signing.rs
@@ -17,7 +17,7 @@ use elliptic_curve::{
 };
 use signature::{
     hazmat::{PrehashSigner, RandomizedPrehashSigner},
-    rand_core::CryptoRngCore,
+    rand_core::{CryptoRng, TryCryptoRng},
     DigestSigner, RandomizedDigestSigner, RandomizedSigner, Signer,
 };
 
@@ -83,7 +83,7 @@ where
     SignatureSize<C>: ArraySize,
 {
     /// Generate a cryptographically random [`SigningKey`].
-    pub fn random(rng: &mut impl CryptoRngCore) -> Self {
+    pub fn random(rng: &mut impl CryptoRng) -> Self {
         NonZeroScalar::<C>::random(rng).into()
     }
 
@@ -182,9 +182,9 @@ where
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
     SignatureSize<C>: ArraySize,
 {
-    fn try_sign_digest_with_rng(
+    fn try_sign_digest_with_rng<R: TryCryptoRng>(
         &self,
-        rng: &mut impl CryptoRngCore,
+        rng: &mut R,
         msg_digest: D,
     ) -> Result<Signature<C>> {
         self.sign_prehash_with_rng(rng, &msg_digest.finalize_fixed())
@@ -197,14 +197,14 @@ where
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
     SignatureSize<C>: ArraySize,
 {
-    fn sign_prehash_with_rng(
+    fn sign_prehash_with_rng<R: TryCryptoRng>(
         &self,
-        rng: &mut impl CryptoRngCore,
+        rng: &mut R,
         prehash: &[u8],
     ) -> Result<Signature<C>> {
         let z = bits2field::<C>(prehash)?;
         let mut ad = FieldBytes::<C>::default();
-        rng.fill_bytes(&mut ad);
+        rng.try_fill_bytes(&mut ad).expect("Failed to read random values");
         Ok(sign_prehashed_rfc6979::<C, C::Digest>(&self.secret_scalar, &z, &ad)?.0)
     }
 }
@@ -216,7 +216,7 @@ where
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
     SignatureSize<C>: ArraySize,
 {
-    fn try_sign_with_rng(&self, rng: &mut impl CryptoRngCore, msg: &[u8]) -> Result<Signature<C>> {
+    fn try_sign_with_rng<R: TryCryptoRng>(&self, rng: &mut R, msg: &[u8]) -> Result<Signature<C>> {
         self.try_sign_digest_with_rng(rng, C::Digest::new_with_prefix(msg))
     }
 }
@@ -285,9 +285,9 @@ where
     der::MaxSize<C>: ArraySize,
     <FieldBytesSize<C> as Add>::Output: Add<der::MaxOverhead> + ArraySize,
 {
-    fn try_sign_digest_with_rng(
+    fn try_sign_digest_with_rng<R: CryptoRng>(
         &self,
-        rng: &mut impl CryptoRngCore,
+        rng: &mut R,
         msg_digest: D,
     ) -> Result<der::Signature<C>> {
         RandomizedDigestSigner::<D, Signature<C>>::try_sign_digest_with_rng(self, rng, msg_digest)
@@ -304,9 +304,9 @@ where
     der::MaxSize<C>: ArraySize,
     <FieldBytesSize<C> as Add>::Output: Add<der::MaxOverhead> + ArraySize,
 {
-    fn sign_prehash_with_rng(
+    fn sign_prehash_with_rng<R: CryptoRng>(
         &self,
-        rng: &mut impl CryptoRngCore,
+        rng: &mut R,
         prehash: &[u8],
     ) -> Result<der::Signature<C>> {
         RandomizedPrehashSigner::<Signature<C>>::sign_prehash_with_rng(self, rng, prehash)


### PR DESCRIPTION
The method signatures in RandomizedPrehashSigner and RandomizedDigestSigner have updated in the signature crate. This change makes the relevant changes to have the implementations match the updated traits