### PR TITLE
Revert "downgrade ml-dsa and slh-dsa to non-prerelease deps"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aes"
-version = "0.8.4"
+version = "0.9.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+checksum = "e7856582c758ade85d71daf27ec6bcea6c1c73913692b07b8dffea2dc03531c9"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -41,10 +41,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bit-set"
@@ -75,11 +90,11 @@ checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.11.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "a229bfd78e4827c91b9b95784f69492c1b77c1ab75a45a8a037b139215086f94"
 dependencies = [
- "generic-array",
+ "hybrid-array 0.3.0",
 ]
 
 [[package]]
@@ -135,9 +150,9 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
+version = "0.5.0-pre.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "5b1425e6ce000f05a73096556cabcfb6a10a3ffe3bb4d75416ca8f00819c0b6a"
 dependencies = [
  "crypto-common",
  "inout",
@@ -170,9 +185,9 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "const-oid"
-version = "0.9.6"
+version = "0.10.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+checksum = "68ff6be19477a1bd5441f382916a89bc2a0b2c35db6d41e0f6e8538bf6d6463f"
 
 [[package]]
 name = "cpufeatures"
@@ -251,29 +266,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
-name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+name = "crypto-bigint"
+version = "0.7.0-pre"
+source = "git+https://github.com/RustCrypto/crypto-bigint.git#534c2940b1f0aa9ec8ada964ce654cc0e6e1e7bb"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array 0.2.3",
+ "num-traits",
+ "rand_core 0.9.2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170d71b5b14dec99db7739f6fc7d6ec2db80b78c3acb77db48392ccc3d8a9ea0"
+dependencies = [
+ "hybrid-array 0.3.0",
 ]
 
 [[package]]
 name = "ctr"
-version = "0.9.2"
+version = "0.10.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+checksum = "77e1482d284b80d7fddb211666d513dc5e23b0cc3a03ad398ff70543827c789f"
 dependencies = [
  "cipher",
 ]
 
 [[package]]
 name = "der"
-version = "0.7.9"
+version = "0.8.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+checksum = "82db698b33305f0134faf590b9d1259dc171b5481ac41d5c8146c3b3ee7d4319"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -282,13 +308,56 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.0-pre.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "6c478574b20020306f98d61c8ca3322d762e1ff08117422ac6106438605ea516"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.17.0-pre.9"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "hex-literal 1.0.0",
+ "rfc6979",
+ "serdect",
+ "sha2",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.3.0-pre.0"
+dependencies = [
+ "bincode",
+ "hex-literal 1.0.0",
+ "pkcs8",
+ "rand_core 0.9.2",
+ "serde",
+ "serde_bytes",
+ "signature",
+ "zeroize",
+]
+
+[[package]]
+name = "ed448-signature"
+version = "0.0.0"
+dependencies = [
+ "bincode",
+ "hex-literal 1.0.0",
+ "pkcs8",
+ "serde",
+ "serde_bytes",
+ "signature",
+ "zeroize",
 ]
 
 [[package]]
@@ -296,6 +365,27 @@ name = "either"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.14.0-rc.1"
+source = "git+https://github.com/RustCrypto/traits.git#27835aa66710bded06caef143284892dda83dda5"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "group",
+ "hex-literal 1.0.0",
+ "hybrid-array 0.3.0",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.9.2",
+ "sec1",
+ "serdect",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "env_logger"
@@ -324,20 +414,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
+name = "ff"
+version = "0.13.0"
+source = "git+https://github.com/zkcrypto/ff.git?branch=release-0.14.0#1bb634588722b1b7ce986d239c263e332bedda7f"
+dependencies = [
+ "rand_core 0.9.2",
+ "subtle",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
 
 [[package]]
 name = "getrandom"
@@ -347,7 +436,29 @@ checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "git+https://github.com/pinkforest/group.git?branch=bump-rand-0.9#06ac6fb11ced26fbf980ee65e74fced4da66ec3e"
+dependencies = [
+ "ff",
+ "rand_core 0.9.2",
+ "subtle",
 ]
 
 [[package]]
@@ -377,17 +488,32 @@ dependencies = [
 
 [[package]]
 name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
+name = "hex-literal"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcaaec4551594c969335c98c903c1397853d4198408ea609190f420500f6be71"
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "62c11fc82c6b89c906b4d26b7b5a305d0b3aebd4b458dd1bd0a7ed98c548a28e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2d35805454dc9f8662a98d6d61886ffe26bd465f5960e0e55345c70d5c0d2a9"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -402,11 +528,11 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.4"
+version = "0.2.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "ac5e145e8ade9f74c0a5efc60ccb4e714b0144f7e2220b7ca64254feee71c57f"
 dependencies = [
- "generic-array",
+ "hybrid-array 0.3.0",
 ]
 
 [[package]]
@@ -446,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.5"
+version = "0.2.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+checksum = "a7cdd4f0dc5807b9a2b25dd48a3f58e862606fe7bd47f41ecde36e97422d7e90"
 dependencies = [
  "cpufeatures",
 ]
@@ -478,6 +604,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
+name = "lms-signature"
+version = "0.1.0-pre"
+dependencies = [
+ "digest",
+ "hex",
+ "hex-literal 0.4.1",
+ "hybrid-array 0.3.0",
+ "rand 0.9.0",
+ "rand_core 0.9.2",
+ "sha2",
+ "signature",
+ "static_assertions",
+ "typenum",
+ "zeroize",
+]
+
+[[package]]
 name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,18 +634,18 @@ checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "ml-dsa"
-version = "0.0.4"
+version = "0.1.0-pre.2"
 dependencies = [
  "const-oid",
  "criterion",
  "hex",
- "hex-literal",
- "hybrid-array",
+ "hex-literal 1.0.0",
+ "hybrid-array 0.3.0",
  "num-traits",
  "pkcs8",
  "proptest",
- "rand",
- "rand_core",
+ "rand 0.9.0",
+ "rand_core 0.9.2",
  "serde",
  "serde_json",
  "sha3",
@@ -559,18 +702,18 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.7.0"
+version = "1.0.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+checksum = "c2dfbfa5c6f0906884269722c5478e72fd4d6c0e24fe600332c6d62359567ce1"
 dependencies = [
  "base64ct",
 ]
 
 [[package]]
 name = "pkcs8"
-version = "0.10.2"
+version = "0.11.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+checksum = "f22636de7c995e997ed3d8d2949b7414d4faba3efa7312a6c0e75d875a14bdd4"
 dependencies = [
  "der",
  "spki",
@@ -630,8 +773,8 @@ dependencies = [
  "bitflags 2.5.0",
  "lazy_static",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -653,7 +796,7 @@ checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
 dependencies = [
  "env_logger",
  "log",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -683,8 +826,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.2",
+ "zerocopy 0.8.20",
 ]
 
 [[package]]
@@ -694,7 +848,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.2",
 ]
 
 [[package]]
@@ -703,7 +867,17 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.11",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a509b1a2ffbe92afab0e55c8fd99dea1c280e8171bd2d88682bb20bc41cbc2c"
+dependencies = [
+ "getrandom 0.3.1",
+ "zerocopy 0.8.20",
 ]
 
 [[package]]
@@ -712,7 +886,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -774,6 +948,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
+name = "rfc6979"
+version = "0.5.0-pre.4"
+dependencies = [
+ "hex-literal 1.0.0",
+ "hmac",
+ "sha2",
+ "subtle",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -814,12 +998,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "sec1"
+version = "0.8.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a017a4aa8f0bd51e9d0184d98042dfe9285218fec098493f47d9a8aa0f1a3f27"
+dependencies = [
+ "base16ct",
+ "der",
+ "hybrid-array 0.3.0",
+ "pkcs8",
+ "serdect",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -846,10 +1054,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.10.8"
+name = "serdect"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "f42f67da2385b51a5f9652db9c93d78aeaf7610bf5ec366080b6de810604af53"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0-pre.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b4241d1a56954dce82cecda5c8e9c794eef6f53abe5e5216bac0a0ea71ffa7"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -858,9 +1076,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.8"
+version = "0.11.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "f1bc997d7a5fa67cc1e352b2001124d28edb948b4e7a16567f9b3c1e51952524"
 dependencies = [
  "digest",
  "keccak",
@@ -868,16 +1086,16 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+version = "2.3.0-pre.6"
+source = "git+https://github.com/RustCrypto/traits.git#27835aa66710bded06caef143284892dda83dda5"
 dependencies = [
- "rand_core",
+ "digest",
+ "rand_core 0.9.2",
 ]
 
 [[package]]
 name = "slh-dsa"
-version = "0.0.3"
+version = "0.2.0-pre"
 dependencies = [
  "aes",
  "cipher",
@@ -886,35 +1104,41 @@ dependencies = [
  "ctr",
  "digest",
  "hex",
- "hex-literal",
+ "hex-literal 1.0.0",
  "hmac",
- "hybrid-array",
+ "hybrid-array 0.3.0",
  "num-bigint",
  "paste",
  "pkcs8",
  "proptest",
  "quickcheck",
  "quickcheck_macros",
- "rand",
- "rand_core",
+ "rand 0.9.0",
+ "rand_core 0.9.2",
  "serde",
  "serde_json",
  "sha2",
  "sha3",
  "signature",
  "typenum",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
 name = "spki"
-version = "0.7.3"
+version = "0.8.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+checksum = "ee3fb1c675852398475928637b3ebbdd7e1d0cc24d27b3bbc81788b4eb51e310"
 dependencies = [
  "base64ct",
  "der",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "subtle"
@@ -986,12 +1210,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
 name = "wait-timeout"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1015,6 +1233,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1178,13 +1405,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags 2.5.0",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde3bb8c68a8f3f1ed4ac9221aad6b10cece3e60a8e2ea54a6a2dec806d0084c"
+dependencies = [
+ "zerocopy-derive 0.8.20",
 ]
 
 [[package]]
@@ -1199,47 +1444,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerocopy-derive"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea57037071898bf96a6da35fd626f4f27e9cee3ead2a6c703cf09d472b2e700"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
-
-[[patch.unused]]
-name = "crypto-bigint"
-version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/crypto-bigint.git#534c2940b1f0aa9ec8ada964ce654cc0e6e1e7bb"
-
-[[patch.unused]]
-name = "ecdsa"
-version = "0.17.0-pre.9"
-
-[[patch.unused]]
-name = "ed25519"
-version = "2.3.0-pre.0"
-
-[[patch.unused]]
-name = "ed448-signature"
-version = "0.0.0"
-
-[[patch.unused]]
-name = "elliptic-curve"
-version = "0.14.0-rc.1"
-source = "git+https://github.com/RustCrypto/traits.git#27835aa66710bded06caef143284892dda83dda5"
-
-[[patch.unused]]
-name = "ff"
-version = "0.13.0"
-source = "git+https://github.com/zkcrypto/ff.git?branch=release-0.14.0#1bb634588722b1b7ce986d239c263e332bedda7f"
-
-[[patch.unused]]
-name = "group"
-version = "0.13.0"
-source = "git+https://github.com/pinkforest/group.git?branch=bump-rand-0.9#06ac6fb11ced26fbf980ee65e74fced4da66ec3e"
-
-[[patch.unused]]
-name = "lms-signature"
-version = "0.1.0-pre"
-
-[[patch.unused]]
-name = "rfc6979"
-version = "0.5.0-pre.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,22 +1,17 @@
 [workspace]
 resolver = "2"
 members = [
-    # "dsa",
-    # "ecdsa",
-    # "ed448",
-    # "ed25519",
-    # "lms",
+    #"dsa",
+    "ecdsa",
+    "ed448",
+    "ed25519",
+    "lms",
     "ml-dsa",
-    # "rfc6979",
+    "rfc6979",
     "slh-dsa",
 ]
 exclude = [
-  "dsa", # still on rand_core 0.8
-  "ecdsa",
-  "ed448",
-  "ed25519",
-  "lms",
-  "rfc6979",
+    "dsa", # still on rand_core 0.8
 ]
 
 [profile.dev]
@@ -38,7 +33,7 @@ slh-dsa         = { path = "./slh-dsa" }
 # https://github.com/RustCrypto/traits/pull/1767
 # https://github.com/RustCrypto/traits/pull/1774
 elliptic-curve = { git = "https://github.com/RustCrypto/traits.git" }
-# signature      = { git = "https://github.com/RustCrypto/traits.git" }
+signature      = { git = "https://github.com/RustCrypto/traits.git" }
 
 # https://github.com/RustCrypto/crypto-bigint/pull/762
 # https://github.com/RustCrypto/crypto-bigint/pull/765

--- a/ml-dsa/Cargo.toml
+++ b/ml-dsa/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Pure Rust implementation of ML-DSA (formerly known as CRYSTALS-Dilithium) as
 described in FIPS-204 (final)
 """
-version = "0.0.4"
+version = "0.1.0-pre.2"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"
@@ -34,21 +34,21 @@ pkcs8 = ["dep:const-oid", "dep:pkcs8"]
 [dependencies]
 hybrid-array = { version = "0.3", features = ["extra-sizes"] }
 num-traits = "0.2.19"
-rand_core = { version = "0.6", optional = true }
-sha3 = "0.10.0"
-signature = "2.2.0"
+rand_core = { version = "0.9", optional = true }
+sha3 = "=0.11.0-pre.5"
+signature = "=2.3.0-pre.6"
 zeroize = { version = "1.8.1", optional = true, default-features = false }
 
-const-oid = { version = "0.9", features = ["db"], optional = true }
-pkcs8 = { version = "0.10", default-features = false, optional = true }
+const-oid = { version = "0.10.0-rc.1", features = ["db"], optional = true }
+pkcs8 = { version = "0.11.0-rc.2", default-features = false, optional = true }
 
 [dev-dependencies]
 criterion = "0.5.1"
 hex = { version = "0.4.3", features = ["serde"] }
 hex-literal = "1"
-pkcs8 = { version = "0.10.0", features = ["pem"] }
+pkcs8 = { version = "0.11.0-rc.2", features = ["pem"] }
 proptest = "1"
-rand = "0.8"
+rand = "0.9"
 serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.132"
 

--- a/ml-dsa/benches/ml_dsa.rs
+++ b/ml-dsa/benches/ml_dsa.rs
@@ -1,16 +1,16 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use hybrid_array::{Array, ArraySize};
 use ml_dsa::{B32, KeyGen, MlDsa65, Signature, SigningKey, VerifyingKey};
-use rand::{CryptoRng, RngCore};
+use rand::CryptoRng;
 
-pub fn rand<L: ArraySize, R: RngCore + CryptoRng + ?Sized>(rng: &mut R) -> Array<u8, L> {
+pub fn rand<L: ArraySize, R: CryptoRng + ?Sized>(rng: &mut R) -> Array<u8, L> {
     let mut val = Array::<u8, L>::default();
     rng.fill_bytes(&mut val);
     val
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    let mut rng = rand::rngs::OsRng;
+    let mut rng = rand::rng();
     let xi: B32 = rand(&mut rng);
     let m: B32 = rand(&mut rng);
     let ctx: B32 = rand(&mut rng);

--- a/ml-dsa/src/encode.rs
+++ b/ml-dsa/src/encode.rs
@@ -150,9 +150,9 @@ pub(crate) mod test {
         assert_eq!(actual_decoded, *decoded);
 
         // Test random decode/encode and encode/decode round trips
-        let mut rng = rand::rngs::OsRng;
+        let mut rng = rand::rng();
         let decoded = Polynomial::new(Array::from_fn(|_| {
-            let x: u32 = rng.r#gen();
+            let x: u32 = rng.random();
             Elem::new(x % (b + 1))
         }));
 
@@ -223,9 +223,9 @@ pub(crate) mod test {
         assert_eq!(actual_decoded, *decoded);
 
         // Test random decode/encode and encode/decode round trips
-        let mut rng = rand::rngs::OsRng;
+        let mut rng = rand::rng();
         let decoded = Polynomial::new(Array::from_fn(|_| {
-            let mut x: u32 = rng.r#gen();
+            let mut x: u32 = rng.random();
             x %= a.0 + b.0;
             b - Elem::new(x)
         }));

--- a/slh-dsa/Cargo.toml
+++ b/slh-dsa/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Pure Rust implementation of SLH-DSA (aka SPHINCS+) as described in the
 FIPS-205 standard
 """
-version = "0.0.3"
+version = "0.2.0-pre"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"
@@ -18,15 +18,15 @@ exclude = ["tests"]
 [dependencies]
 hybrid-array = { version = "0.3", features = ["extra-sizes"] }
 typenum = { version = "1.17.0", features = ["const-generics"] }
-sha3 = { version = "0.10", default-features = false }
+sha3 = { version = "=0.11.0-pre.5", default-features = false }
 zerocopy = { version = "0.7.34", features = ["derive"] }
-rand_core = { version = "0.6" }
-signature = { version = "2.2", features = ["rand_core"] }
-hmac = "0.12"
-sha2 = { version = "0.10", default-features = false }
-digest = "0.10"
-pkcs8 = { version = "0.10", default-features = false }
-const-oid = { version = "0.9", features = ["db"] }
+rand_core = { version = "0.9.2" }
+signature = { version = "=2.3.0-pre.6", features = ["rand_core"] }
+hmac = "=0.13.0-pre.5"
+sha2 = { version = "=0.11.0-pre.5", default-features = false }
+digest = "=0.11.0-pre.10"
+pkcs8 = { version = "0.11.0-rc.1", default-features = false }
+const-oid = { version = "0.10.0-rc.1", features = ["db"] }
 
 [dev-dependencies]
 hex-literal = "1"
@@ -36,15 +36,15 @@ quickcheck = "1"
 quickcheck_macros = "1"
 proptest = "1.4.0"
 criterion = "0.5"
-aes = "0.8.0"
-cipher = "0.4"
-ctr = "0.9"
-rand_core = "0.6"
+aes = "=0.9.0-pre.2"
+cipher = "=0.5.0-pre.7"
+ctr = "=0.10.0-pre.2"
+rand_core = "0.9.2"
 paste = "1.0.15"
-rand = "0.8"
+rand = "0.9"
 serde_json = "1.0.124"
 serde = { version = "1.0.207", features = ["derive"] }
-pkcs8 = { version = "0.10", features = ["pem"] }
+pkcs8 = { version = "0.11.0-rc.1", features = ["pem"] }
 
 [lib]
 bench = false

--- a/slh-dsa/benches/sign_verify.rs
+++ b/slh-dsa/benches/sign_verify.rs
@@ -3,7 +3,7 @@ use signature::{Keypair, Signer, Verifier};
 use slh_dsa::*;
 
 pub fn sign_benchmark<P: ParameterSet>(c: &mut Criterion) {
-    let mut rng = rand::rngs::OsRng;
+    let mut rng = rand::rng();
     let sk = SigningKey::<P>::new(&mut rng);
     c.bench_function(&format!("sign: {}", P::NAME), |b| {
         b.iter(|| {
@@ -15,7 +15,7 @@ pub fn sign_benchmark<P: ParameterSet>(c: &mut Criterion) {
 }
 
 pub fn verify_benchmark<P: ParameterSet>(c: &mut Criterion) {
-    let mut rng = rand::rngs::OsRng;
+    let mut rng = rand::rng();
     let sk = SigningKey::<P>::new(&mut rng);
     let msg = b"Hello, world!";
     let sig = sk.try_sign(msg).unwrap();

--- a/slh-dsa/src/fors.rs
+++ b/slh-dsa/src/fors.rs
@@ -217,7 +217,7 @@ mod tests {
     use crate::Shake128f;
     use crate::util::macros::test_parameter_sets;
 
-    use rand::{Rng, RngCore};
+    use rand::{Rng, RngCore, rng};
 
     use super::*;
 
@@ -472,7 +472,7 @@ mod tests {
 
     fn test_sign_verify<Fors: ForsParams>() {
         // Generate random sk_seed, pk_seed, message, index, address
-        let mut rng = rand::rngs::OsRng;
+        let mut rng = rng();
 
         let sk_seed = SkSeed::new(&mut rng);
 
@@ -481,12 +481,12 @@ mod tests {
         let mut msg = Array::<u8, Fors::MD>::default();
         rng.fill_bytes(msg.as_mut_slice());
 
-        let idx_tree = rng.gen_range(
+        let idx_tree = rng.random_range(
             0..=(1u64
                 .wrapping_shl(Fors::H::U32 - Fors::HPrime::U32)
                 .wrapping_sub(1)),
         );
-        let idx_leaf = rng.gen_range(0..(1 << (Fors::HPrime::USIZE)));
+        let idx_leaf = rng.random_range(0..(1 << (Fors::HPrime::USIZE)));
 
         let mut adrs = ForsTree::new(idx_tree, idx_leaf);
         let mut pks = Array::<Array<u8, Fors::N>, Fors::K>::default();
@@ -505,7 +505,7 @@ mod tests {
 
     fn test_sign_verify_failure<Fors: ForsParams>() {
         // Generate random sk_seed, pk_seed, message, index, address
-        let mut rng = rand::rngs::OsRng;
+        let mut rng = rng();
 
         let sk_seed = SkSeed::new(&mut rng);
 
@@ -514,12 +514,12 @@ mod tests {
         let mut msg = Array::<u8, Fors::MD>::default();
         rng.fill_bytes(msg.as_mut_slice());
 
-        let idx_tree = rng.gen_range(
+        let idx_tree = rng.random_range(
             0..=(1u64
                 .wrapping_shl(Fors::H::U32 - Fors::HPrime::U32)
                 .wrapping_sub(1)),
         );
-        let idx_leaf = rng.gen_range(0..(1 << (Fors::HPrime::USIZE)));
+        let idx_leaf = rng.random_range(0..(1 << (Fors::HPrime::USIZE)));
 
         let mut adrs = ForsTree::new(idx_tree, idx_leaf);
         let mut pks = Array::<Array<u8, Fors::N>, Fors::K>::default();

--- a/slh-dsa/src/hashes/sha2.rs
+++ b/slh-dsa/src/hashes/sha2.rs
@@ -9,6 +9,7 @@ use crate::{
     xmss::XmssParams,
 };
 use crate::{PkSeed, SkPrf, SkSeed};
+use const_oid::db::fips205;
 use digest::{Digest, KeyInit, Mac};
 use hmac::Hmac;
 use hybrid_array::{Array, ArraySize};
@@ -62,7 +63,7 @@ where
         opt_rand: &Array<u8, Self::N>,
         msg: &[impl AsRef<[u8]>],
     ) -> Array<u8, Self::N> {
-        let mut mac = <Hmac<Sha256> as KeyInit>::new_from_slice(sk_prf.as_ref()).unwrap();
+        let mut mac = Hmac::<Sha256>::new_from_slice(sk_prf.as_ref()).unwrap();
         mac.update(opt_rand.as_slice());
         msg.iter()
             .for_each(|msg_part| mac.update(msg_part.as_ref()));
@@ -169,8 +170,7 @@ impl ForsParams for Sha2_128s {
 }
 impl ParameterSet for Sha2_128s {
     const NAME: &'static str = "SLH-DSA-SHA2-128s";
-    const ALGORITHM_OID: pkcs8::ObjectIdentifier =
-        pkcs8::ObjectIdentifier::new_unwrap("2.16.840.1.101.3.4.3.20");
+    const ALGORITHM_OID: pkcs8::ObjectIdentifier = fips205::ID_SLH_DSA_SHA_2_128_S;
 }
 
 /// SHA2 at L1 security with fast signatures
@@ -193,8 +193,7 @@ impl ForsParams for Sha2_128f {
 }
 impl ParameterSet for Sha2_128f {
     const NAME: &'static str = "SLH-DSA-SHA2-128f";
-    const ALGORITHM_OID: pkcs8::ObjectIdentifier =
-        pkcs8::ObjectIdentifier::new_unwrap("2.16.840.1.101.3.4.3.21");
+    const ALGORITHM_OID: pkcs8::ObjectIdentifier = fips205::ID_SLH_DSA_SHA_2_128_F;
 }
 
 /// Implementation of the component hash functions using SHA2 at Security Category 3 and 5
@@ -227,7 +226,7 @@ where
         opt_rand: &Array<u8, Self::N>,
         msg: &[impl AsRef<[u8]>],
     ) -> Array<u8, Self::N> {
-        let mut mac = <Hmac<Sha512> as KeyInit>::new_from_slice(sk_prf.as_ref()).unwrap();
+        let mut mac = Hmac::<Sha512>::new_from_slice(sk_prf.as_ref()).unwrap();
         mac.update(opt_rand.as_slice());
         msg.iter()
             .for_each(|msg_part| mac.update(msg_part.as_ref()));
@@ -334,8 +333,7 @@ impl ForsParams for Sha2_192s {
 }
 impl ParameterSet for Sha2_192s {
     const NAME: &'static str = "SLH-DSA-SHA2-192s";
-    const ALGORITHM_OID: pkcs8::ObjectIdentifier =
-        pkcs8::ObjectIdentifier::new_unwrap("2.16.840.1.101.3.4.3.22");
+    const ALGORITHM_OID: pkcs8::ObjectIdentifier = fips205::ID_SLH_DSA_SHA_2_192_S;
 }
 
 /// SHA2 at L3 security with fast signatures
@@ -358,8 +356,7 @@ impl ForsParams for Sha2_192f {
 }
 impl ParameterSet for Sha2_192f {
     const NAME: &'static str = "SLH-DSA-SHA2-192f";
-    const ALGORITHM_OID: pkcs8::ObjectIdentifier =
-        pkcs8::ObjectIdentifier::new_unwrap("2.16.840.1.101.3.4.3.23");
+    const ALGORITHM_OID: pkcs8::ObjectIdentifier = fips205::ID_SLH_DSA_SHA_2_192_F;
 }
 
 /// SHA2 at L5 security with small signatures
@@ -382,8 +379,7 @@ impl ForsParams for Sha2_256s {
 }
 impl ParameterSet for Sha2_256s {
     const NAME: &'static str = "SLH-DSA-SHA2-256s";
-    const ALGORITHM_OID: pkcs8::ObjectIdentifier =
-        pkcs8::ObjectIdentifier::new_unwrap("2.16.840.1.101.3.4.3.24");
+    const ALGORITHM_OID: pkcs8::ObjectIdentifier = fips205::ID_SLH_DSA_SHA_2_256_S;
 }
 
 /// SHA2 at L5 security with fast signatures
@@ -406,6 +402,5 @@ impl ForsParams for Sha2_256f {
 }
 impl ParameterSet for Sha2_256f {
     const NAME: &'static str = "SLH-DSA-SHA2-256f";
-    const ALGORITHM_OID: pkcs8::ObjectIdentifier =
-        pkcs8::ObjectIdentifier::new_unwrap("2.16.840.1.101.3.4.3.25");
+    const ALGORITHM_OID: pkcs8::ObjectIdentifier = fips205::ID_SLH_DSA_SHA_2_256_F;
 }

--- a/slh-dsa/src/hashes/shake.rs
+++ b/slh-dsa/src/hashes/shake.rs
@@ -7,6 +7,7 @@ use crate::hypertree::HypertreeParams;
 use crate::wots::WotsParams;
 use crate::xmss::XmssParams;
 use crate::{ParameterSet, PkSeed, SkPrf, SkSeed};
+use const_oid::db::fips205;
 use digest::{ExtendableOutput, Update};
 use hybrid_array::typenum::consts::{U16, U30, U32};
 use hybrid_array::typenum::{U24, U34, U39, U42, U47, U49};
@@ -146,8 +147,7 @@ impl ForsParams for Shake128s {
 }
 impl ParameterSet for Shake128s {
     const NAME: &'static str = "SLH-DSA-SHAKE-128s";
-    const ALGORITHM_OID: pkcs8::ObjectIdentifier =
-        pkcs8::ObjectIdentifier::new_unwrap("2.16.840.1.101.3.4.3.26");
+    const ALGORITHM_OID: pkcs8::ObjectIdentifier = fips205::ID_SLH_DSA_SHAKE_128_S;
 }
 
 /// SHAKE256 at L1 security with fast signatures
@@ -170,8 +170,7 @@ impl ForsParams for Shake128f {
 }
 impl ParameterSet for Shake128f {
     const NAME: &'static str = "SLH-DSA-SHAKE-128f";
-    const ALGORITHM_OID: pkcs8::ObjectIdentifier =
-        pkcs8::ObjectIdentifier::new_unwrap("2.16.840.1.101.3.4.3.27");
+    const ALGORITHM_OID: pkcs8::ObjectIdentifier = fips205::ID_SLH_DSA_SHAKE_128_F;
 }
 
 /// SHAKE256 at L3 security with small signatures
@@ -194,8 +193,7 @@ impl ForsParams for Shake192s {
 }
 impl ParameterSet for Shake192s {
     const NAME: &'static str = "SLH-DSA-SHAKE-192s";
-    const ALGORITHM_OID: pkcs8::ObjectIdentifier =
-        pkcs8::ObjectIdentifier::new_unwrap("2.16.840.1.101.3.4.3.28");
+    const ALGORITHM_OID: pkcs8::ObjectIdentifier = fips205::ID_SLH_DSA_SHAKE_192_S;
 }
 
 /// SHAKE256 at L3 security with fast signatures
@@ -218,8 +216,7 @@ impl ForsParams for Shake192f {
 }
 impl ParameterSet for Shake192f {
     const NAME: &'static str = "SLH-DSA-SHAKE-192f";
-    const ALGORITHM_OID: pkcs8::ObjectIdentifier =
-        pkcs8::ObjectIdentifier::new_unwrap("2.16.840.1.101.3.4.3.29");
+    const ALGORITHM_OID: pkcs8::ObjectIdentifier = fips205::ID_SLH_DSA_SHAKE_192_F;
 }
 
 /// SHAKE256 at L5 security with small signatures
@@ -242,8 +239,7 @@ impl ForsParams for Shake256s {
 }
 impl ParameterSet for Shake256s {
     const NAME: &'static str = "SLH-DSA-SHAKE-256s";
-    const ALGORITHM_OID: pkcs8::ObjectIdentifier =
-        pkcs8::ObjectIdentifier::new_unwrap("2.16.840.1.101.3.4.3.30");
+    const ALGORITHM_OID: pkcs8::ObjectIdentifier = fips205::ID_SLH_DSA_SHAKE_256_S;
 }
 
 /// SHAKE256 at L5 security with fast signatures
@@ -266,8 +262,7 @@ impl ForsParams for Shake256f {
 }
 impl ParameterSet for Shake256f {
     const NAME: &'static str = "SLH-DSA-SHAKE-256f";
-    const ALGORITHM_OID: pkcs8::ObjectIdentifier =
-        pkcs8::ObjectIdentifier::new_unwrap("2.16.840.1.101.3.4.3.31");
+    const ALGORITHM_OID: pkcs8::ObjectIdentifier = fips205::ID_SLH_DSA_SHAKE_256_F;
 }
 
 #[cfg(test)]

--- a/slh-dsa/src/hypertree.rs
+++ b/slh-dsa/src/hypertree.rs
@@ -132,10 +132,10 @@ mod tests {
     use super::*;
     use crate::{PkSeed, hashes::Shake128f, util::macros::test_parameter_sets};
     use hybrid_array::Array;
-    use rand::Rng;
+    use rand::{Rng, rng};
 
     fn test_ht_sign_verify<HTMode: HypertreeParams>() {
-        let mut rng = rand::rngs::OsRng;
+        let mut rng = rng();
 
         let sk_seed = SkSeed::new(&mut rng);
 
@@ -144,12 +144,12 @@ mod tests {
         let mut m = Array::<u8, HTMode::N>::default();
         rng.fill(m.as_mut_slice());
 
-        let idx_tree = rng.gen_range(
+        let idx_tree = rng.random_range(
             0..=(1u64
                 .wrapping_shl(HTMode::H::U32 - HTMode::HPrime::U32)
                 .wrapping_sub(1)),
         );
-        let idx_leaf = rng.gen_range(0..(1 << (HTMode::HPrime::USIZE)));
+        let idx_leaf = rng.random_range(0..(1 << (HTMode::HPrime::USIZE)));
 
         let mut adrs = WotsHash::default();
         adrs.tree_adrs_low.set(0);
@@ -167,7 +167,7 @@ mod tests {
     test_parameter_sets!(test_ht_sign_verify);
 
     fn test_ht_sign_verify_fail<HTMode: HypertreeParams>() {
-        let mut rng = rand::rngs::OsRng;
+        let mut rng = rng();
 
         let sk_seed = SkSeed::new(&mut rng);
 
@@ -176,12 +176,12 @@ mod tests {
         let mut m = Array::<u8, HTMode::N>::default();
         rng.fill(m.as_mut_slice());
 
-        let idx_tree = rng.gen_range(
+        let idx_tree = rng.random_range(
             0..=(1u64
                 .wrapping_shl(HTMode::H::U32 - HTMode::HPrime::U32)
                 .wrapping_sub(1)),
         );
-        let idx_leaf = rng.gen_range(0..(1 << (HTMode::HPrime::USIZE)));
+        let idx_leaf = rng.random_range(0..(1 << (HTMode::HPrime::USIZE)));
 
         let mut adrs = WotsHash::default();
         adrs.tree_adrs_low.set(0);

--- a/slh-dsa/src/lib.rs
+++ b/slh-dsa/src/lib.rs
@@ -24,7 +24,7 @@
 //! use slh_dsa::*;
 //! use signature::*;
 //!
-//! let mut rng = rand::rngs::OsRng;
+//! let mut rng = rand::rng();
 //!
 //! // Generate a signing key using the SHAKE128f parameter set
 //! let sk = SigningKey::<Shake128f>::new(&mut rng);
@@ -86,7 +86,7 @@ mod tests {
     use util::macros::test_parameter_sets;
 
     fn test_sign_verify<P: ParameterSet>() {
-        let mut rng = rand::rngs::OsRng;
+        let mut rng = rand::rng();
         let sk = SigningKey::<P>::new(&mut rng);
         let vk = sk.verifying_key();
         let msg = b"Hello, world!";
@@ -98,7 +98,7 @@ mod tests {
     // Check signature fails on modified message
     #[test]
     fn test_sign_verify_shake_128f_fail_on_modified_message() {
-        let mut rng = rand::rngs::OsRng;
+        let mut rng = rand::rng();
         let sk = SigningKey::<Shake128f>::new(&mut rng);
         let msg = b"Hello, world!";
         let modified_msg = b"Goodbye, world!";
@@ -111,7 +111,7 @@ mod tests {
 
     #[test]
     fn test_sign_verify_fail_with_wrong_verifying_key() {
-        let mut rng = rand::rngs::OsRng;
+        let mut rng = rand::rng();
         let sk = SigningKey::<Shake128f>::new(&mut rng);
         let wrong_sk = SigningKey::<Shake128f>::new(&mut rng); // Generate a different signing key
         let msg = b"Hello, world!";
@@ -125,14 +125,14 @@ mod tests {
 
     #[test]
     fn test_sign_verify_fail_on_modified_signature() {
-        let mut rng = rand::rngs::OsRng;
+        let mut rng = rand::rng();
         let sk = SigningKey::<Shake128f>::new(&mut rng);
         let msg = b"Hello, world!";
 
         let mut sig_bytes = sk.try_sign(msg).unwrap().to_bytes();
         // Randomly modify one byte in the signature
         let sig_len = sig_bytes.len();
-        let random_byte_index = rng.gen_range(0..sig_len);
+        let random_byte_index = rng.random_range(0..sig_len);
         sig_bytes[random_byte_index] ^= 0xff; // Invert one byte to ensure it's different
         let sig = (&sig_bytes).into();
 
@@ -145,7 +145,7 @@ mod tests {
 
     #[test]
     fn test_successive_signatures_not_equal() {
-        let mut rng = rand::rngs::OsRng;
+        let mut rng = rand::rng();
         let sk = SigningKey::<Shake128f>::new(&mut rng);
         let msg = b"Hello, world!";
 
@@ -160,7 +160,7 @@ mod tests {
 
     #[test]
     fn test_sign_verify_nonempty_context() {
-        let mut rng = rand::rngs::OsRng;
+        let mut rng = rand::rng();
         let sk = SigningKey::<Shake128f>::new(&mut rng);
         let vk = sk.verifying_key();
         let msg = b"Hello, world!";
@@ -171,7 +171,7 @@ mod tests {
 
     #[test]
     fn test_sign_verify_wrong_context() {
-        let mut rng = rand::rngs::OsRng;
+        let mut rng = rand::rng();
         let sk = SigningKey::<Shake128f>::new(&mut rng);
         let vk = sk.verifying_key();
         let msg = b"Hello, world!";

--- a/slh-dsa/src/signature_encoding.rs
+++ b/slh-dsa/src/signature_encoding.rs
@@ -187,7 +187,7 @@ mod tests {
     use signature::{SignatureEncoding, Signer};
 
     fn test_serialize_deserialize<P: ParameterSet>() {
-        let mut rng = rand::rngs::OsRng;
+        let mut rng = rand::rng();
         let sk = SigningKey::<P>::new(&mut rng);
         let msg = b"Hello, world!";
         let sig = sk.try_sign(msg).unwrap();
@@ -205,7 +205,7 @@ mod tests {
 
     #[cfg(feature = "alloc")]
     fn test_serialize_deserialize_vec<P: ParameterSet>() {
-        let mut rng = rand::rngs::OsRng;
+        let mut rng = rand::rng();
         let sk = SigningKey::<P>::new(&mut rng);
         let msg = b"Hello, world!";
         let sig = sk.try_sign(msg).unwrap();
@@ -224,7 +224,7 @@ mod tests {
 
     #[test]
     fn test_deserialize_fail_on_incorrect_length() {
-        let mut rng = rand::rngs::OsRng;
+        let mut rng = rand::rng();
         let sk = SigningKey::<Shake128f>::new(&mut rng);
         let msg = b"Hello, world!";
         let sig = sk.try_sign(msg).unwrap();

--- a/slh-dsa/src/verifying_key.rs
+++ b/slh-dsa/src/verifying_key.rs
@@ -8,7 +8,7 @@ use crate::util::split_digest;
 use ::signature::{Error, Verifier};
 use hybrid_array::{Array, ArraySize};
 use pkcs8::{der, spki};
-use rand_core::{CryptoRng, RngCore};
+use rand_core::CryptoRng;
 use typenum::{U, U16, U24, U32, Unsigned};
 
 #[cfg(feature = "alloc")]
@@ -34,7 +34,7 @@ impl<N: ArraySize> From<&[u8]> for PkSeed<N> {
     }
 }
 impl<N: ArraySize> PkSeed<N> {
-    pub(crate) fn new<R: RngCore + CryptoRng + ?Sized>(rng: &mut R) -> Self {
+    pub(crate) fn new<R: CryptoRng + ?Sized>(rng: &mut R) -> Self {
         let mut bytes = Array::<u8, N>::default();
         rng.fill_bytes(bytes.as_mut_slice());
         Self(bytes)
@@ -217,7 +217,7 @@ mod tests {
     use signature::*;
     #[test]
     fn test_vk_serialize_deserialize() {
-        let mut rng = rand::rngs::OsRng;
+        let mut rng = rand::rng();
         let sk = SigningKey::<Shake128f>::new(&mut rng);
         let vk = sk.verifying_key();
         let vk_bytes: Array<u8, _> = (&vk).into();

--- a/slh-dsa/src/wots.rs
+++ b/slh-dsa/src/wots.rs
@@ -151,7 +151,7 @@ mod tests {
     use crate::{PkSeed, SkSeed, util::macros::test_parameter_sets};
     use hex_literal::hex;
     use hybrid_array::Array;
-    use rand::RngCore;
+    use rand::{RngCore, rng};
 
     use crate::{address::WotsHash, hashes::Shake128f};
 
@@ -159,7 +159,7 @@ mod tests {
 
     fn test_sign_verify<Wots: WotsParams>() {
         // Generate random sk_seed, pk_seed, message, address
-        let mut rng = rand::rngs::OsRng;
+        let mut rng = rng();
 
         let sk_seed = SkSeed::new(&mut rng);
 
@@ -182,7 +182,7 @@ mod tests {
 
     fn test_sign_verify_fail<Wots: WotsParams>() {
         // Generate random sk_seed, pk_seed, message
-        let mut rng = rand::rngs::OsRng;
+        let mut rng = rng();
 
         let sk_seed = SkSeed::new(&mut rng);
 

--- a/slh-dsa/src/xmss.rs
+++ b/slh-dsa/src/xmss.rs
@@ -144,6 +144,7 @@ mod tests {
     use hybrid_array::Array;
     use rand::Rng;
     use rand::RngCore;
+    use rand::rng;
 
     use typenum::Unsigned;
 
@@ -205,7 +206,7 @@ mod tests {
 
     fn test_sign_verify<Xmss: XmssParams>() {
         // Generate random sk_seed, pk_seed, message, index, address
-        let mut rng = rand::rngs::OsRng;
+        let mut rng = rng();
 
         let sk_seed = SkSeed::new(&mut rng);
 
@@ -214,7 +215,7 @@ mod tests {
         let mut msg = Array::<u8, _>::default();
         rng.fill_bytes(msg.as_mut_slice());
 
-        let idx = rng.gen_range(0..(1 << Xmss::HPrime::U32));
+        let idx = rng.random_range(0..(1 << Xmss::HPrime::U32));
 
         let adrs = WotsHash::default();
 
@@ -230,7 +231,7 @@ mod tests {
 
     fn test_sign_verify_fail<Xmss: XmssParams>() {
         // Generate random sk_seed, pk_seed, message, index, address
-        let mut rng = rand::rngs::OsRng;
+        let mut rng = rng();
 
         let sk_seed = SkSeed::new(&mut rng);
 
@@ -239,7 +240,7 @@ mod tests {
         let mut msg = Array::<u8, _>::default();
         rng.fill_bytes(msg.as_mut_slice());
 
-        let idx = rng.gen_range(0..(1 << Xmss::HPrime::U32));
+        let idx = rng.random_range(0..(1 << Xmss::HPrime::U32));
 
         let adrs = WotsHash::default();
 


### PR DESCRIPTION
This reverts commit 64b55c6393736de5a89b9b4c64f013d680945eef from #931

This was done to kick out some releases, which have now been published, so these crates are going back to using the latest development releases.