### PR TITLE
ml-dsa: cargo build --benches in github workflow

### DIFF
--- a/.github/workflows/ml-dsa.yml
+++ b/.github/workflows/ml-dsa.yml
@@ -30,5 +30,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
+      - run: cargo build --benches
+      - run: cargo build --benches --all-features
       - run: cargo test --release
       - run: cargo test --all-features --release


### PR DESCRIPTION
This is something to consider after #921 lands. It makes sure the benchmarks can build against the current code.