### PR TITLE
ml-dsa: exclude tests/ in published crate due to size

### DIFF
--- a/ml-dsa/Cargo.toml
+++ b/ml-dsa/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/RustCrypto/signatures"
 readme = "README.md"
 categories = ["cryptography"]
 keywords = ["crypto", "signature"]
+exclude = ["tests"]
 
 [features]
 default = ["rand_core", "alloc", "pkcs8"]


### PR DESCRIPTION
This addresses bug #887 "ml-dsa: large crate size due to test vectors".

The simplest solution is to exclude all of tests/ in the published crate, so that's what my pull request does.