### PR TITLE
ed448: implement `AssociatedAlgorithmIdentifier` for `Signature`

### DIFF
--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -396,10 +396,7 @@ impl SignatureBitStringEncoding for Signature {
 impl AssociatedAlgorithmIdentifier for Signature {
     type Params = AnyRef<'static>;
 
-    const ALGORITHM_IDENTIFIER: AlgorithmIdentifierRef<'static> = AlgorithmIdentifierRef {
-        oid: ObjectIdentifier::new_unwrap("1.3.101.112"),
-        parameters: None,
-    };
+    const ALGORITHM_IDENTIFIER: AlgorithmIdentifierRef<'static> = pkcs8::ALGORITHM_ID;
 }
 
 impl From<Signature> for SignatureBytes {

--- a/ed448/src/lib.rs
+++ b/ed448/src/lib.rs
@@ -81,6 +81,21 @@ pub use signature::{self, Error, SignatureEncoding};
 
 use core::fmt;
 
+#[cfg(feature = "pkcs8")]
+pub use crate::pkcs8::{
+    KeypairBytes, PublicKeyBytes,
+    spki::{
+        AlgorithmIdentifierRef, AssociatedAlgorithmIdentifier,
+        der::{AnyRef, oid::ObjectIdentifier},
+    },
+};
+
+#[cfg(all(feature = "alloc", feature = "pkcs8"))]
+use pkcs8::spki::{
+    SignatureBitStringEncoding,
+    der::{self, asn1::BitString},
+};
+
 /// Size of a single component of an Ed448 signature.
 pub const COMPONENT_SIZE: usize = 57;
 
@@ -207,4 +222,18 @@ impl fmt::Display for Signature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:X}", self)
     }
+}
+
+#[cfg(all(feature = "alloc", feature = "pkcs8"))]
+impl SignatureBitStringEncoding for Signature {
+    fn to_bitstring(&self) -> der::Result<BitString> {
+        BitString::new(0, self.to_bytes())
+    }
+}
+
+#[cfg(feature = "pkcs8")]
+impl AssociatedAlgorithmIdentifier for Signature {
+    type Params = AnyRef<'static>;
+
+    const ALGORITHM_IDENTIFIER: AlgorithmIdentifierRef<'static> = pkcs8::ALGORITHM_ID;
 }


### PR DESCRIPTION
See <https://datatracker.ietf.org/doc/html/rfc8410#section-3>