### PR TITLE
`rfc6979`: replace `Digest` requirement with `EagerHash`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,6 +358,7 @@ dependencies = [
  "digest",
  "elliptic-curve",
  "hex-literal",
+ "hmac",
  "rfc6979",
  "serdect",
  "sha2",

--- a/dsa/src/generate/secret_number.rs
+++ b/dsa/src/generate/secret_number.rs
@@ -6,7 +6,7 @@ use crate::{Components, signing_key::SigningKey};
 use alloc::vec;
 use core::cmp::min;
 use crypto_bigint::{BoxedUint, NonZero, RandomBits, Resize};
-use digest::{Digest, FixedOutputReset, block_api::BlockSizeUser};
+use rfc6979::hmac::EagerHash;
 use signature::rand_core::TryCryptoRng;
 use zeroize::Zeroizing;
 
@@ -25,7 +25,7 @@ pub fn secret_number_rfc6979<D>(
     hash: &[u8],
 ) -> Result<(BoxedUint, BoxedUint), signature::Error>
 where
-    D: Digest + BlockSizeUser + FixedOutputReset,
+    D: EagerHash,
 {
     let q = signing_key.verifying_key().components().q();
     let size = (q.bits() / 8) as usize;

--- a/dsa/src/signing_key.rs
+++ b/dsa/src/signing_key.rs
@@ -13,7 +13,8 @@ use crypto_bigint::{
     BoxedUint, NonZero, Resize,
     modular::{BoxedMontyForm, BoxedMontyParams},
 };
-use digest::{Digest, FixedOutputReset, Update, block_api::BlockSizeUser};
+use digest::Update;
+use rfc6979::hmac::EagerHash;
 use signature::{
     DigestSigner, MultipartSigner, RandomizedDigestSigner, Signer,
     hazmat::{PrehashSigner, RandomizedPrehashSigner},
@@ -94,7 +95,7 @@ impl SigningKey {
     #[cfg(feature = "hazmat")]
     pub fn sign_prehashed_rfc6979<D>(&self, prehash: &[u8]) -> Result<Signature, signature::Error>
     where
-        D: Digest + BlockSizeUser + FixedOutputReset,
+        D: EagerHash,
     {
         let k_kinv = crate::generate::secret_number_rfc6979::<D>(self, prehash)?;
         self.sign_prehashed(k_kinv, prehash)
@@ -158,7 +159,7 @@ impl Signer<Signature> for SigningKey {
 impl MultipartSigner<Signature> for SigningKey {
     fn try_multipart_sign(&self, msg: &[&[u8]]) -> Result<Signature, signature::Error> {
         self.try_sign_digest(|digest: &mut sha2::Sha256| {
-            msg.iter().for_each(|slice| Digest::update(digest, slice));
+            msg.iter().for_each(|slice| digest.update(slice));
             Ok(())
         })
     }
@@ -190,7 +191,7 @@ impl RandomizedPrehashSigner<Signature> for SigningKey {
 
 impl<D> DigestSigner<D, Signature> for SigningKey
 where
-    D: Digest + BlockSizeUser + FixedOutputReset,
+    D: EagerHash + Update,
 {
     fn try_sign_digest<F: Fn(&mut D) -> Result<(), signature::Error>>(
         &self,
@@ -198,7 +199,7 @@ where
     ) -> Result<Signature, signature::Error> {
         let mut digest = D::new();
         f(&mut digest)?;
-        let hash = digest.finalize_fixed();
+        let hash = digest.finalize();
         let ks = crate::generate::secret_number_rfc6979::<D>(self, &hash)?;
 
         self.sign_prehashed(ks, &hash)
@@ -207,7 +208,7 @@ where
 
 impl<D> RandomizedDigestSigner<D, Signature> for SigningKey
 where
-    D: Digest + Update,
+    D: EagerHash + Update,
 {
     fn try_sign_digest_with_rng<
         R: TryCryptoRng + ?Sized,

--- a/dsa/src/verifying_key.rs
+++ b/dsa/src/verifying_key.rs
@@ -8,7 +8,8 @@ use crypto_bigint::{
     BoxedUint, NonZero, Resize,
     modular::{BoxedMontyForm, BoxedMontyParams},
 };
-use digest::{Digest, Update};
+use digest::Update;
+use rfc6979::hmac::EagerHash;
 use signature::{DigestVerifier, MultipartVerifier, Verifier, hazmat::PrehashVerifier};
 
 #[cfg(feature = "pkcs8")]
@@ -126,7 +127,7 @@ impl MultipartVerifier<Signature> for VerifyingKey {
     ) -> Result<(), signature::Error> {
         self.verify_digest(
             |digest: &mut sha2::Sha256| {
-                msg.iter().for_each(|slice| Digest::update(digest, slice));
+                msg.iter().for_each(|slice| digest.update(slice));
                 Ok(())
             },
             signature,
@@ -150,7 +151,7 @@ impl PrehashVerifier<Signature> for VerifyingKey {
 
 impl<D> DigestVerifier<D, Signature> for VerifyingKey
 where
-    D: Digest + Update,
+    D: EagerHash + Update,
 {
     fn verify_digest<F: Fn(&mut D) -> Result<(), signature::Error>>(
         &self,

--- a/dsa/tests/deterministic.rs
+++ b/dsa/tests/deterministic.rs
@@ -1,7 +1,8 @@
 #![cfg(feature = "hazmat")]
 use crypto_bigint::BoxedUint;
-use digest::{Digest, FixedOutputReset, block_api::BlockSizeUser};
+use digest::Update;
 use dsa::{Components, Signature, SigningKey, VerifyingKey};
+use rfc6979::hmac::EagerHash;
 use sha1::Sha1;
 use sha2::{Sha224, Sha256, Sha384, Sha512};
 use signature::DigestSigner;
@@ -100,15 +101,15 @@ fn dsa_2048_signing_key() -> SigningKey {
 /// Generate a signature given the unhashed message and a private key
 fn generate_signature<D>(signing_key: SigningKey, data: &[u8]) -> Signature
 where
-    D: Digest + BlockSizeUser + FixedOutputReset,
+    D: EagerHash + Update,
 {
-    signing_key.sign_digest(|digest: &mut D| Digest::update(digest, data))
+    signing_key.sign_digest(|digest: &mut D| Update::update(digest, data))
 }
 
 /// Generate a signature using the 1024-bit DSA key
 fn generate_1024_signature<D>(data: &[u8]) -> Signature
 where
-    D: Digest + BlockSizeUser + FixedOutputReset,
+    D: EagerHash + Update,
 {
     generate_signature::<D>(dsa_1024_signing_key(), data)
 }
@@ -116,7 +117,7 @@ where
 /// Generate a signature using the 2048-bit DSA key
 fn generate_2048_signature<D>(data: &[u8]) -> Signature
 where
-    D: Digest + BlockSizeUser + FixedOutputReset,
+    D: EagerHash + Update,
 {
     generate_signature::<D>(dsa_2048_signing_key(), data)
 }

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -24,6 +24,7 @@ zeroize = { version = "1.5", default-features = false }
 # optional dependencies
 der = { version = "0.8.0-rc.8", optional = true }
 digest = { version = "0.11.0-rc.1", optional = true, default-features = false, features = ["oid"] }
+hmac = { version = "0.13.0-rc.1", default-features = false, optional = true }
 rfc6979 = { version = "0.5.0-rc.1", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false, features = ["alloc"] }
 sha2 = { version = "0.11.0-rc.2", optional = true, default-features = false, features = ["oid"] }
@@ -39,14 +40,15 @@ default = ["digest"]
 alloc = ["elliptic-curve/alloc", "signature/alloc", "spki/alloc"]
 std = ["alloc", "elliptic-curve/std"]
 
-arithmetic = ["elliptic-curve/arithmetic"]
+arithmetic = ["dep:hmac", "dep:rfc6979", "elliptic-curve/arithmetic"]
+algorithm = ["dep:rfc6979", "arithmetic", "digest", "hazmat"]
 dev = ["arithmetic", "digest", "elliptic-curve/dev", "hazmat"]
-digest = ["dep:digest", "elliptic-curve/digest", "signature/digest", "rfc6979"]
+der = ["dep:der"]
+digest = ["dep:digest", "dep:hmac", "elliptic-curve/digest", "signature/digest"]
 hazmat = []
-pkcs8 = ["digest", "elliptic-curve/pkcs8", "der"]
+pkcs8 = ["der", "digest", "elliptic-curve/pkcs8"]
 pem = ["elliptic-curve/pem", "pkcs8"]
-serde = ["elliptic-curve/serde", "pkcs8", "serdect"]
-signature = ["arithmetic", "digest", "hazmat", "rfc6979"]
+serde = ["dep:serdect", "elliptic-curve/serde", "pkcs8"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -41,13 +41,12 @@ std = ["alloc", "elliptic-curve/std"]
 
 arithmetic = ["elliptic-curve/arithmetic"]
 dev = ["arithmetic", "digest", "elliptic-curve/dev", "hazmat"]
-digest = ["dep:digest", "elliptic-curve/digest", "signature/digest"]
+digest = ["dep:digest", "elliptic-curve/digest", "signature/digest", "rfc6979"]
 hazmat = []
 pkcs8 = ["digest", "elliptic-curve/pkcs8", "der"]
 pem = ["elliptic-curve/pem", "pkcs8"]
 serde = ["elliptic-curve/serde", "pkcs8", "serdect"]
-signing = ["arithmetic", "digest", "hazmat", "rfc6979"]
-verifying = ["arithmetic", "digest", "hazmat"]
+signature = ["arithmetic", "digest", "hazmat", "rfc6979"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -34,7 +34,7 @@ use crate::{
 };
 
 #[cfg(any(feature = "arithmetic", feature = "digest"))]
-use rfc6979::hmac::EagerHash;
+use hmac::EagerHash;
 
 /// Bind a preferred [`Digest`] algorithm to an elliptic curve type.
 ///

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -65,9 +65,9 @@ pub mod der;
 pub mod dev;
 #[cfg(feature = "hazmat")]
 pub mod hazmat;
-#[cfg(feature = "signing")]
+#[cfg(feature = "signature")]
 mod signing;
-#[cfg(feature = "verifying")]
+#[cfg(feature = "signature")]
 mod verifying;
 
 pub use crate::recovery::RecoveryId;
@@ -79,9 +79,9 @@ pub use elliptic_curve::{self, PrimeCurve, sec1::EncodedPoint};
 pub use signature::{self, Error, Result, SignatureEncoding};
 use zeroize::Zeroize;
 
-#[cfg(feature = "signing")]
+#[cfg(feature = "signature")]
 pub use crate::signing::SigningKey;
-#[cfg(feature = "verifying")]
+#[cfg(feature = "signature")]
 pub use crate::verifying::VerifyingKey;
 
 use core::{fmt, ops::Add};

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -65,9 +65,9 @@ pub mod der;
 pub mod dev;
 #[cfg(feature = "hazmat")]
 pub mod hazmat;
-#[cfg(feature = "signature")]
+#[cfg(feature = "algorithm")]
 mod signing;
-#[cfg(feature = "signature")]
+#[cfg(feature = "algorithm")]
 mod verifying;
 
 pub use crate::recovery::RecoveryId;
@@ -79,9 +79,9 @@ pub use elliptic_curve::{self, PrimeCurve, sec1::EncodedPoint};
 pub use signature::{self, Error, Result, SignatureEncoding};
 use zeroize::Zeroize;
 
-#[cfg(feature = "signature")]
+#[cfg(feature = "algorithm")]
 pub use crate::signing::SigningKey;
-#[cfg(feature = "signature")]
+#[cfg(feature = "algorithm")]
 pub use crate::verifying::VerifyingKey;
 
 use core::{fmt, ops::Add};

--- a/ecdsa/src/recovery.rs
+++ b/ecdsa/src/recovery.rs
@@ -2,7 +2,7 @@
 
 use crate::{Error, Result};
 
-#[cfg(feature = "signature")]
+#[cfg(feature = "algorithm")]
 use {
     crate::{
         EcdsaCurve, Signature, SignatureSize, SigningKey, VerifyingKey,
@@ -80,7 +80,7 @@ impl RecoveryId {
     }
 }
 
-#[cfg(feature = "signature")]
+#[cfg(feature = "algorithm")]
 impl RecoveryId {
     /// Given a public key, message, and signature, use trial recovery
     /// to determine if a suitable recovery ID exists, or return an error
@@ -167,7 +167,7 @@ impl From<RecoveryId> for u8 {
     }
 }
 
-#[cfg(feature = "signature")]
+#[cfg(feature = "algorithm")]
 impl<C> SigningKey<C>
 where
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
@@ -216,7 +216,7 @@ where
     }
 }
 
-#[cfg(feature = "signature")]
+#[cfg(feature = "algorithm")]
 impl<C, D> DigestSigner<D, (Signature<C>, RecoveryId)> for SigningKey<C>
 where
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
@@ -234,7 +234,7 @@ where
     }
 }
 
-#[cfg(feature = "signature")]
+#[cfg(feature = "algorithm")]
 impl<C> RandomizedPrehashSigner<(Signature<C>, RecoveryId)> for SigningKey<C>
 where
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
@@ -250,7 +250,7 @@ where
     }
 }
 
-#[cfg(feature = "signature")]
+#[cfg(feature = "algorithm")]
 impl<C, D> RandomizedDigestSigner<D, (Signature<C>, RecoveryId)> for SigningKey<C>
 where
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
@@ -269,7 +269,7 @@ where
     }
 }
 
-#[cfg(feature = "signature")]
+#[cfg(feature = "algorithm")]
 impl<C> PrehashSigner<(Signature<C>, RecoveryId)> for SigningKey<C>
 where
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
@@ -281,7 +281,7 @@ where
     }
 }
 
-#[cfg(feature = "signature")]
+#[cfg(feature = "algorithm")]
 impl<C> Signer<(Signature<C>, RecoveryId)> for SigningKey<C>
 where
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
@@ -293,7 +293,7 @@ where
     }
 }
 
-#[cfg(feature = "signature")]
+#[cfg(feature = "algorithm")]
 impl<C> MultipartSigner<(Signature<C>, RecoveryId)> for SigningKey<C>
 where
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
@@ -307,7 +307,7 @@ where
     }
 }
 
-#[cfg(feature = "signature")]
+#[cfg(feature = "algorithm")]
 impl<C> VerifyingKey<C>
 where
     C: EcdsaCurve + CurveArithmetic,

--- a/ecdsa/src/signing.rs
+++ b/ecdsa/src/signing.rs
@@ -23,10 +23,13 @@ use signature::{
 };
 
 #[cfg(feature = "der")]
-use {crate::der, core::ops::Add, elliptic_curve::FieldBytesSize};
+use {crate::der, core::ops::Add};
 
 #[cfg(feature = "pem")]
 use {core::str::FromStr, elliptic_curve::pkcs8::DecodePrivateKey};
+
+#[cfg(any(feature = "der", feature = "pem"))]
+use elliptic_curve::FieldBytesSize;
 
 #[cfg(feature = "pkcs8")]
 use crate::elliptic_curve::{
@@ -39,7 +42,7 @@ use crate::elliptic_curve::{
     sec1::{self, FromEncodedPoint, ToEncodedPoint},
 };
 
-#[cfg(feature = "signature")]
+#[cfg(feature = "algorithm")]
 use {crate::VerifyingKey, elliptic_curve::PublicKey, signature::KeypairRef};
 
 #[cfg(all(feature = "alloc", feature = "pkcs8"))]
@@ -72,7 +75,7 @@ where
     secret_scalar: NonZeroScalar<C>,
 
     /// Verifying key which corresponds to this signing key.
-    #[cfg(feature = "signature")]
+    #[cfg(feature = "algorithm")]
     verifying_key: VerifyingKey<C>,
 }
 
@@ -125,7 +128,7 @@ where
     }
 
     /// Get the [`VerifyingKey`] which corresponds to this [`SigningKey`].
-    #[cfg(feature = "signature")]
+    #[cfg(feature = "algorithm")]
     pub fn verifying_key(&self) -> &VerifyingKey<C> {
         &self.verifying_key
     }
@@ -441,7 +444,7 @@ where
 // Other trait impls
 //
 
-#[cfg(feature = "signature")]
+#[cfg(feature = "algorithm")]
 impl<C> AsRef<VerifyingKey<C>> for SigningKey<C>
 where
     C: EcdsaCurve + CurveArithmetic,
@@ -512,12 +515,12 @@ where
     SignatureSize<C>: ArraySize,
 {
     fn from(secret_scalar: NonZeroScalar<C>) -> Self {
-        #[cfg(feature = "signature")]
+        #[cfg(feature = "algorithm")]
         let public_key = PublicKey::from_secret_scalar(&secret_scalar);
 
         Self {
             secret_scalar,
-            #[cfg(feature = "signature")]
+            #[cfg(feature = "algorithm")]
             verifying_key: public_key.into(),
         }
     }
@@ -588,7 +591,7 @@ where
 {
 }
 
-#[cfg(feature = "signature")]
+#[cfg(feature = "algorithm")]
 impl<C> From<SigningKey<C>> for VerifyingKey<C>
 where
     C: EcdsaCurve + CurveArithmetic,
@@ -600,7 +603,7 @@ where
     }
 }
 
-#[cfg(feature = "signature")]
+#[cfg(feature = "algorithm")]
 impl<C> From<&SigningKey<C>> for VerifyingKey<C>
 where
     C: EcdsaCurve + CurveArithmetic,
@@ -612,7 +615,7 @@ where
     }
 }
 
-#[cfg(feature = "signature")]
+#[cfg(feature = "algorithm")]
 impl<C> KeypairRef for SigningKey<C>
 where
     C: EcdsaCurve + CurveArithmetic,

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -5,6 +5,7 @@ use crate::{
     hazmat::{self, DigestAlgorithm, bits2field},
 };
 use core::{cmp::Ordering, fmt::Debug};
+use digest::Update;
 use elliptic_curve::{
     AffinePoint, CurveArithmetic, FieldBytesSize, ProjectivePoint, PublicKey,
     array::ArraySize,
@@ -12,11 +13,8 @@ use elliptic_curve::{
     scalar::IsHigh,
     sec1::{self, CompressedPoint, EncodedPoint, FromEncodedPoint, ToEncodedPoint},
 };
-use signature::{
-    DigestVerifier, MultipartVerifier, Verifier,
-    digest::{Digest, FixedOutput},
-    hazmat::PrehashVerifier,
-};
+use rfc6979::hmac::EagerHash;
+use signature::{DigestVerifier, MultipartVerifier, Verifier, hazmat::PrehashVerifier};
 
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
@@ -147,7 +145,7 @@ where
 impl<C, D> DigestVerifier<D, Signature<C>> for VerifyingKey<C>
 where
     C: EcdsaCurve + CurveArithmetic,
-    D: Digest + FixedOutput,
+    D: EagerHash + Update,
     SignatureSize<C>: ArraySize,
 {
     fn verify_digest<F: Fn(&mut D) -> Result<()>>(
@@ -223,26 +221,28 @@ where
     SignatureSize<C>: ArraySize,
 {
     fn multipart_verify(&self, msg: &[&[u8]], sig: &SignatureWithOid<C>) -> Result<()> {
+        use digest::FixedOutput;
+
         match sig.oid() {
             ECDSA_SHA224_OID => {
-                let mut digest = Sha224::new();
+                let mut digest = Sha224::default();
                 msg.iter().for_each(|slice| digest.update(slice));
-                self.verify_prehash(&digest.finalize(), sig.signature())
+                self.verify_prehash(&digest.finalize_fixed(), sig.signature())
             }
             ECDSA_SHA256_OID => {
-                let mut digest = Sha256::new();
+                let mut digest = Sha256::default();
                 msg.iter().for_each(|slice| digest.update(slice));
-                self.verify_prehash(&digest.finalize(), sig.signature())
+                self.verify_prehash(&digest.finalize_fixed(), sig.signature())
             }
             ECDSA_SHA384_OID => {
-                let mut digest = Sha384::new();
+                let mut digest = Sha384::default();
                 msg.iter().for_each(|slice| digest.update(slice));
-                self.verify_prehash(&digest.finalize(), sig.signature())
+                self.verify_prehash(&digest.finalize_fixed(), sig.signature())
             }
             ECDSA_SHA512_OID => {
-                let mut digest = Sha512::new();
+                let mut digest = Sha512::default();
                 msg.iter().for_each(|slice| digest.update(slice));
-                self.verify_prehash(&digest.finalize(), sig.signature())
+                self.verify_prehash(&digest.finalize_fixed(), sig.signature())
             }
             _ => Err(Error::new()),
         }
@@ -253,7 +253,7 @@ where
 impl<C, D> DigestVerifier<D, der::Signature<C>> for VerifyingKey<C>
 where
     C: EcdsaCurve + CurveArithmetic,
-    D: Digest + FixedOutput,
+    D: EagerHash + Update,
     SignatureSize<C>: ArraySize,
     der::MaxSize<C>: ArraySize,
     <FieldBytesSize<C> as Add>::Output: Add<der::MaxOverhead> + ArraySize,

--- a/rfc6979/src/lib.rs
+++ b/rfc6979/src/lib.rs
@@ -39,14 +39,14 @@
 
 mod ct;
 
+pub use hmac;
 pub use hmac::digest::array::typenum::consts;
 
 use hmac::{
-    SimpleHmacReset,
+    EagerHash, HmacReset,
     digest::{
-        Digest, FixedOutput, FixedOutputReset, KeyInit, Mac,
+        KeyInit, Mac, OutputSizeUser,
         array::{Array, ArraySize},
-        block_api::BlockSizeUser,
     },
 };
 
@@ -66,7 +66,7 @@ pub fn generate_k<D, N>(
     data: &[u8],
 ) -> Array<u8, N>
 where
-    D: Digest + BlockSizeUser + FixedOutput + FixedOutputReset,
+    D: EagerHash,
     N: ArraySize,
 {
     let mut k = Array::default();
@@ -88,7 +88,7 @@ where
 #[inline]
 pub fn generate_k_mut<D>(x: &[u8], q: &[u8], h: &[u8], data: &[u8], k: &mut [u8])
 where
-    D: Digest + BlockSizeUser + FixedOutput + FixedOutputReset,
+    D: EagerHash,
 {
     let k_len = k.len();
     assert_eq!(k_len, x.len());
@@ -121,22 +121,22 @@ where
 /// deterministic ephemeral scalar `k`.
 pub struct HmacDrbg<D>
 where
-    D: Digest + BlockSizeUser + FixedOutputReset,
+    D: EagerHash,
 {
     /// HMAC key `K` (see RFC 6979 Section 3.2.c)
-    k: SimpleHmacReset<D>,
+    k: HmacReset<D>,
 
     /// Chaining value `V` (see RFC 6979 Section 3.2.c)
-    v: Array<u8, D::OutputSize>,
+    v: Array<u8, <D::Core as OutputSizeUser>::OutputSize>,
 }
 
 impl<D> HmacDrbg<D>
 where
-    D: Digest + BlockSizeUser + FixedOutputReset,
+    D: EagerHash,
 {
     /// Initialize `HMAC_DRBG`
     pub fn new(entropy_input: &[u8], nonce: &[u8], personalization_string: &[u8]) -> Self {
-        let mut k = SimpleHmacReset::new(&Default::default());
+        let mut k = HmacReset::new(&Default::default());
         let mut v = Array::default();
 
         v.fill(0x01);
@@ -147,7 +147,7 @@ where
             k.update(entropy_input);
             k.update(nonce);
             k.update(personalization_string);
-            k = SimpleHmacReset::new_from_slice(&k.finalize().into_bytes()).expect("HMAC error");
+            k = HmacReset::new_from_slice(&k.finalize().into_bytes()).expect("HMAC error");
 
             // Steps 3.2.e,g: v = HMAC_k(v)
             k.update(&v);
@@ -176,8 +176,8 @@ where
 
         self.k.update(&self.v);
         self.k.update(&[0x00]);
-        self.k = SimpleHmacReset::new_from_slice(&self.k.finalize_reset().into_bytes())
-            .expect("HMAC error");
+        self.k =
+            HmacReset::new_from_slice(&self.k.finalize_reset().into_bytes()).expect("HMAC error");
         self.k.update(&self.v);
         self.v = self.k.finalize_reset().into_bytes();
     }


### PR DESCRIPTION
This PR replaces the `Digest` requirements of `rfc6979` items with `EagerHash`. In the process I merged the `ecdsa` `signing` and `verifying` crate features into `signature`.

As discussed in https://github.com/RustCrypto/elliptic-curves/pull/1423#issuecomment-3288837711.