### PR TITLE
Bump dependencies in Cargo.toml(s)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aes"
-version = "0.9.0-pre.2"
+version = "0.9.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7856582c758ade85d71daf27ec6bcea6c1c73913692b07b8dffea2dc03531c9"
+checksum = "7e713c57c2a2b19159e7be83b9194600d7e8eb3b7c2cd67e671adf47ce189a05"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -144,10 +144,11 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.5.0-pre.7"
+version = "0.5.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b1425e6ce000f05a73096556cabcfb6a10a3ffe3bb4d75416ca8f00819c0b6a"
+checksum = "1e12a13eb01ded5d32ee9658d94f553a19e804204f2dc811df69ab4d9e0cb8c7"
 dependencies = [
+ "block-buffer",
  "crypto-common",
  "inout",
 ]
@@ -194,25 +195,22 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
 dependencies = [
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
  "itertools",
  "num-traits",
- "once_cell",
  "oorandom",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -220,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
 dependencies = [
  "cast",
  "itertools",
@@ -295,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.10.0-pre.2"
+version = "0.10.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e1482d284b80d7fddb211666d513dc5e23b0cc3a03ad398ff70543827c789f"
+checksum = "27e41d01c6f73b9330177f5cf782ae5b581b5f2c7840e298e0275ceee5001434"
 dependencies = [
  "cipher",
 ]
@@ -346,7 +344,7 @@ dependencies = [
  "der",
  "digest",
  "hex",
- "hex-literal 1.0.0",
+ "hex-literal",
  "pkcs8",
  "proptest",
  "rand 0.9.1",
@@ -365,7 +363,7 @@ dependencies = [
  "der",
  "digest",
  "elliptic-curve",
- "hex-literal 1.0.0",
+ "hex-literal",
  "rfc6979",
  "serdect",
  "sha2",
@@ -379,7 +377,7 @@ name = "ed25519"
 version = "3.0.0-rc.0"
 dependencies = [
  "bincode",
- "hex-literal 1.0.0",
+ "hex-literal",
  "pkcs8",
  "rand_core 0.9.3",
  "serde",
@@ -393,7 +391,7 @@ name = "ed448"
 version = "0.5.0-rc.0"
 dependencies = [
  "bincode",
- "hex-literal 1.0.0",
+ "hex-literal",
  "pkcs8",
  "serde",
  "serde_bytes",
@@ -418,7 +416,7 @@ dependencies = [
  "digest",
  "ff",
  "group",
- "hex-literal 1.0.0",
+ "hex-literal",
  "hybrid-array",
  "pem-rfc7468",
  "pkcs8",
@@ -516,12 +514,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,12 +521,6 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "hex-literal"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hex-literal"
@@ -571,21 +557,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -608,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.2.0-pre.0"
+version = "0.2.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cdd4f0dc5807b9a2b25dd48a3f58e862606fe7bd47f41ecde36e97422d7e90"
+checksum = "3d546793a04a1d3049bd192856f804cfe96356e2cf36b54b4e575155babe9f41"
 dependencies = [
  "cpufeatures",
 ]
@@ -645,7 +620,7 @@ version = "0.1.0-pre"
 dependencies = [
  "digest",
  "hex",
- "hex-literal 0.4.1",
+ "hex-literal",
  "hybrid-array",
  "rand 0.9.1",
  "rand_core 0.9.3",
@@ -675,7 +650,7 @@ dependencies = [
  "const-oid",
  "criterion",
  "hex",
- "hex-literal 1.0.0",
+ "hex-literal",
  "hybrid-array",
  "num-traits",
  "pkcs8",
@@ -984,7 +959,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 name = "rfc6979"
 version = "0.5.0-rc.1"
 dependencies = [
- "hex-literal 1.0.0",
+ "hex-literal",
  "hmac",
  "sha2",
  "subtle",
@@ -1125,9 +1100,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e6a92fd180fd205defdc0b78288ce847c7309d329fd6647a814567e67db50e"
+checksum = "2103ca0e6f4e9505eae906de5e5883e06fc3b2232fb5d6914890c7bbcb62f478"
 dependencies = [
  "digest",
  "keccak",
@@ -1154,7 +1129,7 @@ dependencies = [
  "ctr",
  "digest",
  "hex",
- "hex-literal 1.0.0",
+ "hex-literal",
  "hmac",
  "hybrid-array",
  "num-bigint",

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -29,7 +29,7 @@ zeroize = { version = "1", default-features = false, features = ["alloc"] }
 pkcs8 = { version = "0.11.0-rc.6", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
-hex = "0.4.3"
+hex = "0.4"
 hex-literal = "1"
 pkcs8 = { version = "0.11.0-rc.6", default-features = false, features = ["pem"] }
 proptest = "1"

--- a/lms/Cargo.toml
+++ b/lms/Cargo.toml
@@ -12,16 +12,16 @@ categories = ["cryptography"]
 keywords = ["crypto", "signature"]
 
 [dependencies]
-digest = "0.11.0-rc.0"
+digest = "0.11.0-rc.1"
 hybrid-array = { version = "0.4", features = ["extra-sizes", "zeroize"] }
 rand = "0.9.0"
-sha2 = "0.11.0-rc.0"
-static_assertions = "1.1.0"
-rand_core = "0.9.0"
+sha2 = "0.11.0-rc.2"
+static_assertions = "1.1"
+rand_core = "0.9"
 signature = { version = "3.0.0-rc.4", features = ["alloc", "digest", "rand_core"] }
-typenum = { version = "1.17.0", features = ["const-generics"] }
-zeroize = "1.8.1"
+typenum = { version = "1.17", features = ["const-generics"] }
+zeroize = "1.8"
 
 [dev-dependencies]
-hex = "0.4.3"
-hex-literal = "0.4.1"
+hex = "0.4"
+hex-literal = "1"

--- a/ml-dsa/Cargo.toml
+++ b/ml-dsa/Cargo.toml
@@ -33,18 +33,19 @@ pkcs8 = ["dep:const-oid", "dep:pkcs8"]
 
 [dependencies]
 hybrid-array = { version = "0.4", features = ["extra-sizes"] }
-num-traits = { version = "0.2.19", default-features = false }
-rand_core = { version = "0.9", optional = true }
-sha3 = "0.11.0-rc.0"
+num-traits = { version = "0.2", default-features = false }
+sha3 = "0.11.0-rc.3"
 signature = { version = "3.0.0-rc.4", default-features = false, features = ["digest"] }
-zeroize = { version = "1.8.1", optional = true, default-features = false }
 
+# optional dependencies
 const-oid = { version = "0.10", features = ["db"], optional = true }
 pkcs8 = { version = "0.11.0-rc.6", default-features = false, optional = true }
+rand_core = { version = "0.9", optional = true }
+zeroize = { version = "1.8.1", optional = true, default-features = false }
 
 [dev-dependencies]
-criterion = "0.5.1"
-hex = { version = "0.4.3", features = ["serde"] }
+criterion = "0.7"
+hex = { version = "0.4", features = ["serde"] }
 hex-literal = "1"
 pkcs8 = { version = "0.11.0-rc.6", features = ["pem"] }
 proptest = "1"

--- a/slh-dsa/Cargo.toml
+++ b/slh-dsa/Cargo.toml
@@ -17,14 +17,14 @@ exclude = ["tests"]
 
 [dependencies]
 hybrid-array = { version = "0.4", features = ["extra-sizes"] }
-typenum = { version = "1.17.0", features = ["const-generics"] }
+typenum = { version = "1.17", features = ["const-generics"] }
 sha3 = { version = "0.11.0-rc.0", default-features = false }
-zerocopy = { version = "0.7.34", features = ["derive"] }
-rand_core = { version = "0.9.2" }
+zerocopy = { version = "0.7", features = ["derive"] }
+rand_core = { version = "0.9" }
 signature = { version = "3.0.0-rc.4", features = ["rand_core"] }
-hmac = "0.13.0-prc.0"
-sha2 = { version = "0.11.0-rc.0", default-features = false }
-digest = "0.11.0-rc.0"
+hmac = "0.13.0-rc.1"
+sha2 = { version = "0.11.0-rc.2", default-features = false }
+digest = "0.11.0-rc.1"
 pkcs8 = { version = "0.11.0-rc.6", default-features = false }
 const-oid = { version = "0.10", features = ["db"] }
 zeroize = { version = "1.8.1", optional = true, default-features = false }
@@ -36,10 +36,10 @@ num-bigint = "0.4.4"
 quickcheck = "1"
 quickcheck_macros = "1"
 proptest = "1.4.0"
-criterion = "0.5"
-aes = "=0.9.0-pre.2"
-cipher = "=0.5.0-pre.7"
-ctr = "=0.10.0-pre.2"
+criterion = "0.7"
+aes = "0.9.0-rc.1"
+cipher = "0.5.0-rc.1"
+ctr = "0.10.0-rc.1"
 rand_core = "0.9.2"
 paste = "1.0.15"
 rand = "0.9"

--- a/slh-dsa/benches/sign_verify.rs
+++ b/slh-dsa/benches/sign_verify.rs
@@ -1,6 +1,7 @@
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
 use signature::{Keypair, Signer, Verifier};
 use slh_dsa::*;
+use std::hint::black_box;
 
 pub fn sign_benchmark<P: ParameterSet>(c: &mut Criterion) {
     let mut rng = rand::rng();


### PR DESCRIPTION
Bumps the following:
- `aes` v0.9.0-rc.1
- `cipher` v0.5.0-rc.1
- `criterion` v0.7
- `ctr` v0.10.0-rc.1
- `hex-literal` v1
- `sha3` v0.11.0-rc.3