### PR TITLE
dsa v0.7.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "dsa"
-version = "0.7.0-rc.0"
+version = "0.7.0-rc.1"
 dependencies = [
  "crypto-bigint",
  "crypto-primes",
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.2"
+version = "0.17.0-rc.3"
 dependencies = [
  "der",
  "digest",

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsa"
-version = "0.7.0-rc.0"
+version = "0.7.0-rc.1"
 description = """
 Pure Rust implementation of the Digital Signature Algorithm (DSA) as specified
 in FIPS 186-4 (Digital Signature Standard), providing RFC6979 deterministic


### PR DESCRIPTION
Includes `crypto-bigint` v0.7.0-pre.5 upgrade