### PR TITLE
update LICENSE-MIT

### DIFF
--- a/dsa/LICENSE-MIT
+++ b/dsa/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2018-2023 RustCrypto Developers
+Copyright (c) 2018-2025 RustCrypto Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/ecdsa/LICENSE-MIT
+++ b/ecdsa/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2018-2022 RustCrypto Developers
+Copyright (c) 2018-2025 RustCrypto Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated


### PR DESCRIPTION
Update the copyright year to 2025. It is similar to what was done in [commit 801e2ee](https://github.com/RustCrypto/signatures/commit/801e2eeb40778b46394b9edefb16a56ca4ab9e25#diff-970e79e821bd39d53f732dc6925ef11ba3b6ffdafa52a0f8c47eb836306f49b4)