### PR TITLE
Bump `signature` dependency to v3.0.0-rc.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,9 +81,9 @@ checksum = "89af0b093cc13baa4e51e64e65ec2422f7e73aea0e612e5ad3872986671622f1"
 
 [[package]]
 name = "block-buffer"
-version = "0.11.0-rc.5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9ef36a6fcdb072aa548f3da057640ec10859eb4e91ddf526ee648d50c76a949"
+checksum = "96eb4cdd6cf1b31d671e9efe75c5d1ec614776856cefbe109ca373554a6d514f"
 dependencies = [
  "hybrid-array",
 ]
@@ -108,14 +108,14 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0-rc.3"
+version = "0.10.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3585020fc6766ef7ff5c58d69819dbca16a19008ae347bb5d3e4e145c495eb38"
+checksum = "f895fb33c1ad22da4bc79d37c0bddff8aee2ba4575705345eb73b8ffbc386074"
 dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
- "rand_core 0.10.0-rc-2",
+ "rand_core 0.10.0-rc-3",
 ]
 
 [[package]]
@@ -268,7 +268,7 @@ checksum = "6715836b4946e8585016e80b79c7561476aff3b22f7b756778e7b109d86086c6"
 dependencies = [
  "hybrid-array",
  "num-traits",
- "rand_core 0.10.0-rc-2",
+ "rand_core 0.10.0-rc-3",
  "serdect",
  "subtle",
  "zeroize",
@@ -276,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919bd05924682a5480aec713596b9e2aabed3a0a6022fab6847f85a99e5f190a"
+checksum = "e6165b8029cdc3e765b74d3548f85999ee799d5124877ce45c2c85ca78e4d4aa"
 dependencies = [
  "hybrid-array",
 ]
@@ -291,7 +291,7 @@ checksum = "fdd9b2855017318a49714c07ee8895b89d3510d54fa6d86be5835de74c389609"
 dependencies = [
  "crypto-bigint",
  "libm",
- "rand_core 0.10.0-rc-2",
+ "rand_core 0.10.0-rc-3",
 ]
 
 [[package]]
@@ -328,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.4"
+version = "0.11.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea390c940e465846d64775e55e3115d5dc934acb953de6f6e6360bc232fe2bf7"
+checksum = "ebf9423bafb058e4142194330c52273c343f8a5beb7176d052f0e73b17dd35b9"
 dependencies = [
  "blobby",
  "block-buffer",
@@ -352,7 +352,7 @@ dependencies = [
  "hex-literal",
  "pkcs8",
  "proptest",
- "rand 0.10.0-rc.1",
+ "rand 0.10.0-rc.5",
  "rfc6979",
  "sha1",
  "sha2",
@@ -422,7 +422,7 @@ dependencies = [
  "once_cell",
  "pem-rfc7468",
  "pkcs8",
- "rand_core 0.10.0-rc-2",
+ "rand_core 0.10.0-rc-3",
  "rustcrypto-ff",
  "rustcrypto-group",
  "sec1",
@@ -456,12 +456,12 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "getrandom"
 version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+source = "git+https://github.com/rust-random/getrandom.git?rev=f67c70110f706f80d7dd6fa52e38d0920754fe2c#f67c70110f706f80d7dd6fa52e38d0920754fe2c"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core 0.10.0-rc-3",
  "wasip2",
 ]
 
@@ -586,8 +586,8 @@ dependencies = [
  "hex",
  "hex-literal",
  "hybrid-array",
- "rand 0.10.0-rc.1",
- "rand_core 0.10.0-rc-2",
+ "rand 0.10.0-rc.5",
+ "rand_core 0.10.0-rc-3",
  "sha2",
  "signature",
  "static_assertions",
@@ -619,8 +619,8 @@ dependencies = [
  "num-traits",
  "pkcs8",
  "proptest",
- "rand 0.10.0-rc.1",
- "rand_core 0.10.0-rc-2",
+ "rand 0.10.0-rc.5",
+ "rand_core 0.10.0-rc-3",
  "serde",
  "serde_json",
  "sha3",
@@ -792,13 +792,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e7d245ced4538f0406b1579d3d4a6515a2ff1bdf20733492e2e4fc90a648769"
+version = "0.10.0-rc.5"
+source = "git+https://github.com/rust-random/rand?rev=99ae06fb348e5c5fee0fe41d2201bd4cbb107635#99ae06fb348e5c5fee0fe41d2201bd4cbb107635"
 dependencies = [
  "chacha20",
  "getrandom",
- "rand_core 0.10.0-rc-2",
+ "rand_core 0.10.0-rc-3",
 ]
 
 [[package]]
@@ -822,9 +821,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0-rc-2"
+version = "0.10.0-rc-3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "104a23e4e8b77312a823b6b5613edbac78397e2f34320bc7ac4277013ec4478e"
+checksum = "f66ee92bc15280519ef199a274fe0cafff4245d31bc39aaa31c011ad56cb1f05"
 
 [[package]]
 name = "rand_xorshift"
@@ -900,7 +899,7 @@ version = "0.14.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9cd37111549306f79b09aa2618e15b1e8241b7178c286821e3dd71579db4db"
 dependencies = [
- "rand_core 0.10.0-rc-2",
+ "rand_core 0.10.0-rc-3",
  "subtle",
 ]
 
@@ -910,7 +909,7 @@ version = "0.14.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e394cd734b5f97dfc3484fa42aad7acd912961c2bcd96c99aa05b3d6cab7cafd"
 dependencies = [
- "rand_core 0.10.0-rc-2",
+ "rand_core 0.10.0-rc-3",
  "rustcrypto-ff",
  "subtle",
 ]
@@ -1072,12 +1071,12 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "3.0.0-rc.5"
+version = "3.0.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0251c9d6468f4ba853b6352b190fb7c1e405087779917c238445eb03993826"
+checksum = "597a96996ccff7dfa16f052bd995b4cecc72af22c35138738dc029f0ead6608d"
 dependencies = [
  "digest",
- "rand_core 0.10.0-rc-2",
+ "rand_core 0.10.0-rc-3",
 ]
 
 [[package]]
@@ -1098,8 +1097,8 @@ dependencies = [
  "paste",
  "pkcs8",
  "proptest",
- "rand 0.10.0-rc.1",
- "rand_core 0.10.0-rc-2",
+ "rand 0.10.0-rc.5",
+ "rand_core 0.10.0-rc-3",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,7 @@ lms-signature = { path = "./lms" }
 ml-dsa = { path = "./ml-dsa" }
 rfc6979 = { path = "./rfc6979" }
 slh-dsa = { path = "./slh-dsa" }
+
+# https://github.com/rust-random/rand/pull/1697
+rand = { git = "https://github.com/rust-random/rand", rev = "99ae06fb348e5c5fee0fe41d2201bd4cbb107635" }
+getrandom = { git = "https://github.com/rust-random/getrandom.git", rev = "f67c70110f706f80d7dd6fa52e38d0920754fe2c" }

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -17,12 +17,12 @@ rust-version = "1.85"
 
 [dependencies]
 der = { version = "0.8.0-rc.9", features = ["alloc"] }
-digest = "0.11.0-rc.4"
+digest = "0.11.0-rc.5"
 crypto-bigint = { version = "0.7.0-rc.10", default-features = false, features = ["alloc", "zeroize"] }
 crypto-primes = { version = "0.7.0-pre.4", default-features = false }
 rfc6979 = { version = "0.5.0-rc.3" }
 sha2 = { version = "0.11.0-rc.3", default-features = false }
-signature = { version = "3.0.0-rc.5", default-features = false, features = ["alloc", "digest", "rand_core"] }
+signature = { version = "3.0.0-rc.6", default-features = false, features = ["alloc", "digest", "rand_core"] }
 zeroize = { version = "1", default-features = false, features = ["alloc"] }
 
 # optional dependencies
@@ -34,7 +34,7 @@ hex = "0.4"
 hex-literal = "1"
 pkcs8 = { version = "0.11.0-rc.8", default-features = false, features = ["pem"] }
 proptest = "1"
-rand = "0.10.0-rc.1"
+rand = "0.10.0-rc.5"
 sha1 = "0.11.0-rc.2"
 der = { version = "0.8.0-rc.9", features = ["derive"] }
 

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -18,12 +18,12 @@ rust-version = "1.85"
 
 [dependencies]
 elliptic-curve = { version = "0.14.0-rc.17", default-features = false, features = ["sec1"] }
-signature = { version = "3.0.0-rc.5", default-features = false, features = ["rand_core"] }
+signature = { version = "3.0.0-rc.6", default-features = false, features = ["rand_core"] }
 zeroize = { version = "1.5", default-features = false }
 
 # optional dependencies
 der = { version = "0.8.0-rc.9", optional = true }
-digest = { version = "0.11.0-rc.4", optional = true, default-features = false, features = ["oid"] }
+digest = { version = "0.11.0-rc.5", optional = true, default-features = false, features = ["oid"] }
 rfc6979 = { version = "0.5.0-rc.3", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false, features = ["alloc"] }
 sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false, features = ["oid"] }

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-signature = { version = "3.0.0-rc.5", default-features = false }
+signature = { version = "3.0.0-rc.6", default-features = false }
 
 # optional dependencies
 pkcs8 = { version = "0.11.0-rc.8", optional = true }

--- a/ed448/Cargo.toml
+++ b/ed448/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["crypto", "curve448", "ecc", "signature", "signing"]
 rust-version = "1.85"
 
 [dependencies]
-signature = { version = "3.0.0-rc.5", default-features = false }
+signature = { version = "3.0.0-rc.6", default-features = false }
 
 # optional dependencies
 pkcs8 = { version = "0.11.0-rc.8", optional = true }

--- a/lms/Cargo.toml
+++ b/lms/Cargo.toml
@@ -12,13 +12,13 @@ categories = ["cryptography"]
 keywords = ["crypto", "signature"]
 
 [dependencies]
-digest = "0.11.0-rc.4"
+digest = "0.11.0-rc.5"
 hybrid-array = { version = "0.4", features = ["extra-sizes", "zeroize"] }
-rand = "0.10.0-rc.1"
+rand = "0.10.0-rc.5"
 sha2 = "0.11.0-rc.3"
 static_assertions = "1.1"
-rand_core = "0.10.0-rc-2"
-signature = { version = "3.0.0-rc.5", features = ["alloc", "digest", "rand_core"] }
+rand_core = "0.10.0-rc-3"
+signature = { version = "3.0.0-rc.6", features = ["alloc", "digest", "rand_core"] }
 typenum = { version = "1.17", features = ["const-generics"] }
 zeroize = "1.8"
 

--- a/ml-dsa/Cargo.toml
+++ b/ml-dsa/Cargo.toml
@@ -35,12 +35,12 @@ pkcs8 = ["dep:const-oid", "dep:pkcs8"]
 hybrid-array = { version = "0.4", features = ["extra-sizes"] }
 num-traits = { version = "0.2", default-features = false }
 sha3 = { version = "0.11.0-rc.3", default-features = false }
-signature = { version = "3.0.0-rc.5", default-features = false, features = ["digest"] }
+signature = { version = "3.0.0-rc.6", default-features = false, features = ["digest"] }
 
 # optional dependencies
 const-oid = { version = "0.10", features = ["db"], optional = true }
 pkcs8 = { version = "0.11.0-rc.8", default-features = false, optional = true }
-rand_core = { version = "0.10.0-rc-2", optional = true }
+rand_core = { version = "0.10.0-rc-3", optional = true }
 zeroize = { version = "1.8.1", optional = true, default-features = false }
 
 [dev-dependencies]
@@ -49,7 +49,7 @@ hex = { version = "0.4", features = ["serde"] }
 hex-literal = "1"
 pkcs8 = { version = "0.11.0-rc.8", features = ["pem"] }
 proptest = "1"
-rand = "0.10.0-rc.1"
+rand = "0.10.0-rc.5"
 serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.132"
 

--- a/slh-dsa/Cargo.toml
+++ b/slh-dsa/Cargo.toml
@@ -17,14 +17,14 @@ exclude = ["tests"]
 
 [dependencies]
 const-oid = { version = "0.10", features = ["db"] }
-digest = "0.11.0-rc.4"
+digest = "0.11.0-rc.5"
 hmac = "0.13.0-rc.3"
 hybrid-array = { version = "0.4", features = ["extra-sizes"] }
 pkcs8 = { version = "0.11.0-rc.8", default-features = false }
-rand_core = { version = "0.10.0-rc-2" }
+rand_core = { version = "0.10.0-rc-3" }
 sha2 = { version = "0.11.0-rc.3", default-features = false }
 sha3 = { version = "0.11.0-rc.3", default-features = false }
-signature = { version = "3.0.0-rc.5", features = ["rand_core"] }
+signature = { version = "3.0.0-rc.6", features = ["rand_core"] }
 typenum = { version = "1.17", features = ["const-generics"] }
 zerocopy = { version = "0.8", features = ["derive"] }
 
@@ -42,8 +42,8 @@ num-bigint = "0.4.4"
 paste = "1.0.15"
 pkcs8 = { version = "0.11.0-rc.8", features = ["pem"] }
 proptest = "1.4.0"
-rand_core = "0.10.0-rc-2"
-rand = "0.10.0-rc.1"
+rand_core = "0.10.0-rc-3"
+rand = "0.10.0-rc.5"
 serde_json = "1.0.124"
 serde = { version = "1.0.207", features = ["derive"] }
 

--- a/slh-dsa/tests/known_answer_tests.rs
+++ b/slh-dsa/tests/known_answer_tests.rs
@@ -49,11 +49,11 @@ impl RngCore for KatRng {
     }
 
     fn next_u32(&mut self) -> u32 {
-        rand_core::le::next_u32_via_fill(self)
+        rand_core::utils::next_word_via_fill(self)
     }
 
     fn next_u64(&mut self) -> u64 {
-        rand_core::le::next_u64_via_fill(self)
+        rand_core::utils::next_word_via_fill(self)
     }
 }
 


### PR DESCRIPTION
Also bumps the `digest` crate dependency to v0.11.0-rc.5 and `rand_core` to v0.10.0-rc-3