### PR TITLE
ecdsa: restore `RandomizedSigner<der::Signature>`

### DIFF
--- a/ecdsa/src/signing.rs
+++ b/ecdsa/src/signing.rs
@@ -346,6 +346,24 @@ where
     }
 }
 
+#[cfg(feature = "der")]
+impl<C> RandomizedSigner<der::Signature<C>> for SigningKey<C>
+where
+    C: EcdsaCurve + CurveArithmetic + DigestPrimitive,
+    Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
+    SignatureSize<C>: ArraySize,
+    der::MaxSize<C>: ArraySize,
+    <FieldBytesSize<C> as Add>::Output: Add<der::MaxOverhead> + ArraySize,
+{
+    fn try_sign_with_rng<R: TryCryptoRng + ?Sized>(
+        &self,
+        rng: &mut R,
+        msg: &[u8],
+    ) -> Result<der::Signature<C>> {
+        RandomizedSigner::<Signature<C>>::try_sign_with_rng(self, rng, msg).map(Into::into)
+    }
+}
+
 //
 // Other trait impls
 //


### PR DESCRIPTION
I *think* this was missed in in #955 as this came in #947 which I did not revert.