### PR TITLE
Update broken Signature struct docs link to current ed448_goldilocks_plus

### DIFF
--- a/ed448/README.md
+++ b/ed448/README.md
@@ -67,6 +67,6 @@ dual licensed as above, without any additional terms or conditions.
 
 [1]: https://en.wikipedia.org/wiki/EdDSA#Ed448
 [2]: https://tools.ietf.org/html/rfc7748
-[3]: https://docs.rs/ed448/latest/ed448/struct.Signature.html
+[3]: https://docs.rs/ed448-goldilocks-plus/latest/ed448_goldilocks_plus/struct.Signature.html
 [4]: https://docs.rs/signature/latest/signature/trait.Signer.html
 [5]: https://docs.rs/signature/latest/signature/trait.Verifier.html


### PR DESCRIPTION
Replaced the outdated and non-working documentation link for the ed448::Signature struct with the correct URL pointing to the Signature struct in the ed448_goldilocks_plus crate on docs.rs. This ensures that users are directed to the up-to-date and maintained documentation. No other content was changed.