### PR TITLE
Disable default features for `sha3`

### DIFF
--- a/ml-dsa/Cargo.toml
+++ b/ml-dsa/Cargo.toml
@@ -34,7 +34,7 @@ pkcs8 = ["dep:const-oid", "dep:pkcs8"]
 [dependencies]
 hybrid-array = { version = "0.4", features = ["extra-sizes"] }
 num-traits = { version = "0.2", default-features = false }
-sha3 = "0.11.0-rc.3"
+sha3 = { version = "0.11.0-rc.3", default-features = false }
 signature = { version = "3.0.0-rc.4", default-features = false, features = ["digest"] }
 
 # optional dependencies


### PR DESCRIPTION
The `sha3` crate by default [enables `alloc` and `oid`](https://docs.rs/crate/sha3/0.11.0-rc.3/features), which aren't needed. I checked it locally with `cargo check -p ml-dsa --all-features`. I assume this was just an oversight, since `slh-dsa` already disables the default features for `sha3`:
https://github.com/RustCrypto/signatures/blob/8aa41de7b88f1e25711f54151367b954ab08e814/slh-dsa/Cargo.toml#L21