### PR TITLE
Fix  hi-bit description in RecoveryId documentation

### DIFF
--- a/ecdsa/src/recovery.rs
+++ b/ecdsa/src/recovery.rs
@@ -47,7 +47,7 @@ use {
 /// - low bit (0/1): was the y-coordinate of the affine point resulting from
 ///   the fixed-base multiplication 𝑘×𝑮 odd? This part of the algorithm
 ///   functions similar to point decompression.
-/// - hi bit (3/4): did the affine x-coordinate of 𝑘×𝑮 overflow the order of
+/// - hi bit (2/3): did the affine x-coordinate of 𝑘×𝑮 overflow the order of
 ///   the scalar field, requiring a reduction when computing `r`?
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct RecoveryId(pub(crate) u8);


### PR DESCRIPTION
There are 4 bits in total, low-bits are (0/1) and hi-bits should be (2/3) but before it was incorrectly written as (3/4).
This PR fixes this description.

Closes #852 