### PR TITLE
bump signature git pin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1136,7 +1136,7 @@ dependencies = [
 [[package]]
 name = "signature"
 version = "3.0.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#ac5443909846354e11570e2968937a62f2019bed"
+source = "git+https://github.com/RustCrypto/traits.git#439fc8c28c61b09eff35349b4c091a5586d70ea7"
 dependencies = [
  "digest",
  "rand_core 0.9.2",


### PR DESCRIPTION
This removes the `derive` feature from `signature`:
 - https://github.com/RustCrypto/traits/pull/1843