### PR TITLE
ml-dsa: update pkcs8@0.11.0-rc.2

### DIFF
--- a/ml-dsa/Cargo.lock
+++ b/ml-dsa/Cargo.lock
@@ -484,9 +484,9 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.11.0-rc.1"
+version = "0.11.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eacd2c7141f32aef1cfd1ad0defb5287a3d94592d7ab57c1ae20e3f9f1f0db1f"
+checksum = "f22636de7c995e997ed3d8d2949b7414d4faba3efa7312a6c0e75d875a14bdd4"
 dependencies = [
  "der",
  "spki",

--- a/ml-dsa/Cargo.toml
+++ b/ml-dsa/Cargo.toml
@@ -30,13 +30,13 @@ signature = "=2.3.0-pre.6"
 zeroize = { version = "1.8.1", optional = true, default-features = false }
 
 const-oid = { version = "0.10.0-rc.1", features = ["db"], optional = true }
-pkcs8 = { version = "=0.11.0-rc.1", default-features = false, optional = true }
+pkcs8 = { version = "=0.11.0-rc.2", default-features = false, optional = true }
 
 [dev-dependencies]
 criterion = "0.5.1"
 hex = { version = "0.4.3", features = ["serde"] }
 hex-literal = "0.4.1"
-pkcs8 = { version = "=0.11.0-rc.1", features = ["pem"] }
+pkcs8 = { version = "=0.11.0-rc.2", features = ["pem"] }
 proptest = "1"
 rand = "0.9"
 serde = { version = "1.0.215", features = ["derive"] }

--- a/ml-dsa/Cargo.toml
+++ b/ml-dsa/Cargo.toml
@@ -30,13 +30,13 @@ signature = "=2.3.0-pre.6"
 zeroize = { version = "1.8.1", optional = true, default-features = false }
 
 const-oid = { version = "0.10.0-rc.1", features = ["db"], optional = true }
-pkcs8 = { version = "=0.11.0-rc.2", default-features = false, optional = true }
+pkcs8 = { version = "0.11.0-rc.2", default-features = false, optional = true }
 
 [dev-dependencies]
 criterion = "0.5.1"
 hex = { version = "0.4.3", features = ["serde"] }
 hex-literal = "0.4.1"
-pkcs8 = { version = "=0.11.0-rc.2", features = ["pem"] }
+pkcs8 = { version = "0.11.0-rc.2", features = ["pem"] }
 proptest = "1"
 rand = "0.9"
 serde = { version = "1.0.215", features = ["derive"] }


### PR DESCRIPTION
As far as I can tell, this is the only change need to make ml-dsa build against pkcs8 0.11.0-rc.2.