### PR TITLE
fix: add SignatureEncoding for ed448::Signature

### DIFF
--- a/ed448/src/lib.rs
+++ b/ed448/src/lib.rs
@@ -177,6 +177,14 @@ impl Signature {
     }
 }
 
+impl SignatureEncoding for Signature {
+    type Repr = SignatureBytes;
+
+    fn to_bytes(&self) -> SignatureBytes {
+        self.to_bytes()
+    }
+}
+
 impl From<Signature> for SignatureBytes {
     fn from(sig: Signature) -> SignatureBytes {
         sig.to_bytes()


### PR DESCRIPTION
```
the trait bound `ed448_goldilocks::Signature: SignatureEncoding` is not satisfied
the following other types implement trait `SignatureEncoding`:
  Ed448Signature
  SignatureWithOid<C>
  ecdsa::Signature<C>
  ecdsa::der::Signature<C>
  ed25519_dalek::Signature
  rsa::pkcs1v15::Signature
  rsa::pss::Signature
```
