### PR TITLE
ml-dsa: update signature@2.3.0-pre.6

### DIFF
--- a/ml-dsa/Cargo.lock
+++ b/ml-dsa/Cargo.lock
@@ -782,9 +782,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.3.0-pre.5"
+version = "2.3.0-pre.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2709fb57c97dd1496b041ae261a6b92def6e6f97d206898b4726e6bdf4ec8f"
+checksum = "4633ec5613e4218fbab07568ca79ee388e3c041af75f0f83a15f040f096f94cf"
 dependencies = [
  "rand_core 0.9.0",
 ]

--- a/ml-dsa/Cargo.toml
+++ b/ml-dsa/Cargo.toml
@@ -26,7 +26,7 @@ hybrid-array = { version = "0.2.3", features = ["extra-sizes"] }
 num-traits = "0.2.19"
 rand_core = { version = "0.9", optional = true }
 sha3 = "0.10.8"
-signature = "=2.3.0-pre.5"
+signature = "2.3.0-pre.6"
 zeroize = { version = "1.8.1", optional = true, default-features = false }
 
 const-oid = { version = "0.10.0-rc.1", features = ["db"], optional = true }

--- a/ml-dsa/Cargo.toml
+++ b/ml-dsa/Cargo.toml
@@ -26,7 +26,7 @@ hybrid-array = { version = "0.2.3", features = ["extra-sizes"] }
 num-traits = "0.2.19"
 rand_core = { version = "0.9", optional = true }
 sha3 = "0.10.8"
-signature = "2.3.0-pre.6"
+signature = "=2.3.0-pre.6"
 zeroize = { version = "1.8.1", optional = true, default-features = false }
 
 const-oid = { version = "0.10.0-rc.1", features = ["db"], optional = true }


### PR DESCRIPTION
Tiny change, but... my first for RustCrypto stuffs, so I'm super excited.

As far as I can tell, this is the only change need to make ml-dsa build against signatures@2.3.6-pre.6.

Have an awesome day and happy Rust 1.85! 💖 🦀

