### PR TITLE
ecdsa: decode der signature using `derive(Sequence)` macro

### DIFF
--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -22,7 +22,7 @@ signature = { version = "=3.0.0-pre", default-features = false, features = ["ran
 zeroize = { version = "1.5", default-features = false }
 
 # optional dependencies
-der = { version = "0.8.0-rc.2", optional = true }
+der = { version = "0.8.0-rc.2", features = ["derive"], optional = true }
 digest = { version = "=0.11.0-pre.10", optional = true, default-features = false, features = ["oid"] }
 rfc6979 = { version = "=0.5.0-pre.4", optional = true }
 serdect = { version = "0.3", optional = true, default-features = false, features = ["alloc"] }


### PR DESCRIPTION
Rewritten as `#[derive(Sequence)]`