### PR TITLE
dsa: bump `crypto-bigint` to v0.7.0-rc.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,8 +271,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.9"
-source = "git+https://github.com/RustCrypto/crypto-bigint?branch=rand_core%2Fv0.10.0-rc-2#896b26cc24c96cad5edf957528d0e9558b13dc75"
+version = "0.7.0-rc.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6715836b4946e8585016e80b79c7561476aff3b22f7b756778e7b109d86086c6"
 dependencies = [
  "hybrid-array",
  "num-traits",
@@ -294,7 +295,7 @@ dependencies = [
 [[package]]
 name = "crypto-primes"
 version = "0.7.0-pre.3"
-source = "git+https://github.com/baloo/crypto-primes.git?branch=baloo%2Frand_core%2F0.10.0-rc.2#1accbdb17e6a8f17462adab53ee24ed297223e70"
+source = "git+https://github.com/baloo/crypto-primes.git?branch=baloo%2Frand_core%2F0.10.0-rc.2#54ba25dd7f14370991b75702356e4380fd535e45"
 dependencies = [
  "crypto-bigint",
  "libm",
@@ -419,7 +420,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "elliptic-curve"
 version = "0.14.0-rc.16"
-source = "git+https://github.com/RustCrypto/traits#3f5fb163636d59f9aad45eacfe9ef4f5d329dc01"
+source = "git+https://github.com/RustCrypto/traits#e8af70d7513422157590f3f764ddc8f8ca55bf72"
 dependencies = [
  "base16ct",
  "crypto-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ rfc6979 = { path = "./rfc6979" }
 slh-dsa = { path = "./slh-dsa" }
 
 elliptic-curve = { git = "https://github.com/RustCrypto/traits" }
-crypto-bigint = { git = "https://github.com/RustCrypto/crypto-bigint", branch = "rand_core/v0.10.0-rc-2" }
 crypto-primes = { git = "https://github.com/baloo/crypto-primes.git", branch = "baloo/rand_core/0.10.0-rc.2" }
 ff = { git = "https://github.com/tarcieri/ff", branch = "rand_core/v0.10.0-rc-2" }
 group = { git = "https://github.com/tarcieri/group", branch = "rand_core/v0.10.0-rc-2" }

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.85"
 [dependencies]
 der = { version = "0.8.0-rc.9", features = ["alloc"] }
 digest = "0.11.0-rc.4"
-crypto-bigint = { version = "0.7.0-rc.9", default-features = false, features = ["alloc", "zeroize"] }
+crypto-bigint = { version = "0.7.0-rc.10", default-features = false, features = ["alloc", "zeroize"] }
 crypto-primes = { version = "0.7.0-pre.3", default-features = false }
 rfc6979 = { version = "0.5.0-rc.2" }
 sha2 = { version = "0.11.0-rc.3", default-features = false }


### PR DESCRIPTION
Switches to the crate release