### PR TITLE
Update to `PrimeField::from_repr()` changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,8 +414,7 @@ checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 [[package]]
 name = "elliptic-curve"
 version = "0.14.0-rc.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1786d08ca7d401fcc540b2fab11ec37b224ced5a0455c451656f83d80e681ddb"
+source = "git+https://github.com/RustCrypto/traits.git?rev=2ec3e144f69af5d3836d5d2b545b36105f6d69f9#2ec3e144f69af5d3836d5d2b545b36105f6d69f9"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -462,8 +461,7 @@ checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 [[package]]
 name = "ff"
 version = "0.14.0-pre.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d42dd26f5790eda47c1a2158ea4120e32c35ddc9a7743c98a292accc01b54ef3"
+source = "git+https://github.com/zkcrypto/ff.git?rev=8e139e2fb25ab61a5d362394af0a34b10c03d59b#8e139e2fb25ab61a5d362394af0a34b10c03d59b"
 dependencies = [
  "rand_core 0.9.2",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,9 @@ ml-dsa = { path = "./ml-dsa" }
 rfc6979 = { path = "./rfc6979" }
 slh-dsa = { path = "./slh-dsa" }
 
+# https://github.com/RustCrypto/traits/pull/1869
+# https://github.com/zkcrypto/ff/pull/137
+elliptic-curve = { git = "https://github.com/RustCrypto/traits.git", rev = "2ec3e144f69af5d3836d5d2b545b36105f6d69f9" }
+ff = { git = "https://github.com/zkcrypto/ff.git", rev = "8e139e2fb25ab61a5d362394af0a34b10c03d59b" }
+
 crypto-primes = { git = "https://github.com/entropyxyz/crypto-primes.git" }

--- a/ecdsa/src/dev.rs
+++ b/ecdsa/src/dev.rs
@@ -50,7 +50,7 @@ macro_rules! new_signing_test {
 
         fn decode_scalar(bytes: &[u8]) -> Option<NonZeroScalar<$curve>> {
             if bytes.len() == <$curve as Curve>::FieldBytesSize::USIZE {
-                NonZeroScalar::<$curve>::from_repr(bytes.try_into().unwrap()).into()
+                NonZeroScalar::<$curve>::from_repr(&bytes.try_into().unwrap()).into()
             } else {
                 None
             }

--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -196,7 +196,7 @@ where
     // h = bits2int(H(m)) mod q
     let z2 = <Scalar<C> as Reduce<C::Uint>>::reduce_bytes(z);
 
-    let k = NonZeroScalar::<C>::from_repr(rfc6979::generate_k::<D, _>(
+    let k = NonZeroScalar::<C>::from_repr(&rfc6979::generate_k::<D, _>(
         &d.to_repr(),
         &C::ORDER.encode_field_bytes(),
         &z2.to_repr(),


### PR DESCRIPTION
Preliminary update to changes in https://github.com/zkcrypto/ff/pull/137.

`elliptic-curve` PR: https://github.com/RustCrypto/traits/pull/1869.
`elliptic-curves` PR: https://github.com/RustCrypto/elliptic-curves/pull/1209.