### PR TITLE
dsa: handle `NonZero`/`Odd` conversions on `BoxedUint` internally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,9 +261,9 @@ checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-pre.4"
+version = "0.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edaae5fb9dac79a07260e0b2006799ff4f1d342ab243fd7d0892215113b27904"
+checksum = "a06a5e703b883b3744ddac8b7c5eade2d800d6559ef99760566f8103e3ad39bf"
 dependencies = [
  "hybrid-array",
  "num-traits",
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.1"
+version = "0.17.0-rc.2"
 dependencies = [
  "der",
  "digest",
@@ -410,8 +410,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "elliptic-curve"
 version = "0.14.0-rc.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ccc36f4cfd3b96979b66a2162a10052eb0b98c9241ed1498273c79898d26a7"
+source = "git+https://github.com/RustCrypto/traits.git#efb7780b086fad4b8d6eaf13f5471d102b162bf7"
 dependencies = [
  "base16ct",
  "crypto-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ members = [
 opt-level = 2
 
 [patch.crates-io]
+elliptic-curve = { git = "https://github.com/RustCrypto/traits.git" }
+
 # A global patch crates-io block is used to avoid duplicate dependencies
 # when pulling a member crate through git
 dsa = { path = "./dsa" }

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.85"
 
 [dependencies]
 digest = "0.11.0-rc.0"
-crypto-bigint = { version = "=0.7.0-pre.4", default-features = false, features = ["alloc", "zeroize"] }
+crypto-bigint = { version = "=0.7.0-pre.5", default-features = false, features = ["alloc", "zeroize"] }
 crypto-primes = { version = "=0.7.0-pre.1", default-features = false }
 pkcs8 = { version = "0.11.0-rc.1", default-features = false, features = ["alloc"] }
 rfc6979 = { version = "0.5.0-rc.0" }

--- a/dsa/src/generate/keypair.rs
+++ b/dsa/src/generate/keypair.rs
@@ -39,7 +39,7 @@ pub fn keypair<R: CryptoRng + ?Sized>(rng: &mut R, components: Components) -> Si
 
     let (x, y) = find_components(rng, &components);
 
-    VerifyingKey::from_components(components, y)
-        .and_then(|verifying_key| SigningKey::from_components(verifying_key, x))
+    VerifyingKey::from_components(components, y.get())
+        .and_then(|verifying_key| SigningKey::from_components(verifying_key, x.get()))
         .expect("[Bug] Newly generated keypair considered invalid")
 }

--- a/dsa/tests/deterministic.rs
+++ b/dsa/tests/deterministic.rs
@@ -1,5 +1,5 @@
 #![cfg(feature = "hazmat")]
-use crypto_bigint::{BoxedUint, NonZero, Odd};
+use crypto_bigint::BoxedUint;
 use digest::{Digest, FixedOutputReset, block_api::BlockSizeUser};
 use dsa::{Components, Signature, SigningKey, VerifyingKey};
 use sha1::Sha1;
@@ -38,14 +38,6 @@ fn dsa_1024_signing_key() -> SigningKey {
             4CE935437DC11C3C8FD426338933EBFE739CB3465F4D3668C5E473508253B1E6\
             82F65CBDC4FAE93C2EA212390E54905A86E2223170B44EAA7DA5DD9FFCFB7F3B";
     let y = decode_hex_number(y_str, 1024);
-
-    let (p, q, g, y, x) = (
-        Odd::new(p).unwrap(),
-        NonZero::new(q).unwrap(),
-        NonZero::new(g).unwrap(),
-        NonZero::new(y).unwrap(),
-        NonZero::new(x).unwrap(),
-    );
 
     let components = Components::from_components(p, q, g).expect("Invalid components");
     let verifying_key =
@@ -98,14 +90,6 @@ fn dsa_2048_signing_key() -> SigningKey {
         2048,
     );
 
-    let (p, q, g, y, x) = (
-        Odd::new(p).unwrap(),
-        NonZero::new(q).unwrap(),
-        NonZero::new(g).unwrap(),
-        NonZero::new(y).unwrap(),
-        NonZero::new(x).unwrap(),
-    );
-
     let components = Components::from_components(p, q, g).expect("Invalid components");
     let verifying_key =
         VerifyingKey::from_components(components, y).expect("Invalid verifying key");
@@ -144,9 +128,10 @@ fn from_str_signature(r: &str, s: &str) -> Signature {
     let precision = (r.len() * 8) as u32;
 
     Signature::from_components(
-        NonZero::new(decode_hex_number(r, precision)).unwrap(),
-        NonZero::new(decode_hex_number(s, precision)).unwrap(),
+        decode_hex_number(r, precision),
+        decode_hex_number(s, precision),
     )
+    .unwrap()
 }
 
 /// Return the RFC 6979 test cases


### PR DESCRIPTION
Makes `BoxedUint` the one unsigned integer type in the public API, converting to `NonZero<BoxedUint>` and `Odd<BoxedUint>` as needed.

This makes the API simpler to use for end-users, with fewer types for them to manage.

Closes #987