### PR TITLE
ml-dsa: Rename `KeyGen::key_gen_internal` to `from_seed`

### DIFF
--- a/ml-dsa/benches/ml_dsa.rs
+++ b/ml-dsa/benches/ml_dsa.rs
@@ -15,7 +15,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     let m: B32 = rand(&mut rng);
     let ctx: B32 = rand(&mut rng);
 
-    let kp = MlDsa65::key_gen_internal(&xi);
+    let kp = MlDsa65::from_seed(&xi);
     let sk = kp.signing_key();
     let vk = kp.verifying_key();
     let sig = sk.sign_deterministic(&m, &ctx).unwrap();
@@ -27,7 +27,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     // Key generation
     c.bench_function("keygen", |b| {
         b.iter(|| {
-            let kp = MlDsa65::key_gen_internal(&xi);
+            let kp = MlDsa65::from_seed(&xi);
             let _sk_bytes = kp.signing_key().encode();
             let _vk_bytes = kp.verifying_key().encode();
         })
@@ -53,7 +53,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     // Round trip
     c.bench_function("round_trip", |b| {
         b.iter(|| {
-            let kp = MlDsa65::key_gen_internal(&xi);
+            let kp = MlDsa65::from_seed(&xi);
             let sig = kp.signing_key().sign_deterministic(&m, &ctx).unwrap();
             let _ver = kp.verifying_key().verify_with_context(&m, &ctx, &sig);
         })

--- a/ml-dsa/tests/key-gen.rs
+++ b/ml-dsa/tests/key-gen.rs
@@ -31,7 +31,7 @@ fn verify<P: MlDsaParams>(tc: &acvp::TestCase) {
     let vk_bytes = EncodedVerifyingKey::<P>::try_from(tc.pk.as_slice()).unwrap();
     let sk_bytes = EncodedSigningKey::<P>::try_from(tc.sk.as_slice()).unwrap();
 
-    let kp = P::key_gen_internal(&seed);
+    let kp = P::from_seed(&seed);
     let sk = kp.signing_key().clone();
     let vk = kp.verifying_key().clone();
 

--- a/ml-dsa/tests/proptests.rs
+++ b/ml-dsa/tests/proptests.rs
@@ -11,17 +11,17 @@ const MSG: &[u8] = b"Hello world";
 // Keypairs
 prop_compose! {
     fn mldsa44_keypair()(seed_bytes in any::<[u8; 32]>()) -> KeyPair<MlDsa44> {
-       MlDsa44::key_gen_internal(seed_bytes.as_array_ref())
+       MlDsa44::from_seed(seed_bytes.as_array_ref())
     }
 }
 prop_compose! {
     fn mldsa65_keypair()(seed_bytes in any::<[u8; 32]>()) -> KeyPair<MlDsa65> {
-       MlDsa65::key_gen_internal(seed_bytes.as_array_ref())
+       MlDsa65::from_seed(seed_bytes.as_array_ref())
     }
 }
 prop_compose! {
     fn mldsa87_keypair()(seed_bytes in any::<[u8; 32]>()) -> KeyPair<MlDsa87> {
-        MlDsa87::key_gen_internal(seed_bytes.as_array_ref())
+        MlDsa87::from_seed(seed_bytes.as_array_ref())
     }
 }
 


### PR DESCRIPTION
This is an alternative to #1046 to reduce copying the seed derivation logic. Implementing a `from_seed` as raised in issue #1045.

- Renames `KeyGen::key_gen_internal` to `KeyGen::from_seed`.
- Adds `SigningKey::from_seed`. This internally calls `KeyGen::from_seed` for now, as the majority of the computational work is the same for both keys. A future PR could be slightly more efficient by specialising the SigningKey from_seed method by skipping the couple of extra steps performed to also compute a VerifyingKey, but #1046 shows this only nets a 20us / 10% speed up.
- Adds a test to the `from_seed` implementations don't deviate from each other in future, if more efficient implementations are provided.

I am not sure why `key_gen_internal` was commented to be behind a feature flag or private, as I believe deriving from a seed value is a must-have, assuming this implementation correctly matches the spec. I can look through the spec and codebase for test vectors to make sure, if desired?

Cheers!