### PR TITLE
ecdsa: bump `der` to v0.8.0-rc.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.0-rc.3"
+version = "0.8.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00a9651bf9c00a38b7c383073cb22fb42f20a5f978c9f97ad5c7128cbd3c1bd"
+checksum = "9843074b9f917c0ae9144eeab6f7cb5c09fe6d4b79807a4aa7aa123d4d5eabd4"
 dependencies = [
  "const-oid",
  "der_derive",

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecdsa"
-version = "0.17.0-rc.2"
+version = "0.17.0-rc.3"
 description = """
 Pure Rust implementation of the Elliptic Curve Digital Signature Algorithm
 (ECDSA) as specified in FIPS 186-4 (Digital Signature Standard), providing
@@ -22,7 +22,7 @@ signature = { version = "3.0.0-rc.1", default-features = false, features = ["ran
 zeroize = { version = "1.5", default-features = false }
 
 # optional dependencies
-der = { version = "0.8.0-rc.2", optional = true }
+der = { version = "0.8.0-rc.5", optional = true }
 digest = { version = "0.11.0-rc.0", optional = true, default-features = false, features = ["oid"] }
 rfc6979 = { version = "0.5.0-rc.0", optional = true }
 serdect = { version = "0.3", optional = true, default-features = false, features = ["alloc"] }

--- a/ecdsa/src/der.rs
+++ b/ecdsa/src/der.rs
@@ -357,6 +357,7 @@ struct SignatureRef<'a> {
     pub r: UintRef<'a>,
     pub s: UintRef<'a>,
 }
+
 impl EncodeValue for SignatureRef<'_> {
     fn value_len(&self) -> der::Result<Length> {
         self.r.encoded_len()? + self.s.encoded_len()?
@@ -368,19 +369,15 @@ impl EncodeValue for SignatureRef<'_> {
         Ok(())
     }
 }
-impl<'a> SignatureRef<'a> {
-    fn decode_value_inner<R: Reader<'a>>(reader: &mut R) -> der::Result<Self> {
+
+impl<'a> DecodeValue<'a> for SignatureRef<'a> {
+    type Error = der::Error;
+
+    fn decode_value<R: Reader<'a>>(reader: &mut R, _header: Header) -> der::Result<Self> {
         Ok(Self {
             r: UintRef::decode(reader)?,
             s: UintRef::decode(reader)?,
         })
-    }
-}
-impl<'a> DecodeValue<'a> for SignatureRef<'a> {
-    type Error = der::Error;
-
-    fn decode_value<R: Reader<'a>>(reader: &mut R, header: Header) -> der::Result<Self> {
-        reader.read_nested(header.length, Self::decode_value_inner)
     }
 }
 impl<'a> Sequence<'a> for SignatureRef<'a> {}


### PR DESCRIPTION
This version notably automatically handles setting up a nested `Reader` for passing to `DecodeValue::decode_value`, eliminating the need to do it manually.

Also cuts an `ecdsa` v0.17.0-rc.3