### PR TITLE
dsa: remove `std` feature

### DIFF
--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -36,7 +36,6 @@ sha1 = "0.11.0-rc.0"
 der = { version = "0.8.0-rc.1", features = ["derive"] }
 
 [features]
-std = []
 hazmat = []
 
 [package.metadata.docs.rs]

--- a/dsa/src/lib.rs
+++ b/dsa/src/lib.rs
@@ -185,8 +185,7 @@ impl TryFrom<&[u8]> for Signature {
     type Error = signature::Error;
 
     fn try_from(bytes: &[u8]) -> signature::Result<Self> {
-        // TODO(tarcieri): capture error source when `std` feature enabled
-        Self::from_der(bytes).map_err(|_| signature::Error::new())
+        Self::from_der(bytes).map_err(signature::Error::from_source)
     }
 }
 


### PR DESCRIPTION
It isn't actually used for anything, and with a hard dependency on `alloc` and `core::error::Error` we can always capture `Box<std::error::Error>` in `signature::Error`.