### PR TITLE
Bump `crypto-bigint` to v0.7.0-rc.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,9 +261,9 @@ checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.4"
+version = "0.7.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c069823f41bdc75e99546bfd59eb1ed27d69dc720e5c949fe502b82926f8448"
+checksum = "19f2e3541e47d5e2c984b2832e8633b1443671eebba61f0d05e4d2bafba16b23"
 dependencies = [
  "hybrid-array",
  "num-traits",
@@ -284,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-primes"
-version = "0.7.0-pre.1"
+version = "0.7.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae744b9f528151f8c440cf67498f24d2d1ac0ab536b5ce7b1f87a7a5961bd1c1"
+checksum = "6ad2e4e276b4f3cc222e2724cc94e147008ee0e4481c7a220c79e2ec3bdd2bba"
 dependencies = [
  "crypto-bigint",
  "libm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,8 +410,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "elliptic-curve"
 version = "0.14.0-rc.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b95fd42abd85018a59f5dbe05551e9eed19edfd1182a415cd98f90ca5af1422"
+source = "git+https://github.com/RustCrypto/traits#80cfc312a53c41c5c57d50db88172f61b1637f46"
 dependencies = [
  "base16ct",
  "crypto-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,6 @@ lms-signature = { path = "./lms" }
 ml-dsa = { path = "./ml-dsa" }
 rfc6979 = { path = "./rfc6979" }
 slh-dsa = { path = "./slh-dsa" }
+
+# https://github.com/RustCrypto/traits/pull/2008
+elliptic-curve = { git = "https://github.com/RustCrypto/traits" }

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -18,8 +18,8 @@ rust-version = "1.85"
 [dependencies]
 der = { version = "0.8.0-rc.8", features = ["alloc"] }
 digest = "0.11.0-rc.1"
-crypto-bigint = { version = "0.7.0-rc.4", default-features = false, features = ["alloc", "zeroize"] }
-crypto-primes = { version = "0.7.0-pre.1", default-features = false }
+crypto-bigint = { version = "0.7.0-rc.5", default-features = false, features = ["alloc", "zeroize"] }
+crypto-primes = { version = "0.7.0-pre.2", default-features = false }
 rfc6979 = { version = "0.5.0-rc.1" }
 sha2 = { version = "0.11.0-rc.2", default-features = false }
 signature = { version = "3.0.0-rc.3", default-features = false, features = ["alloc", "digest", "rand_core"] }

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -86,7 +86,7 @@ pub use crate::verifying::VerifyingKey;
 
 use core::{fmt, ops::Add};
 use elliptic_curve::{
-    FieldBytes, FieldBytesSize, ScalarPrimitive,
+    FieldBytes, FieldBytesSize, ScalarValue,
     array::{Array, ArraySize, typenum::Unsigned},
 };
 
@@ -208,8 +208,8 @@ pub type SignatureBytes<C> = Array<u8, SignatureSize<C>>;
 /// [IEEE P1363]: https://en.wikipedia.org/wiki/IEEE_P1363
 #[derive(Clone, Eq, PartialEq)]
 pub struct Signature<C: EcdsaCurve> {
-    r: ScalarPrimitive<C>,
-    s: ScalarPrimitive<C>,
+    r: ScalarValue<C>,
+    s: ScalarValue<C>,
 }
 
 impl<C> Signature<C>
@@ -258,8 +258,8 @@ where
     /// - `Err(err)` if the `r` and/or `s` component of the signature is
     ///   out-of-range when interpreted as a big endian integer.
     pub fn from_scalars(r: impl Into<FieldBytes<C>>, s: impl Into<FieldBytes<C>>) -> Result<Self> {
-        let r = ScalarPrimitive::from_slice(&r.into()).map_err(|_| Error::new())?;
-        let s = ScalarPrimitive::from_slice(&s.into()).map_err(|_| Error::new())?;
+        let r = ScalarValue::from_slice(&r.into()).map_err(|_| Error::new())?;
+        let s = ScalarValue::from_slice(&s.into()).map_err(|_| Error::new())?;
 
         if r.is_zero().into() || s.is_zero().into() {
             return Err(Error::new());
@@ -327,7 +327,7 @@ where
     /// [1]: https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki
     pub fn normalize_s(&self) -> Self {
         let mut result = self.clone();
-        let s_inv = ScalarPrimitive::from(-self.s());
+        let s_inv = ScalarValue::from(-self.s());
         result.s.conditional_assign(&s_inv, self.s.is_high());
         result
     }
@@ -524,8 +524,8 @@ where
 
 impl<C: EcdsaCurve> Zeroize for Signature<C> {
     fn zeroize(&mut self) {
-        self.r = ScalarPrimitive::ONE;
-        self.s = ScalarPrimitive::ONE;
+        self.r = ScalarValue::ONE;
+        self.s = ScalarValue::ONE;
     }
 }
 


### PR DESCRIPTION
ecdsa: renames `ScalarPrimitive` to `ScalarValue`

Companion PR to RustCrypto/traits#2008