### PR TITLE
refactor: improve no_std support for slh-dsa

### DIFF
--- a/slh-dsa/src/fors.rs
+++ b/slh-dsa/src/fors.rs
@@ -105,8 +105,8 @@ impl<P: ForsParams> ForsSignature<P> {
     }
 
     #[cfg(feature = "alloc")]
-    pub fn to_vec(&self) -> Vec<u8> {
-        let mut v = vec![0u8; Self::SIZE];
+    pub fn to_vec(&self) -> alloc::vec::Vec<u8> {
+        let mut v = alloc::vec![0u8; Self::SIZE];
         self.write_to(&mut v);
         v
     }

--- a/slh-dsa/src/hypertree.rs
+++ b/slh-dsa/src/hypertree.rs
@@ -28,8 +28,8 @@ impl<P: HypertreeParams> HypertreeSig<P> {
     }
 
     #[cfg(feature = "alloc")]
-    pub fn to_vec(&self) -> Vec<u8> {
-        let mut buf = vec![0u8; Self::SIZE];
+    pub fn to_vec(&self) -> alloc::vec::Vec<u8> {
+        let mut buf = alloc::vec![0u8; Self::SIZE];
         self.write_to(&mut buf);
         buf
     }

--- a/slh-dsa/src/lib.rs
+++ b/slh-dsa/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "alloc"), no_std)]
+#![no_std]
 #![doc = include_str!("../README.md")]
 #![warn(clippy::pedantic)] // Be pedantic by default
 //#![allow(non_snake_case)] // Allow notation matching the spec
@@ -45,6 +45,9 @@
 //!
 //! assert!(vk_deserialized.verify(message, &sig).is_ok())
 //! ```
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
 pub use signature;
 

--- a/slh-dsa/src/signature_encoding.rs
+++ b/slh-dsa/src/signature_encoding.rs
@@ -209,7 +209,7 @@ mod tests {
         let sk = SigningKey::<P>::new(&mut rng);
         let msg = b"Hello, world!";
         let sig = sk.try_sign(msg).unwrap();
-        let sig_vec: Vec<u8> = (&sig).into();
+        let sig_vec: alloc::vec::Vec<u8> = (&sig).into();
         assert_eq!(
             sig.encoded_len(),
             sig_vec.len(),

--- a/slh-dsa/src/signature_encoding.rs
+++ b/slh-dsa/src/signature_encoding.rs
@@ -33,8 +33,8 @@ pub struct Signature<P: ParameterSet> {
 impl<P: ParameterSet> Signature<P> {
     #[cfg(feature = "alloc")]
     /// Serialize the signature to a `Vec<u8>` of length `P::SigLen`.
-    pub fn to_vec(&self) -> Vec<u8> {
-        let mut bytes = Vec::with_capacity(P::SigLen::USIZE);
+    pub fn to_vec(&self) -> alloc::vec::Vec<u8> {
+        let mut bytes = alloc::vec::Vec::with_capacity(P::SigLen::USIZE);
         bytes.extend_from_slice(&self.randomizer);
         bytes.extend_from_slice(&self.fors_sig.to_vec());
         bytes.extend_from_slice(&self.ht_sig.to_vec());
@@ -81,8 +81,8 @@ impl<P: ParameterSet> TryFrom<&[u8]> for Signature<P> {
 }
 
 #[cfg(feature = "alloc")]
-impl<P: ParameterSet> From<&Signature<P>> for Vec<u8> {
-    fn from(sig: &Signature<P>) -> Vec<u8> {
+impl<P: ParameterSet> From<&Signature<P>> for alloc::vec::Vec<u8> {
+    fn from(sig: &Signature<P>) -> alloc::vec::Vec<u8> {
         sig.to_vec()
     }
 }

--- a/slh-dsa/src/signing_key.rs
+++ b/slh-dsa/src/signing_key.rs
@@ -188,7 +188,7 @@ impl<P: ParameterSet> SigningKey<P> {
 
     /// Serialize the signing key to a new heap-allocated vector
     #[cfg(feature = "alloc")]
-    pub fn to_vec(&self) -> Vec<u8>
+    pub fn to_vec(&self) -> alloc::vec::Vec<u8>
     where
         P: VerifyingKeyLen,
     {

--- a/slh-dsa/src/verifying_key.rs
+++ b/slh-dsa/src/verifying_key.rs
@@ -105,7 +105,7 @@ impl<P: ParameterSet + VerifyingKeyLen> VerifyingKey<P> {
 
     /// Serialize the verifying key to a new heap-allocated vector
     #[cfg(feature = "alloc")]
-    pub fn to_vec(&self) -> Vec<u8> {
+    pub fn to_vec(&self) -> alloc::vec::Vec<u8> {
         self.to_bytes().to_vec()
     }
 }

--- a/slh-dsa/src/wots.rs
+++ b/slh-dsa/src/wots.rs
@@ -30,8 +30,8 @@ impl<P: WotsParams> WotsSig<P> {
 
     #[cfg(feature = "alloc")]
     #[cfg(test)]
-    pub fn to_vec(&self) -> Vec<u8> {
-        let mut vec = vec![0u8; Self::SIZE];
+    pub fn to_vec(&self) -> alloc::vec::Vec<u8> {
+        let mut vec = alloc::vec![0u8; Self::SIZE];
         self.write_to(&mut vec);
         vec
     }

--- a/slh-dsa/src/xmss.rs
+++ b/slh-dsa/src/xmss.rs
@@ -27,8 +27,8 @@ impl<P: XmssParams> XmssSig<P> {
 
     #[cfg(feature = "alloc")]
     #[cfg(test)]
-    pub fn to_vec(&self) -> Vec<u8> {
-        let mut buf = vec![0u8; Self::SIZE];
+    pub fn to_vec(&self) -> alloc::vec::Vec<u8> {
+        let mut buf = alloc::vec![0u8; Self::SIZE];
         self.write_to(&mut buf);
         buf
     }


### PR DESCRIPTION
correct following configuration from:
```rs
#![cfg_attr(not(feature = "alloc"), no_std)]
```
to
```rs
#![no_std]
```