### PR TITLE
slh-dsa: bump `rand` to v0.10.0-rc.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,8 +823,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0-rc.5"
-source = "git+https://github.com/rust-random/rand#ff07ec205347dd749a586aaee7218cb21590ea4c"
+version = "0.10.0-rc.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bccc05ac8fad6ee391f3cc6725171817eed960345e2fb42ad229d486c1ca2d98"
 dependencies = [
  "chacha20",
  "getrandom 0.4.0-rc.0",
@@ -1129,7 +1130,7 @@ dependencies = [
  "paste",
  "pkcs8",
  "proptest",
- "rand 0.10.0-rc.5",
+ "rand 0.10.0-rc.6",
  "rand_core 0.10.0-rc-3",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,3 @@ lms-signature = { path = "./lms" }
 ml-dsa = { path = "./ml-dsa" }
 rfc6979 = { path = "./rfc6979" }
 slh-dsa = { path = "./slh-dsa" }
-
-rand = { git = "https://github.com/rust-random/rand" }

--- a/slh-dsa/Cargo.toml
+++ b/slh-dsa/Cargo.toml
@@ -42,7 +42,7 @@ num-bigint = "0.4.4"
 paste = "1.0.15"
 pkcs8 = { version = "0.11.0-rc.8", features = ["pem"] }
 proptest = "1.4.0"
-rand = "0.10.0-rc.5"
+rand = "0.10.0-rc.6"
 serde_json = "1.0.124"
 serde = { version = "1.0.207", features = ["derive"] }
 


### PR DESCRIPTION
Gets rid of the `git` crate dependency