### PR TITLE
Automatically retry signing with random `k`

### DIFF
--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -93,6 +93,11 @@ pub fn bits2field<C: EcdsaCurve>(bits: &[u8]) -> Result<FieldBytes<C>> {
 ///
 /// ECDSA [`Signature`] and a [`RecoveryId`] which can be used to recover the verifying key for a
 /// given signature.
+///
+/// # Errors
+///
+/// This will return an error if a zero-scalar was generated. It can be tried again with a
+/// different `k`.
 #[cfg(feature = "arithmetic")]
 #[allow(non_snake_case)]
 pub fn sign_prehashed<C>(
@@ -140,6 +145,11 @@ where
 /// - `d`: signing key. MUST BE UNIFORMLY RANDOM!!!
 /// - `z`: message digest to be signed, i.e. `H(m)`. Does not have to be reduced in advance.
 /// - `ad`: optional additional data, e.g. added entropy from an RNG
+///
+/// # Errors
+///
+/// This will return an error if a zero-scalar was generated. It can be tried again with different
+/// entropy `ad`.
 ///
 /// [RFC6979]: https://datatracker.ietf.org/doc/html/rfc6979
 #[cfg(feature = "rfc6979")]

--- a/ecdsa/src/recovery.rs
+++ b/ecdsa/src/recovery.rs
@@ -188,9 +188,17 @@ where
         prehash: &[u8],
     ) -> Result<(Signature<C>, RecoveryId)> {
         let z = bits2field::<C>(prehash)?;
-        let mut ad = FieldBytes::<C>::default();
-        rng.try_fill_bytes(&mut ad).map_err(|_| Error::new())?;
-        sign_prehashed_rfc6979::<C, C::Digest>(self.as_nonzero_scalar(), &z, &ad)
+
+        loop {
+            let mut ad = FieldBytes::<C>::default();
+            rng.try_fill_bytes(&mut ad).map_err(|_| Error::new())?;
+
+            if let Ok(result) =
+                sign_prehashed_rfc6979::<C, C::Digest>(self.as_nonzero_scalar(), &z, &ad)
+            {
+                break Ok(result);
+            }
+        }
     }
 
     /// Sign the given message prehash, returning a signature and recovery ID.

--- a/ecdsa/src/signing.rs
+++ b/ecdsa/src/signing.rs
@@ -194,9 +194,17 @@ where
         prehash: &[u8],
     ) -> Result<Signature<C>> {
         let z = bits2field::<C>(prehash)?;
-        let mut ad = FieldBytes::<C>::default();
-        rng.try_fill_bytes(&mut ad).map_err(|_| Error::new())?;
-        Ok(sign_prehashed_rfc6979::<C, C::Digest>(&self.secret_scalar, &z, &ad)?.0)
+
+        loop {
+            let mut ad = FieldBytes::<C>::default();
+            rng.try_fill_bytes(&mut ad).map_err(|_| Error::new())?;
+
+            if let Ok((signature, _)) =
+                sign_prehashed_rfc6979::<C, C::Digest>(&self.secret_scalar, &z, &ad)
+            {
+                break Ok(signature);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This PR changes all signing operations that generate a random `k` to retry with a new random `k` on failure instead of returning an error. This follows [FIPS 186](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-5.pdf):
> 11. If r = 0 or if s = 0, and k was generated deterministically (using the procedure in 6.3.2),
then output failure. Otherwise, if r = 0 or if s = 0, then go to Step 3.

Resolves #950.