### PR TITLE
ecdsa: der: use impl `EncodeValue`/`DecodeValue` on `SignatureRef`

### DIFF
--- a/ecdsa/src/der.rs
+++ b/ecdsa/src/der.rs
@@ -385,11 +385,6 @@ impl<'a> DecodeValue<'a> for SignatureRef<'a> {
 }
 impl<'a> Sequence<'a> for SignatureRef<'a> {}
 
-/// Decode the `r` and `s` components of a DER-encoded ECDSA signature.
-fn decode_der(der_bytes: &[u8]) -> der::Result<SignatureRef<'_>> {
-    SignatureRef::from_der(der_bytes)
-}
-
 /// Locate the range within a slice at which a particular subslice is located
 fn find_scalar_range(outer: &[u8], inner: &[u8]) -> Result<Range<usize>> {
     let outer_start = outer.as_ptr() as usize;

--- a/ecdsa/src/der.rs
+++ b/ecdsa/src/der.rs
@@ -85,7 +85,7 @@ where
 {
     /// Parse signature from DER-encoded bytes.
     pub fn from_bytes(input: &[u8]) -> Result<Self> {
-        let SignatureRef { r, s } = decode_der(input).map_err(|_| Error::new())?;
+        let SignatureRef { r, s } = SignatureRef::from_der(input).map_err(|_| Error::new())?;
 
         if r.as_bytes().len() > C::FieldBytesSize::USIZE
             || s.as_bytes().len() > C::FieldBytesSize::USIZE


### PR DESCRIPTION
This way we avoid using internals of `der`:
- `der::SliceWriter`
- `der::SliceReader`
- `tag.assert_eq`
- `writer.sequence`