### PR TITLE
dsa+ecdsa: bump dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,9 +261,9 @@ checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-pre.5"
+version = "0.7.0-pre.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06a5e703b883b3744ddac8b7c5eade2d800d6559ef99760566f8103e3ad39bf"
+checksum = "98dc20cae677f0af161d98f18463804b680f9af060f6dbe6d4249bd7e838bca1"
 dependencies = [
  "hybrid-array",
  "num-traits",
@@ -304,8 +304,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.0-rc.5"
-source = "git+https://github.com/RustCrypto/formats.git#4cb99df01f32ecc51f036de5d71a42d84cb6f499"
+version = "0.8.0-rc.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7d571780ddd86c50ecbcf7099a945804a55e39c5d13f27d0225c1acecbae248"
 dependencies = [
  "const-oid",
  "der_derive",
@@ -408,8 +409,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.7"
-source = "git+https://github.com/RustCrypto/traits.git#f517eff1f9821f7d67c0bbf9f9fe873ba12f3ab5"
+version = "0.14.0-rc.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5820465ba2b8c6487093ee75f23f8ce283b871e0bd854dd0f7e0d046b874108d"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -744,8 +746,9 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.11.0-rc.4"
-source = "git+https://github.com/RustCrypto/formats.git#4cb99df01f32ecc51f036de5d71a42d84cb6f499"
+version = "0.11.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef85549ba672d102373a0566b322f6618e009442459effa41d5b32741981014d"
 dependencies = [
  "der",
  "spki",
@@ -1035,8 +1038,9 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.8.0-rc.5"
-source = "git+https://github.com/RustCrypto/formats.git#4cb99df01f32ecc51f036de5d71a42d84cb6f499"
+version = "0.8.0-rc.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1231d6ed04c5242799d39a97ca91aeda70ecc27a67870a5fe43149e5c12aed3d"
 dependencies = [
  "base16ct",
  "der",
@@ -1174,9 +1178,9 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.8.0-rc.2"
+version = "0.8.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f0e2bdca9b00f5be6dd3bb6647d50fd0f24a508a95f78e3bb2fe98d0403c85"
+checksum = "4b59f16f15f6f84d24525ca54974b59147ec161ef666b44d055a419bc6392582"
 dependencies = [
  "base64ct",
  "der",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,3 @@ lms-signature = { path = "./lms" }
 ml-dsa = { path = "./ml-dsa" }
 rfc6979 = { path = "./rfc6979" }
 slh-dsa = { path = "./slh-dsa" }
-
-der = { git = "https://github.com/RustCrypto/formats.git" }
-pkcs8 = { git = "https://github.com/RustCrypto/formats.git" }
-sec1 = { git = "https://github.com/RustCrypto/formats.git" }
-
-elliptic-curve = { git = "https://github.com/RustCrypto/traits.git" }

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.85"
 
 [dependencies]
 digest = "0.11.0-rc.0"
-crypto-bigint = { version = "=0.7.0-pre.5", default-features = false, features = ["alloc", "zeroize"] }
+crypto-bigint = { version = "=0.7.0-pre.6", default-features = false, features = ["alloc", "zeroize"] }
 crypto-primes = { version = "=0.7.0-pre.1", default-features = false }
 pkcs8 = { version = "0.11.0-rc.1", default-features = false, features = ["alloc"] }
 rfc6979 = { version = "0.5.0-rc.0" }
@@ -28,7 +28,7 @@ zeroize = { version = "1", default-features = false }
 [dev-dependencies]
 hex = "0.4.3"
 hex-literal = "1"
-pkcs8 = { version = "0.11.0-rc.1", default-features = false, features = ["pem"] }
+pkcs8 = { version = "0.11.0-rc.5", default-features = false, features = ["pem"] }
 proptest = "1"
 rand = "0.9"
 rand_chacha = "0.9"

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -17,17 +17,17 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.7", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.8", default-features = false, features = ["sec1"] }
 signature = { version = "3.0.0-rc.1", default-features = false, features = ["rand_core"] }
 zeroize = { version = "1.5", default-features = false }
 
 # optional dependencies
-der = { version = "0.8.0-rc.5", optional = true }
+der = { version = "0.8.0-rc.6", optional = true }
 digest = { version = "0.11.0-rc.0", optional = true, default-features = false, features = ["oid"] }
 rfc6979 = { version = "0.5.0-rc.0", optional = true }
 serdect = { version = "0.3", optional = true, default-features = false, features = ["alloc"] }
 sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false, features = ["oid"] }
-spki = { version = "0.8.0-rc.0", optional = true, default-features = false }
+spki = { version = "0.8.0-rc.3", optional = true, default-features = false }
 
 [dev-dependencies]
 elliptic-curve = { version = "0.14.0-rc.2", default-features = false, features = ["dev"] }


### PR DESCRIPTION
Bumps the following:
- crypto-bigint v0.7.0-pre.6
- der v0.8.0-rc.6
- elliptic-curve v0.14.0-rc.8
- pkcs8 v0.11.0-rc.5
- sec1 v0.8.0-rc.6
- spki v0.8.0-rc.3