### PR TITLE
slh-dsa: bump `zerocopy` to v0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,12 +98,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -763,7 +757,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.25",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1146,7 +1140,7 @@ dependencies = [
  "sha3",
  "signature",
  "typenum",
- "zerocopy 0.7.35",
+ "zerocopy",
  "zeroize",
 ]
 
@@ -1419,32 +1413,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "byteorder",
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
- "zerocopy-derive 0.8.25",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "zerocopy-derive",
 ]
 
 [[package]]

--- a/slh-dsa/Cargo.toml
+++ b/slh-dsa/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["tests"]
 hybrid-array = { version = "0.4", features = ["extra-sizes"] }
 typenum = { version = "1.17", features = ["const-generics"] }
 sha3 = { version = "0.11.0-rc.0", default-features = false }
-zerocopy = { version = "0.7", features = ["derive"] }
+zerocopy = { version = "0.8", features = ["derive"] }
 rand_core = { version = "0.9" }
 signature = { version = "3.0.0-rc.4", features = ["rand_core"] }
 hmac = "0.13.0-rc.1"

--- a/slh-dsa/src/address.rs
+++ b/slh-dsa/src/address.rs
@@ -18,8 +18,10 @@
 use hybrid_array::Array;
 use typenum::U22;
 
-use zerocopy::AsBytes;
-use zerocopy::byteorder::big_endian::{U32, U64};
+use zerocopy::{
+    Immutable, IntoBytes,
+    byteorder::big_endian::{U32, U64},
+};
 
 /// `Address` represents a hash address as defined by FIPS-205 section 4.2
 pub trait Address: AsRef<[u8]> {
@@ -39,7 +41,7 @@ pub trait Address: AsRef<[u8]> {
     }
 }
 
-#[derive(Clone, AsBytes)]
+#[derive(Clone, IntoBytes, Immutable)]
 #[repr(C)]
 pub struct WotsHash {
     pub layer_adrs: U32,
@@ -51,7 +53,7 @@ pub struct WotsHash {
     pub hash_adrs: U32,
 }
 
-#[derive(Clone, AsBytes)]
+#[derive(Clone, IntoBytes, Immutable)]
 #[repr(C)]
 pub struct WotsPk {
     pub layer_adrs: U32,
@@ -62,7 +64,7 @@ pub struct WotsPk {
     padding: U64, // 0
 }
 
-#[derive(Clone, AsBytes)]
+#[derive(Clone, IntoBytes, Immutable)]
 #[repr(C)]
 pub struct HashTree {
     pub layer_adrs: U32,
@@ -74,7 +76,7 @@ pub struct HashTree {
     pub tree_index: U32,
 }
 
-#[derive(Clone, AsBytes)]
+#[derive(Clone, IntoBytes, Immutable)]
 #[repr(C)]
 pub struct ForsTree {
     layer_adrs: U32, // 0
@@ -86,7 +88,7 @@ pub struct ForsTree {
     pub tree_index: U32,
 }
 
-#[derive(Clone, AsBytes)]
+#[derive(Clone, IntoBytes, Immutable)]
 #[repr(C)]
 pub struct ForsRoots {
     layer_adrs: U32, // 0
@@ -97,7 +99,7 @@ pub struct ForsRoots {
     padding: U64, // 0
 }
 
-#[derive(Clone, AsBytes)]
+#[derive(Clone, IntoBytes, Immutable)]
 #[repr(C)]
 pub struct WotsPrf {
     pub layer_adrs: U32,
@@ -109,7 +111,7 @@ pub struct WotsPrf {
     hash_adrs: U32, // 0
 }
 
-#[derive(Clone, AsBytes)]
+#[derive(Clone, IntoBytes, Immutable)]
 #[repr(C)]
 pub struct ForsPrf {
     layer_adrs: U32, // 0


### PR DESCRIPTION
The `AsBytes` trait is gone, and now found on the `IntoBytes` trait.

It needs a new `Immutable` marker trait which says:

> Types which are free from interior mutability.

...so it seems safe to add to the types that previously used `AsBytes` which are simple data structs.