### PR TITLE
Bump `crypto-bigint` to v0.7.0-rc.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
+name = "cmov"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11ed919bd3bae4af5ab56372b627dfc32622aba6cec36906e8ab46746037c9d"
+
+[[package]]
 name = "const-oid"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,10 +268,11 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.10"
+version = "0.7.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6715836b4946e8585016e80b79c7561476aff3b22f7b756778e7b109d86086c6"
+checksum = "a7ddf7876857d903765f30de7c789044ea2e49a4f611fe96416827175cef6b34"
 dependencies = [
+ "ctutils",
  "hybrid-array",
  "num-traits",
  "rand_core 0.10.0-rc-3",
@@ -285,9 +292,8 @@ dependencies = [
 
 [[package]]
 name = "crypto-primes"
-version = "0.7.0-pre.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd9b2855017318a49714c07ee8895b89d3510d54fa6d86be5835de74c389609"
+version = "0.7.0-dev"
+source = "git+https://github.com/tarcieri/crypto-primes?branch=crypto-bigint%2Fv0.7.0-rc.12#a96b3c9e40db97dfd3df73d9368ff096292fcb16"
 dependencies = [
  "crypto-bigint",
  "libm",
@@ -301,6 +307,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0ec605a95e78815a4c4b8040217d56d5a1ab37043851ee9e7e65b89afa00e3"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925ebe186f09a7894817213f89eae07c39374f5c934613605af7accc8aea6414"
+dependencies = [
+ "cmov",
+ "subtle",
 ]
 
 [[package]]
@@ -410,13 +426,12 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "elliptic-curve"
 version = "0.14.0-rc.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ecd2903524729de5d0cba7589121744513feadd56d71980cb480c48caceb11"
+source = "git+https://github.com/RustCrypto/traits#28bb5d487421f35eed714810a7f10fb091179e6f"
 dependencies = [
  "base16ct",
  "crypto-bigint",
  "digest",
- "getrandom 0.3.4",
+ "getrandom 0.4.0-rc.0",
  "hex-literal",
  "hybrid-array",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,6 @@ ml-dsa = { path = "./ml-dsa" }
 rfc6979 = { path = "./rfc6979" }
 slh-dsa = { path = "./slh-dsa" }
 
+crypto-primes = { git = "https://github.com/tarcieri/crypto-primes", branch = "crypto-bigint/v0.7.0-rc.12" }
+elliptic-curve = { git = "https://github.com/RustCrypto/traits" }
 rand = { git = "https://github.com/rust-random/rand" }

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -18,8 +18,8 @@ rust-version = "1.85"
 [dependencies]
 der = { version = "0.8.0-rc.9", features = ["alloc"] }
 digest = "0.11.0-rc.5"
-crypto-bigint = { version = "0.7.0-rc.10", default-features = false, features = ["alloc", "zeroize"] }
-crypto-primes = { version = "0.7.0-pre.4", default-features = false }
+crypto-bigint = { version = "0.7.0-rc.12", default-features = false, features = ["alloc", "zeroize"] }
+crypto-primes = { version = "0.7.0-dev", default-features = false }
 rfc6979 = { version = "0.5.0-rc.3" }
 sha2 = { version = "0.11.0-rc.3", default-features = false }
 signature = { version = "3.0.0-rc.6", default-features = false, features = ["alloc", "digest", "rand_core"] }
@@ -29,7 +29,7 @@ zeroize = { version = "1", default-features = false, features = ["alloc"] }
 pkcs8 = { version = "0.11.0-rc.8", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
-chacha20 = "0.10.0-rc.3"
+chacha20 = "0.10.0-rc.6"
 hex = "0.4"
 hex-literal = "1"
 pkcs8 = { version = "0.11.0-rc.8", default-features = false, features = ["pem"] }

--- a/dsa/src/generate/components.rs
+++ b/dsa/src/generate/components.rs
@@ -15,7 +15,7 @@ use crypto_primes::{Flavor, is_prime};
 use signature::rand_core::CryptoRng;
 
 #[cfg(feature = "hazmat")]
-use {crate::Components, crypto_bigint::subtle::CtOption};
+use {crate::Components, crypto_bigint::CtOption};
 
 /// Generate the common components p, q, and g
 ///

--- a/dsa/src/generate/keypair.rs
+++ b/dsa/src/generate/keypair.rs
@@ -16,7 +16,7 @@ pub(crate) fn keypair<R: CryptoRng + ?Sized>(rng: &mut R, components: Components
         components: &Components,
     ) -> NonZero<BoxedUint> {
         loop {
-            let x = BoxedUint::random_mod(rng, components.q());
+            let x = BoxedUint::random_mod_vartime(rng, components.q());
             if let Some(x) = NonZero::new(x).into() {
                 return x;
             }


### PR DESCRIPTION
This includes a migration from `subtle` to `ctutils`