### PR TITLE
slh-dsa: fix benchmark to also run verify_benches()

### DIFF
--- a/.github/workflows/slh-dsa.yml
+++ b/.github/workflows/slh-dsa.yml
@@ -59,6 +59,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
       - uses: taiki-e/install-action@nextest
       - run: cargo check --all-features
+      - run: cargo build --benches --all-features
       - name: Build and archive tests
         run: |
           PROFILE="${{ matrix.test_config }}"

--- a/slh-dsa/benches/sign_verify.rs
+++ b/slh-dsa/benches/sign_verify.rs
@@ -38,10 +38,10 @@ criterion_group!(name = sign_benches;
 
 criterion_group!(name = verify_benches;
     config = Criterion::default().sample_size(10);
-    targets = sign_benchmark<Shake128s>, sign_benchmark<Shake192s>, sign_benchmark<Shake256s>,
-              sign_benchmark<Shake128f>, sign_benchmark<Shake192f>, sign_benchmark<Shake256f>,
-              sign_benchmark<Sha2_128s>, sign_benchmark<Sha2_192s>, sign_benchmark<Sha2_256s>,
-              sign_benchmark<Sha2_128f>, sign_benchmark<Sha2_192f>, sign_benchmark<Sha2_256f>,
+    targets = verify_benchmark<Shake128s>, verify_benchmark<Shake192s>, verify_benchmark<Shake256s>,
+              verify_benchmark<Shake128f>, verify_benchmark<Shake192f>, verify_benchmark<Shake256f>,
+              verify_benchmark<Sha2_128s>, verify_benchmark<Sha2_192s>, verify_benchmark<Sha2_256s>,
+              verify_benchmark<Sha2_128f>, verify_benchmark<Sha2_192f>, verify_benchmark<Sha2_256f>,
 );
 
 criterion_main!(sign_benches, verify_benches);


### PR DESCRIPTION
The sign_verify.rs benchmark was running the signing benchmarks twice. This fixes that so the verification benchmarks are also run.