### PR TITLE
chore(deps): bump `crypto-bigint` to `0.7.0-pre.3`, use core naming conventions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,9 +267,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-pre.2"
+version = "0.7.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87a5061ea0870b06f7fdd5a0f7268e30c04de1932c148cca0ce5c79a88d18bed"
+checksum = "f727d84cf16cb51297e4388421e2e51b2f94ffe92ee1d8664d81676901196fa3"
 dependencies = [
  "hybrid-array",
  "num-traits",
@@ -414,7 +414,7 @@ checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 [[package]]
 name = "elliptic-curve"
 version = "0.14.0-rc.1"
-source = "git+https://github.com/RustCrypto/traits.git#ac5443909846354e11570e2968937a62f2019bed"
+source = "git+https://github.com/RustCrypto/traits.git#73ffc4055c0d0b4ccfb0fecee8c7a217d0d53cec"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -1136,7 +1136,7 @@ dependencies = [
 [[package]]
 name = "signature"
 version = "3.0.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#439fc8c28c61b09eff35349b4c091a5586d70ea7"
+source = "git+https://github.com/RustCrypto/traits.git#73ffc4055c0d0b4ccfb0fecee8c7a217d0d53cec"
 dependencies = [
  "digest",
  "rand_core 0.9.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,8 @@ slh-dsa         = { path = "./slh-dsa" }
 # https://github.com/RustCrypto/traits/pull/1767
 # https://github.com/RustCrypto/traits/pull/1774
 # https://github.com/RustCrypto/traits/pull/1822
+# https://github.com/RustCrypto/traits/pull/1845
 elliptic-curve = { git = "https://github.com/RustCrypto/traits.git" }
 signature      = { git = "https://github.com/RustCrypto/traits.git" }
- 
+
 crypto-primes = { git = "https://github.com/entropyxyz/crypto-primes.git" }

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.85"
 
 [dependencies]
 digest = "=0.11.0-pre.10"
-crypto-bigint = { version = "=0.7.0-pre.2", default-features = false, features = ["alloc", "zeroize"] }
+crypto-bigint = { version = "=0.7.0-pre.3", default-features = false, features = ["alloc", "zeroize"] }
 crypto-primes = { version = "=0.7.0-dev", default-features = false }
 pkcs8 = { version = "0.11.0-rc.1", default-features = false, features = ["alloc"] }
 rfc6979 = { version = "=0.5.0-pre.4" }

--- a/dsa/src/generate/secret_number.rs
+++ b/dsa/src/generate/secret_number.rs
@@ -48,7 +48,7 @@ where
 
         let k = BoxedUint::from_be_slice(&buffer, q.bits_precision())
             .map_err(|_| signature::Error::new())?;
-        if let Some(inv_k) = k.inv_mod(q).into() {
+        if let Some(inv_k) = k.invert_mod(q).into() {
             if (bool::from(k.is_nonzero())) && (k < **q) {
                 return Ok((k, inv_k));
             }
@@ -79,7 +79,7 @@ pub fn secret_number<R: TryCryptoRng + ?Sized>(
             .expect("[bug] minimum size for q is to 2^(160 - 1)");
         let k = (c % rem) + BoxedUint::one();
 
-        if let Some(inv_k) = k.inv_mod(q).into() {
+        if let Some(inv_k) = k.invert_mod(q).into() {
             // `k` and `k^-1` both have to be in the range `[1, q-1]`
             if (inv_k > BoxedUint::zero() && inv_k < **q) && (k > BoxedUint::zero() && k < **q) {
                 return Ok(Some((k, inv_k)));

--- a/dsa/src/verifying_key.rs
+++ b/dsa/src/verifying_key.rs
@@ -73,7 +73,7 @@ impl VerifyingKey {
         let r = &r.resize(p.bits_precision());
         let s = &s.resize(p.bits_precision());
 
-        let w: BoxedUint = Option::from(s.inv_mod(q))?;
+        let w: BoxedUint = Option::from(s.invert_mod(q))?;
 
         let n = q.bits() / 8;
         let block_size = hash.len(); // Hash function output size


### PR DESCRIPTION
See:
 - https://github.com/RustCrypto/crypto-bigint/pull/817
Depends:
 - https://github.com/RustCrypto/traits/pull/1845