### PR TITLE
chore(deps): bump `elliptic-curve` from `0.14.0-rc.10` to `0.14.0-rc.11`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,9 +261,9 @@ checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-pre.7"
+version = "0.7.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ff38607b7ebe30e4715eeb0a0427ff42e3b6b47b2df55a775e767ef2658ccd"
+checksum = "737a2363b81de8cc95d8780d84aecb4b3c6f41e4473759da6636072b5514c875"
 dependencies = [
  "hybrid-array",
  "num-traits",
@@ -409,8 +409,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.10"
-source = "git+https://github.com/RustCrypto/traits#a10ef181945a480bba5d2fb36ad6f3f78a3474db"
+version = "0.14.0-rc.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88aa505a1a24397f7707ed0c705eb5dfe82920b0768ebde076464d759e9851b5"
 dependencies = [
  "base16ct",
  "crypto-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,6 @@ members = [
 opt-level = 2
 
 [patch.crates-io]
-elliptic-curve = { git = "https://github.com/RustCrypto/traits" }
-
 # A global patch crates-io block is used to avoid duplicate dependencies
 # when pulling a member crate through git
 dsa = { path = "./dsa" }

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -18,8 +18,8 @@ rust-version = "1.85"
 [dependencies]
 der = { version = "0.8.0-rc.7", features = ["alloc"] }
 digest = "0.11.0-rc.0"
-crypto-bigint = { version = "=0.7.0-pre.7", default-features = false, features = ["alloc", "zeroize"] }
-crypto-primes = { version = "=0.7.0-pre.1", default-features = false }
+crypto-bigint = { version = "0.7.0-rc.0", default-features = false, features = ["alloc", "zeroize"] }
+crypto-primes = { version = "0.7.0-pre.1", default-features = false }
 rfc6979 = { version = "0.5.0-rc.0" }
 sha2 = { version = "0.11.0-rc.0", default-features = false }
 signature = { version = "3.0.0-rc.2", default-features = false, features = ["alloc", "digest", "rand_core"] }

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.10", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.11", default-features = false, features = ["sec1"] }
 signature = { version = "3.0.0-rc.2", default-features = false, features = ["rand_core"] }
 zeroize = { version = "1.5", default-features = false }
 
@@ -30,7 +30,7 @@ sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false, fea
 spki = { version = "0.8.0-rc.4", optional = true, default-features = false }
 
 [dev-dependencies]
-elliptic-curve = { version = "0.14.0-rc.10", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.11", default-features = false, features = ["dev"] }
 hex-literal = "1"
 sha2 = { version = "0.11.0-rc.0", default-features = false }
 


### PR DESCRIPTION
This also brings `crypto-bigint` `v0.7.0-rc.0`