### PR TITLE
Bump `digest` dependency to v0.11.0-rc.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,7 +154,7 @@ version = "0.5.0-pre.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b1425e6ce000f05a73096556cabcfb6a10a3ffe3bb4d75416ca8f00819c0b6a"
 dependencies = [
- "crypto-common 0.2.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crypto-common",
  "inout",
 ]
 
@@ -281,17 +281,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.2"
+version = "0.2.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170d71b5b14dec99db7739f6fc7d6ec2db80b78c3acb77db48392ccc3d8a9ea0"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/RustCrypto/traits.git#915474f1ed5be0a19fd102d5f75ef8e04c765416"
+checksum = "8a23fa214dea9efd4dacee5a5614646b30216ae0f05d4bb51bafb50e9da1c5be"
 dependencies = [
  "hybrid-array",
 ]
@@ -339,12 +331,13 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-pre.10"
-source = "git+https://github.com/RustCrypto/traits.git#915474f1ed5be0a19fd102d5f75ef8e04c765416"
+version = "0.11.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460dd7f37e4950526b54a5a6b1f41b6c8e763c58eb9a8fc8fc05ba5c2f44ca7b"
 dependencies = [
  "block-buffer",
  "const-oid",
- "crypto-common 0.2.0-rc.2 (git+https://github.com/RustCrypto/traits.git)",
+ "crypto-common",
  "subtle",
 ]
 
