### PR TITLE
New `.rc` prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "dsa"
-version = "0.7.0-rc.5"
+version = "0.7.0-rc.6"
 dependencies = [
  "crypto-bigint",
  "crypto-primes",
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.6"
+version = "0.17.0-rc.7"
 dependencies = [
  "der",
  "digest",
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "3.0.0-rc.0"
+version = "3.0.0-rc.1"
 dependencies = [
  "bincode",
  "hex-literal",
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "ed448"
-version = "0.5.0-rc.0"
+version = "0.5.0-rc.1"
 dependencies = [
  "bincode",
  "hex-literal",
@@ -610,7 +610,7 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "lms-signature"
-version = "0.1.0-pre"
+version = "0.1.0-rc.0"
 dependencies = [
  "digest",
  "hex",
@@ -639,7 +639,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "ml-dsa"
-version = "0.1.0-pre.2"
+version = "0.1.0-rc.0"
 dependencies = [
  "const-oid",
  "criterion",
@@ -1114,7 +1114,7 @@ dependencies = [
 
 [[package]]
 name = "slh-dsa"
-version = "0.2.0-pre"
+version = "0.2.0-rc.0"
 dependencies = [
  "aes",
  "cipher",

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsa"
-version = "0.7.0-rc.5"
+version = "0.7.0-rc.6"
 description = """
 Pure Rust implementation of the Digital Signature Algorithm (DSA) as specified
 in FIPS 186-4 (Digital Signature Standard), providing RFC6979 deterministic

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecdsa"
-version = "0.17.0-rc.6"
+version = "0.17.0-rc.7"
 description = """
 Pure Rust implementation of the Elliptic Curve Digital Signature Algorithm
 (ECDSA) as specified in FIPS 186-4 (Digital Signature Standard), providing

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed25519"
-version = "3.0.0-rc.0"
+version = "3.0.0-rc.1"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """

--- a/ed448/Cargo.toml
+++ b/ed448/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed448"
-version = "0.5.0-rc.0"
+version = "0.5.0-rc.1"
 edition = "2024"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"

--- a/lms/Cargo.toml
+++ b/lms/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lms-signature"
 description = "Pure Rust implementation of Leighton-Micali Hash-Based Signatures (RFC 8554)"
-version = "0.1.0-pre"
+version = "0.1.0-rc.0"
 edition = "2024"
 license = "Apache-2.0 OR MIT"
 homepage = "https://github.com/RustCrypto/signatures/tree/master/lms"

--- a/ml-dsa/Cargo.toml
+++ b/ml-dsa/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Pure Rust implementation of ML-DSA (formerly known as CRYSTALS-Dilithium) as
 described in FIPS-204 (final)
 """
-version = "0.1.0-pre.2"
+version = "0.1.0-rc.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"

--- a/slh-dsa/Cargo.toml
+++ b/slh-dsa/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Pure Rust implementation of SLH-DSA (aka SPHINCS+) as described in the
 FIPS-205 standard
 """
-version = "0.2.0-pre"
+version = "0.2.0-rc.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
- `dsa` v0.7.0-rc.6
- `ecdsa` v0.17.0-rc.7
- `ed25519` v3.0.0-rc.1
- `ed448` v0.5.0-rc.1
- `lms-signature` v0.1.0-rc.0
- `ml-dsa` v0.1.0-rc.0
- `slh-dsa` v0.2.0-rc.0