### PR TITLE
ecdsa: `dev` module fixups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,7 @@ dependencies = [
 [[package]]
 name = "crypto-common"
 version = "0.2.0-rc.9"
-source = "git+https://github.com/RustCrypto/traits#ded0d2297fba206939bfb5f47b4fd823c4bccae8"
+source = "git+https://github.com/RustCrypto/traits#f3f7feb394e9ced9e77ec7cd9ff5e4c832efbeb0"
 dependencies = [
  "getrandom 0.4.0-rc.0",
  "hybrid-array",
@@ -439,7 +439,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "elliptic-curve"
 version = "0.14.0-rc.20"
-source = "git+https://github.com/RustCrypto/traits#ded0d2297fba206939bfb5f47b4fd823c4bccae8"
+source = "git+https://github.com/RustCrypto/traits#f3f7feb394e9ced9e77ec7cd9ff5e4c832efbeb0"
 dependencies = [
  "base16ct",
  "crypto-bigint",

--- a/ecdsa/src/dev.rs
+++ b/ecdsa/src/dev.rs
@@ -3,38 +3,10 @@
 // TODO(tarcieri): implement full set of tests from ECDSA2VS
 // <https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/dss2/ecdsa2vs.pdf>
 
-use crate::EcdsaCurve;
-use elliptic_curve::dev::MockCurve;
-
 pub use digest::dev::blobby;
 
-impl EcdsaCurve for MockCurve {
-    const NORMALIZE_S: bool = false;
-}
-
-/// ECDSA test vector
-pub struct TestVector {
-    /// Private scalar
-    pub d: &'static [u8],
-
-    /// Public key x-coordinate (`Qx`)
-    pub q_x: &'static [u8],
-
-    /// Public key y-coordinate (`Qy`)
-    pub q_y: &'static [u8],
-
-    /// Ephemeral scalar (a.k.a. nonce)
-    pub k: &'static [u8],
-
-    /// Message digest (prehashed)
-    pub m: &'static [u8],
-
-    /// Signature `r` component
-    pub r: &'static [u8],
-
-    /// Signature `s` component
-    pub s: &'static [u8],
-}
+use crate::EcdsaCurve;
+use elliptic_curve::dev::mock_curve::MockCurve;
 
 /// Define ECDSA signing test.
 #[macro_export]
@@ -265,6 +237,34 @@ macro_rules! new_wycheproof_test {
             }
         }
     };
+}
+
+impl EcdsaCurve for MockCurve {
+    const NORMALIZE_S: bool = false;
+}
+
+/// ECDSA test vector
+pub struct TestVector {
+    /// Private scalar
+    pub d: &'static [u8],
+
+    /// Public key x-coordinate (`Qx`)
+    pub q_x: &'static [u8],
+
+    /// Public key y-coordinate (`Qy`)
+    pub q_y: &'static [u8],
+
+    /// Ephemeral scalar (a.k.a. nonce)
+    pub k: &'static [u8],
+
+    /// Message digest (prehashed)
+    pub m: &'static [u8],
+
+    /// Signature `r` component
+    pub r: &'static [u8],
+
+    /// Signature `s` component
+    pub s: &'static [u8],
 }
 
 #[cfg(test)]

--- a/ecdsa/src/signing.rs
+++ b/ecdsa/src/signing.rs
@@ -131,7 +131,7 @@ where
     fn try_generate_from_rng<R: TryCryptoRng + ?Sized>(
         rng: &mut R,
     ) -> core::result::Result<Self, R::Error> {
-        Ok(NonZeroScalar::<C>::try_generate_from_rng(rng)?.into())
+        NonZeroScalar::<C>::try_generate_from_rng(rng).map(Into::into)
     }
 }
 


### PR DESCRIPTION
- Pull in `MockCurve` from `elliptic_curve::dev::mock_curve`
- Move macros to top of file