### PR TITLE
Cut prereleases with `hybrid-array` v0.4 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "dsa"
-version = "0.7.0-rc.4"
+version = "0.7.0-rc.5"
 dependencies = [
  "crypto-bigint",
  "crypto-primes",
@@ -544,9 +544,9 @@ checksum = "bcaaec4551594c969335c98c903c1397853d4198408ea609190f420500f6be71"
 
 [[package]]
 name = "hmac"
-version = "0.13.0-rc.0"
+version = "0.13.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dc6a2fcc35ab09136c6df2cdf9ca49790701420a3a6b5db0987dddbabc79b21"
+checksum = "49e206bca159aebaaed410f5e78b2fe56bfc0dd5b19ecae922813b8556b8b07e"
 dependencies = [
  "digest",
 ]
@@ -982,7 +982,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rfc6979"
-version = "0.5.0-rc.0"
+version = "0.5.0-rc.1"
 dependencies = [
  "hex-literal 1.0.0",
  "hmac",
@@ -1103,9 +1103,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f9318facddf9ac32a33527066936837e189b3f23ced6edc1603720ead5e2b3d"
+checksum = "c5e046edf639aa2e7afb285589e5405de2ef7e61d4b0ac1e30256e3eab911af9"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsa"
-version = "0.7.0-rc.4"
+version = "0.7.0-rc.5"
 description = """
 Pure Rust implementation of the Digital Signature Algorithm (DSA) as specified
 in FIPS 186-4 (Digital Signature Standard), providing RFC6979 deterministic
@@ -17,12 +17,12 @@ rust-version = "1.85"
 
 [dependencies]
 der = { version = "0.8.0-rc.8", features = ["alloc"] }
-digest = "0.11.0-rc.0"
+digest = "0.11.0-rc.1"
 crypto-bigint = { version = "0.7.0-rc.4", default-features = false, features = ["alloc", "zeroize"] }
 crypto-primes = { version = "0.7.0-pre.1", default-features = false }
-rfc6979 = { version = "0.5.0-rc.0" }
-sha2 = { version = "0.11.0-rc.0", default-features = false }
-signature = { version = "3.0.0-rc.2", default-features = false, features = ["alloc", "digest", "rand_core"] }
+rfc6979 = { version = "0.5.0-rc.1" }
+sha2 = { version = "0.11.0-rc.2", default-features = false }
+signature = { version = "3.0.0-rc.3", default-features = false, features = ["alloc", "digest", "rand_core"] }
 zeroize = { version = "1", default-features = false, features = ["alloc"] }
 
 # optional dependencies
@@ -35,7 +35,7 @@ pkcs8 = { version = "0.11.0-rc.6", default-features = false, features = ["pem"] 
 proptest = "1"
 rand = "0.9"
 rand_chacha = "0.9"
-sha1 = "0.11.0-rc.0"
+sha1 = "0.11.0-rc.2"
 der = { version = "0.8.0-rc.8", features = ["derive"] }
 
 [features]

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecdsa"
-version = "0.17.0-rc.5"
+version = "0.17.0-rc.6"
 description = """
 Pure Rust implementation of the Elliptic Curve Digital Signature Algorithm
 (ECDSA) as specified in FIPS 186-4 (Digital Signature Standard), providing
@@ -24,7 +24,7 @@ zeroize = { version = "1.5", default-features = false }
 # optional dependencies
 der = { version = "0.8.0-rc.8", optional = true }
 digest = { version = "0.11.0-rc.1", optional = true, default-features = false, features = ["oid"] }
-rfc6979 = { version = "0.5.0-rc.0", optional = true }
+rfc6979 = { version = "0.5.0-rc.1", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false, features = ["alloc"] }
 sha2 = { version = "0.11.0-rc.2", optional = true, default-features = false, features = ["oid"] }
 spki = { version = "0.8.0-rc.4", optional = true, default-features = false }

--- a/rfc6979/Cargo.toml
+++ b/rfc6979/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rfc6979"
-version = "0.5.0-rc.0"
+version = "0.5.0-rc.1"
 description = """
 Pure Rust implementation of RFC6979: Deterministic Usage of the
 Digital Signature Algorithm (DSA) and Elliptic Curve Digital Signature Algorithm (ECDSA)
@@ -16,9 +16,9 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-hmac = { version = "0.13.0-rc.0", default-features = false }
+hmac = { version = "0.13.0-rc.1", default-features = false }
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
 hex-literal = "1"
-sha2 = "0.11.0-rc.0"
+sha2 = "0.11.0-rc.2"


### PR DESCRIPTION
Releases the following:
- `dsa` v0.7.0-rc.5
- `ecdsa` v0.17.0-rc.6
- `rfc6979` v0.5.0-rc.1