### PR TITLE
slh-dsa v0.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "slh-dsa"
-version = "0.2.0-pre"
+version = "0.0.3"
 dependencies = [
  "aes",
  "cipher",

--- a/slh-dsa/CHANGELOG.md
+++ b/slh-dsa/CHANGELOG.md
@@ -17,5 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#845]: https://github.com/RustCrypto/signatures/pull/845
 [#847]: https://github.com/RustCrypto/signatures/pull/847
 
-## 0.0.2 (2024-05-31)
+## 0.0.3 (2025-05-10)
+- Backport release with legacy `signature` v2 support
+
+## 0.0.2 (2024-05-31) [YANKED]
 - Initial release

--- a/slh-dsa/Cargo.toml
+++ b/slh-dsa/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Pure Rust implementation of SLH-DSA (aka SPHINCS+) as described in the
 FIPS-205 standard
 """
-version = "0.2.0-pre"
+version = "0.0.3"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"
@@ -13,6 +13,7 @@ repository = "https://github.com/RustCrypto/signatures"
 readme = "README.md"
 categories = ["cryptography"]
 keywords = ["crypto", "signature"]
+exclude = ["tests"]
 
 [dependencies]
 hybrid-array = { version = "0.3", features = ["extra-sizes"] }


### PR DESCRIPTION
Backport release with a looser `signature` v2 dependency