@@ -387,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "2.3.0-pre.0"
+version = "3.0.0-pre"
 dependencies = [
  "bincode",
  "hex-literal 1.0.0",
@@ -420,8 +413,9 @@ checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.1"
-source = "git+https://github.com/RustCrypto/traits.git#73ffc4055c0d0b4ccfb0fecee8c7a217d0d53cec"
+version = "0.14.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1786d08ca7d401fcc540b2fab11ec37b224ced5a0455c451656f83d80e681ddb"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -554,8 +548,9 @@ checksum = "bcaaec4551594c969335c98c903c1397853d4198408ea609190f420500f6be71"
 
 [[package]]
 name = "hmac"
-version = "0.13.0-pre.5"
-source = "git+https://github.com/RustCrypto/MACs.git#64d671d5c375838173d18e30bc14dffc80c13e51"
+version = "0.13.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dc6a2fcc35ab09136c6df2cdf9ca49790701420a3a6b5db0987dddbabc79b21"
 dependencies = [
  "digest",
 ]
@@ -1109,8 +1104,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0-pre.5"
-source = "git+https://github.com/RustCrypto/hashes.git#7d44caf065dbeb3f10a372a26a8b9f1c927f8433"
+version = "0.11.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f9318facddf9ac32a33527066936837e189b3f23ced6edc1603720ead5e2b3d"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1119,8 +1115,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-pre.5"
-source = "git+https://github.com/RustCrypto/hashes.git#7d44caf065dbeb3f10a372a26a8b9f1c927f8433"
+version = "0.11.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa1d2e6b3cc4e43a8258a9a3b17aa5dfd2cc5186c7024bba8a64aa65b2c71a59"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1129,8 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.11.0-pre.5"
-source = "git+https://github.com/RustCrypto/hashes.git#7d44caf065dbeb3f10a372a26a8b9f1c927f8433"
+version = "0.11.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e6a92fd180fd205defdc0b78288ce847c7309d329fd6647a814567e67db50e"
 dependencies = [
  "digest",
  "keccak",
@@ -1138,8 +1136,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "3.0.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#73ffc4055c0d0b4ccfb0fecee8c7a217d0d53cec"
+version = "3.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7ae074ff622614874804868b07d9cb786223082c9fe726a6653608f32f37b02"
 dependencies = [
  "digest",
  "rand_core 0.9.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,28 +17,13 @@ opt-level = 2
 [patch.crates-io]
 # A global patch crates-io block is used to avoid duplicate dependencies
 # when pulling a member crate through git
-dsa             = { path = "./dsa" }
-ecdsa           = { path = "./ecdsa" }
+dsa = { path = "./dsa" }
+ecdsa = { path = "./ecdsa" }
 ed448-signature = { path = "./ed448" }
-ed25519         = { path = "./ed25519" }
-lms-signature   = { path = "./lms" }
-ml-dsa          = { path = "./ml-dsa" }
-rfc6979         = { path = "./rfc6979" }
-slh-dsa         = { path = "./slh-dsa" }
-
-# https://github.com/RustCrypto/traits/pull/1751
-# https://github.com/RustCrypto/traits/pull/1767
-# https://github.com/RustCrypto/traits/pull/1774
-# https://github.com/RustCrypto/traits/pull/1822
-# https://github.com/RustCrypto/traits/pull/1845
-digest         = { git = "https://github.com/RustCrypto/traits.git" }
-elliptic-curve = { git = "https://github.com/RustCrypto/traits.git" }
-signature      = { git = "https://github.com/RustCrypto/traits.git" }
+ed25519 = { path = "./ed25519" }
+lms-signature = { path = "./lms" }
+ml-dsa = { path = "./ml-dsa" }
+rfc6979 = { path = "./rfc6979" }
+slh-dsa = { path = "./slh-dsa" }
 
 crypto-primes = { git = "https://github.com/entropyxyz/crypto-primes.git" }
-
-hmac = { git = "https://github.com/RustCrypto/MACs.git" }
-
-sha1 = { git = "https://github.com/RustCrypto/hashes.git" }
-sha2 = { git = "https://github.com/RustCrypto/hashes.git" }
-sha3 = { git = "https://github.com/RustCrypto/hashes.git" }

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -16,13 +16,13 @@ keywords = ["crypto", "nist", "signature"]
 rust-version = "1.85"
 
 [dependencies]
-digest = "=0.11.0-pre.10"
+digest = "0.11.0-rc.0"
 crypto-bigint = { version = "=0.7.0-pre.3", default-features = false, features = ["alloc", "zeroize"] }
 crypto-primes = { version = "=0.7.0-dev", default-features = false }
 pkcs8 = { version = "0.11.0-rc.1", default-features = false, features = ["alloc"] }
 rfc6979 = { version = "=0.5.0-pre.4" }
-sha2 = { version = "=0.11.0-pre.5", default-features = false }
-signature = { version = "=3.0.0-pre", default-features = false, features = ["alloc", "digest", "rand_core"] }
+sha2 = { version = "0.11.0-rc.0", default-features = false }
+signature = { version = "3.0.0-rc.0", default-features = false, features = ["alloc", "digest", "rand_core"] }
 zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]
@@ -32,7 +32,7 @@ pkcs8 = { version = "0.11.0-rc.1", default-features = false, features = ["pem"] 
 proptest = "1"
 rand = "0.9"
 rand_chacha = "0.9"
-sha1 = "=0.11.0-pre.5"
+sha1 = "0.11.0-rc.0"
 der = { version = "0.8.0-rc.1", features = ["derive"] }
 
 [features]

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -17,22 +17,22 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.1", default-features = false, features = ["sec1"] }
-signature = { version = "=3.0.0-pre", default-features = false, features = ["rand_core"] }
+elliptic-curve = { version = "0.14.0-rc.2", default-features = false, features = ["sec1"] }
+signature = { version = "3.0.0-rc.0", default-features = false, features = ["rand_core"] }
 zeroize = { version = "1.5", default-features = false }
 
 # optional dependencies
 der = { version = "0.8.0-rc.2", optional = true }
-digest = { version = "=0.11.0-pre.10", optional = true, default-features = false, features = ["oid"] }
+digest = { version = "0.11.0-rc.0", optional = true, default-features = false, features = ["oid"] }
 rfc6979 = { version = "=0.5.0-pre.4", optional = true }
 serdect = { version = "0.3", optional = true, default-features = false, features = ["alloc"] }
-sha2 = { version = "=0.11.0-pre.5", optional = true, default-features = false, features = ["oid"] }
+sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false, features = ["oid"] }
 spki = { version = "0.8.0-rc.0", optional = true, default-features = false }
 
 [dev-dependencies]
-elliptic-curve = { version = "0.14.0-rc.1", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.2", default-features = false, features = ["dev"] }
 hex-literal = "1"
-sha2 = { version = "=0.11.0-pre.5", default-features = false }
+sha2 = { version = "0.11.0-rc.0", default-features = false }
 
 [features]
 default = ["digest"]

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed25519"
-version = "2.3.0-pre.0"
+version = "3.0.0-pre"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """
@@ -18,8 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-# TODO(tarcieri): relax requirement back to `3` before next release
-signature = { version = "=3.0.0-pre", default-features = false }
+signature = { version = "3.0.0-rc.0", default-features = false }
 
 # optional dependencies
 pkcs8 = { version = "0.11.0-rc.2", optional = true }

--- a/ed448/Cargo.toml
+++ b/ed448/Cargo.toml
@@ -18,8 +18,7 @@ keywords = ["crypto", "curve448", "ecc", "signature", "signing"]
 rust-version = "1.85"
 
 [dependencies]
-# TODO(tarcieri): relax requirement back to `3` before next release
-signature = { version = "=3.0.0-pre", default-features = false }
+signature = { version = "3.0.0-rc.0", default-features = false }
 
 # optional dependencies
 pkcs8 = { version = "0.11.0-rc.1", optional = true }

--- a/lms/Cargo.toml
+++ b/lms/Cargo.toml
@@ -12,13 +12,13 @@ categories = ["cryptography"]
 keywords = ["crypto", "signature"]
 
 [dependencies]
-digest = "=0.11.0-pre.10"
+digest = "0.11.0-rc.0"
 hybrid-array = { version = "0.3", features = ["extra-sizes", "zeroize"] }
 rand = "0.9.0"
-sha2 = "=0.11.0-pre.5"
+sha2 = "0.11.0-rc.0"
 static_assertions = "1.1.0"
 rand_core = "0.9.0"
-signature = { version = "=3.0.0-pre", features = ["alloc", "digest", "rand_core"] }
+signature = { version = "3.0.0-rc.0", features = ["alloc", "digest", "rand_core"] }
 typenum = { version = "1.17.0", features = ["const-generics"] }
 zeroize = "1.8.1"
 

--- a/ml-dsa/Cargo.toml
+++ b/ml-dsa/Cargo.toml
@@ -35,8 +35,8 @@ pkcs8 = ["dep:const-oid", "dep:pkcs8"]
 hybrid-array = { version = "0.3", features = ["extra-sizes"] }
 num-traits = "0.2.19"
 rand_core = { version = "0.9", optional = true }
-sha3 = "=0.11.0-pre.5"
-signature = "=3.0.0-pre"
+sha3 = "0.11.0-rc.0"
+signature = "3.0.0-rc.0"
 zeroize = { version = "1.8.1", optional = true, default-features = false }
 
 const-oid = { version = "0.10", features = ["db"], optional = true }

--- a/rfc6979/Cargo.toml
+++ b/rfc6979/Cargo.toml
@@ -16,9 +16,9 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-hmac = { version = "=0.13.0-pre.5", default-features = false }
+hmac = { version = "0.13.0-rc.0", default-features = false }
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
 hex-literal = "1"
-sha2 = "=0.11.0-pre.5"
+sha2 = "0.11.0-rc.0"

--- a/slh-dsa/Cargo.toml
+++ b/slh-dsa/Cargo.toml
@@ -18,13 +18,13 @@ exclude = ["tests"]
 [dependencies]
 hybrid-array = { version = "0.3", features = ["extra-sizes"] }
 typenum = { version = "1.17.0", features = ["const-generics"] }
-sha3 = { version = "=0.11.0-pre.5", default-features = false }
+sha3 = { version = "0.11.0-rc.0", default-features = false }
 zerocopy = { version = "0.7.34", features = ["derive"] }
 rand_core = { version = "0.9.2" }
-signature = { version = "=3.0.0-pre", features = ["rand_core"] }
-hmac = "=0.13.0-pre.5"
-sha2 = { version = "=0.11.0-pre.5", default-features = false }
-digest = "=0.11.0-pre.10"
+signature = { version = "3.0.0-rc.0", features = ["rand_core"] }
+hmac = "0.13.0-prc.0"
+sha2 = { version = "0.11.0-rc.0", default-features = false }
+digest = "0.11.0-rc.0"
 pkcs8 = { version = "0.11.0-rc.1", default-features = false }
 const-oid = { version = "0.10", features = ["db"] }
 zeroize = { version = "1.8.1", optional = true, default-features = false }


### PR DESCRIPTION
Also bumps:
- `elliptic-curve` v0.14.0-rc.2
- `signature` v3.0.0-rc.0