### PR TITLE
ml-dsa: cargo test with --no-default-features in workflow

### DIFF
--- a/.github/workflows/ml-dsa.yml
+++ b/.github/workflows/ml-dsa.yml
@@ -34,3 +34,4 @@ jobs:
       - run: cargo build --benches --all-features
       - run: cargo test --release
       - run: cargo test --all-features --release
+      - run: cargo test --no-default-features --release

--- a/.github/workflows/ml-dsa.yml
+++ b/.github/workflows/ml-dsa.yml
@@ -35,3 +35,4 @@ jobs:
       - run: cargo test --release
       - run: cargo test --all-features --release
       - run: cargo test --no-default-features --lib --tests --release
+      - run: cargo test --no-default-features --features alloc --lib --tests --release

--- a/.github/workflows/ml-dsa.yml
+++ b/.github/workflows/ml-dsa.yml
@@ -34,5 +34,5 @@ jobs:
       - run: cargo build --benches --all-features
       - run: cargo test --release
       - run: cargo test --all-features --release
-      - run: cargo test --no-default-features --lib --tests --release
-      - run: cargo test --no-default-features --features alloc --lib --tests --release
+      - run: cargo test --no-default-features --release
+      - run: cargo test --no-default-features --features alloc --lib --release

--- a/.github/workflows/ml-dsa.yml
+++ b/.github/workflows/ml-dsa.yml
@@ -34,4 +34,4 @@ jobs:
       - run: cargo build --benches --all-features
       - run: cargo test --release
       - run: cargo test --all-features --release
-      - run: cargo test --no-default-features --release
+      - run: cargo test --no-default-features --lib --tests --release

--- a/ml-dsa/Cargo.toml
+++ b/ml-dsa/Cargo.toml
@@ -28,7 +28,7 @@ exclude = [
 default = ["rand_core", "alloc", "pkcs8"]
 zeroize = ["dep:zeroize", "hybrid-array/zeroize"]
 rand_core = ["dep:rand_core", "signature/rand_core"]
-alloc = ["pkcs8/alloc"]
+alloc = ["pkcs8", "pkcs8/alloc"]
 pkcs8 = ["dep:const-oid", "dep:pkcs8"]
 
 [dependencies]

--- a/ml-dsa/Cargo.toml
+++ b/ml-dsa/Cargo.toml
@@ -28,7 +28,7 @@ exclude = [
 default = ["rand_core", "alloc", "pkcs8"]
 zeroize = ["dep:zeroize", "hybrid-array/zeroize"]
 rand_core = ["dep:rand_core", "signature/rand_core"]
-alloc = ["pkcs8"]
+alloc = ["pkcs8/alloc"]
 pkcs8 = ["dep:const-oid", "dep:pkcs8"]
 
 [dependencies]

--- a/ml-dsa/Cargo.toml
+++ b/ml-dsa/Cargo.toml
@@ -28,7 +28,7 @@ exclude = [
 default = ["rand_core", "alloc", "pkcs8"]
 zeroize = ["dep:zeroize", "hybrid-array/zeroize"]
 rand_core = ["dep:rand_core", "signature/rand_core"]
-alloc = ["pkcs8?/alloc"]
+alloc = ["pkcs8"]
 pkcs8 = ["dep:const-oid", "dep:pkcs8"]
 
 [dependencies]

--- a/ml-dsa/src/lib.rs
+++ b/ml-dsa/src/lib.rs
@@ -184,6 +184,7 @@ pub struct KeyPair<P: MlDsaParams> {
     verifying_key: VerifyingKey<P>,
 
     /// The seed this signing key was derived from
+    #[allow(dead_code)]
     seed: B32,
 }
 

--- a/ml-dsa/src/lib.rs
+++ b/ml-dsa/src/lib.rs
@@ -184,7 +184,7 @@ pub struct KeyPair<P: MlDsaParams> {
     verifying_key: VerifyingKey<P>,
 
     /// The seed this signing key was derived from
-    #[allow(dead_code)]
+    #[cfg(feature = "pkcs8")]
     seed: B32,
 }
 
@@ -838,6 +838,7 @@ where
         KeyPair {
             signing_key,
             verifying_key,
+            #[cfg(feature = "pkcs8")]
             seed: xi.clone(),
         }
     }

--- a/ml-dsa/src/lib.rs
+++ b/ml-dsa/src/lib.rs
@@ -45,11 +45,11 @@ mod module_lattice;
 
 use core::convert::{AsRef, TryFrom, TryInto};
 use hybrid_array::{
-    typenum::{
-        Diff, Length, Prod, Quot, Shleft, Unsigned, U1, U17, U19, U2, U32, U4, U48, U5, U55, U6,
-        U64, U7, U75, U8, U80, U88,
-    },
     Array,
+    typenum::{
+        Diff, Length, Prod, Quot, Shleft, U1, U2, U4, U5, U6, U7, U8, U17, U19, U32, U48, U55, U64,
+        U75, U80, U88, Unsigned,
+    },
 };
 
 #[cfg(feature = "rand_core")]
@@ -62,20 +62,20 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 use {
     const_oid::db::fips204,
     pkcs8::{
+        AlgorithmIdentifierRef, PrivateKeyInfoRef,
         der::{self, AnyRef},
         spki::{
             self, AlgorithmIdentifier, AssociatedAlgorithmIdentifier, SignatureAlgorithmIdentifier,
             SubjectPublicKeyInfoRef,
         },
-        AlgorithmIdentifierRef, PrivateKeyInfoRef,
     },
 };
 
 #[cfg(all(feature = "alloc", feature = "pkcs8"))]
 use pkcs8::{
+    EncodePrivateKey, EncodePublicKey,
     der::asn1::{BitString, BitStringRef, OctetStringRef},
     spki::{SignatureBitStringEncoding, SubjectPublicKeyInfo},
-    EncodePrivateKey, EncodePublicKey,
 };
 
 use crate::algebra::{AlgebraExt, Elem, NttMatrix, NttVector, Truncate, Vector};

--- a/ml-dsa/src/lib.rs
+++ b/ml-dsa/src/lib.rs
@@ -19,7 +19,7 @@
 //! ```
 //! use ml_dsa::{MlDsa65, KeyGen, signature::{Keypair, Signer, Verifier}};
 //!
-//! let mut rng = rand::thread_rng();
+//! let mut rng = rand::rng();
 //! let kp = MlDsa65::key_gen(&mut rng);
 //!
 //! let msg = b"Hello world";


### PR DESCRIPTION
The CI workflow should build/test with --no-default-features to catch any issues with that configuration.

There is currently 1 warning when building ml-dsa with --no-default-features, and 1 failing doc-test. I'll fix those in upcoming commits, but I first want to run this though the CI to make sure it fails as expected.