### PR TITLE
Implement `Zeroize` for `ecdsa::Signature`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,6 +374,7 @@ dependencies = [
  "sha2",
  "signature 3.0.0-pre",
  "spki",
+ "zeroize",
 ]
 
 [[package]]

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -19,6 +19,7 @@ rust-version = "1.85"
 [dependencies]
 elliptic-curve = { version = "0.14.0-rc.1", default-features = false, features = ["sec1"] }
 signature = { version = "=3.0.0-pre", default-features = false, features = ["rand_core"] }
+zeroize = { version = "1.5", default-features = false }
 
 # optional dependencies
 der = { version = "0.8.0-rc.2", optional = true }

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -77,6 +77,7 @@ pub use elliptic_curve::{self, PrimeCurve, sec1::EncodedPoint};
 
 // Re-export the `signature` crate (and select types)
 pub use signature::{self, Error, Result, SignatureEncoding};
+use zeroize::Zeroize;
 
 #[cfg(feature = "signing")]
 pub use crate::signing::SigningKey;
@@ -522,6 +523,13 @@ where
         let mut bytes = SignatureBytes::<C>::default();
         serdect::array::deserialize_hex_or_bin(&mut bytes, deserializer)?;
         Self::try_from(bytes.as_slice()).map_err(de::Error::custom)
+    }
+}
+
+impl<C: EcdsaCurve> Zeroize for Signature<C> {
+    fn zeroize(&mut self) {
+        self.r = ScalarPrimitive::ONE;
+        self.s = ScalarPrimitive::ONE;
     }
 }
 


### PR DESCRIPTION
This PR implements `Zeroize` for `ecdsa::Signature` by setting both scalars to one, which is still a valid signature and upholds the types invariants.