### PR TITLE
dsa: impl ZeroizeOnDrop for SigningKey

### DIFF
--- a/dsa/src/signing_key.rs
+++ b/dsa/src/signing_key.rs
@@ -22,7 +22,7 @@ use signature::{
     rand_core::CryptoRngCore,
     DigestSigner, RandomizedDigestSigner, Signer,
 };
-use zeroize::{Zeroize, Zeroizing};
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 /// DSA private key.
 ///
@@ -113,6 +113,8 @@ impl SigningKey {
         }
     }
 }
+
+impl ZeroizeOnDrop for SigningKey {}
 
 impl Signer<Signature> for SigningKey {
     fn try_sign(&self, msg: &[u8]) -> Result<Signature, signature::Error> {


### PR DESCRIPTION
Resolves #883 by implementing `ZeroizeOnDrop` for `dsa::SigningKey`.

 Since the private component `x` already is of type `Zeroizing<BigUint>`, no changes were necessary to ensure the `ZeroizeOnDrop` preconditions were met.