### PR TITLE
dsa: bump `crypto-bigint` to v0.7.0-rc.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,9 +268,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.15"
+version = "0.7.0-rc.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9e36ac79ac44866b74e08a0b4925f97b984e3fff17680d2c6fbce8317ab0f6"
+checksum = "fbd828c64d6fecf364ec127641e5ce0f8d6e3264a6c466b4a4bdcbec5b038b9e"
 dependencies = [
  "ctutils",
  "getrandom 0.4.0-rc.0",
@@ -295,9 +295,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-primes"
-version = "0.7.0-pre.5"
+version = "0.7.0-pre.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0b07a7a616370e8b6efca0c6a25e5f4c6d02fde11f3d570e4af64d8ed7e2e9"
+checksum = "e79c98a281f9441200b24e3151407a629bfbe720399186e50516da939195e482"
 dependencies = [
  "crypto-bigint",
  "libm",

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -18,8 +18,8 @@ rust-version = "1.85"
 [dependencies]
 der = { version = "0.8.0-rc.10", features = ["alloc"] }
 digest = "0.11.0-rc.5"
-crypto-bigint = { version = "0.7.0-rc.13", default-features = false, features = ["alloc", "zeroize"] }
-crypto-primes = { version = "0.7.0-pre.5", default-features = false }
+crypto-bigint = { version = "0.7.0-rc.16", default-features = false, features = ["alloc", "zeroize"] }
+crypto-primes = { version = "0.7.0-pre.6", default-features = false }
 rfc6979 = { version = "0.5.0-rc.3" }
 sha2 = { version = "0.11.0-rc.3", default-features = false }
 signature = { version = "3.0.0-rc.6", default-features = false, features = ["alloc", "digest", "rand_core"] }

--- a/dsa/src/generate/components.rs
+++ b/dsa/src/generate/components.rs
@@ -68,7 +68,7 @@ pub(crate) fn common<R: CryptoRng + ?Sized>(
     let mut h = BoxedUint::one().resize(l);
     let g = loop {
         let params = BoxedMontyParams::new_vartime(p.clone());
-        let form = BoxedMontyForm::new(h.clone(), params);
+        let form = BoxedMontyForm::new(h.clone(), &params);
         let g = form.pow(&e).retrieve();
 
         if !bool::from(g.is_one()) {
@@ -96,7 +96,7 @@ pub(crate) fn public(
     let g = components.g();
 
     let params = BoxedMontyParams::new_vartime(p.clone());
-    let form = BoxedMontyForm::new((**g).clone(), params);
+    let form = BoxedMontyForm::new((**g).clone(), &params);
 
     NonZero::new(form.pow(x).retrieve())
 }

--- a/dsa/src/signing_key.rs
+++ b/dsa/src/signing_key.rs
@@ -120,7 +120,7 @@ impl SigningKey {
         let inv_k = inv_k.resize(p.bits_precision());
 
         let params = BoxedMontyParams::new(p.clone());
-        let form = BoxedMontyForm::new((**g).clone(), params);
+        let form = BoxedMontyForm::new((**g).clone(), &params);
         let r = form.pow(&k).retrieve() % q.resize(p.bits_precision());
         debug_assert_eq!(key_size.l_aligned(), r.bits_precision());
 

--- a/dsa/src/verifying_key.rs
+++ b/dsa/src/verifying_key.rs
@@ -38,16 +38,16 @@ pub struct VerifyingKey {
 impl VerifyingKey {
     /// Construct a new public key from the common components and the public component
     pub fn from_components(components: Components, y: BoxedUint) -> signature::Result<Self> {
+        let params = BoxedMontyParams::new_vartime(components.p().clone());
+        let form = BoxedMontyForm::new(y.clone(), &params);
+
+        if y < two() || form.pow(components.q()).retrieve() != BoxedUint::one() {
+            return Err(signature::Error::new());
+        }
+
         let y = NonZero::new(y)
             .into_option()
             .ok_or_else(signature::Error::new)?;
-
-        let params = BoxedMontyParams::new_vartime(components.p().clone());
-        let form = BoxedMontyForm::new((*y).clone(), params);
-
-        if *y < two() || form.pow(components.q()).retrieve() != BoxedUint::one() {
-            return Err(signature::Error::new());
-        }
 
         Ok(Self { components, y })
     }
@@ -97,8 +97,8 @@ impl VerifyingKey {
         let p1_params = BoxedMontyParams::new(p.clone());
         let p2_params = BoxedMontyParams::new(p.clone());
 
-        let g_form = BoxedMontyForm::new((**g).clone(), p1_params);
-        let y_form = BoxedMontyForm::new((**y).clone(), p2_params);
+        let g_form = BoxedMontyForm::new((**g).clone(), &p1_params);
+        let y_form = BoxedMontyForm::new((**y).clone(), &p2_params);
 
         let v1 = g_form.pow(&u1).retrieve();
         let v2 = y_form.pow(&u2).retrieve();

--- a/dsa/tests/signing_key.rs
+++ b/dsa/tests/signing_key.rs
@@ -73,7 +73,7 @@ fn verify_validity() {
     let components = signing_key.verifying_key().components();
 
     let params = BoxedMontyParams::new(Odd::new((**components.p()).clone()).unwrap());
-    let form = BoxedMontyForm::new((**components.g()).clone(), params);
+    let form = BoxedMontyForm::new((**components.g()).clone(), &params);
 
     assert!(
         BoxedUint::zero() < **signing_key.x() && signing_key.x() < components.q(),

--- a/dsa/tests/verifying_key.rs
+++ b/dsa/tests/verifying_key.rs
@@ -57,7 +57,7 @@ fn validate_verifying_key() {
     let q = verifying_key.components().q();
 
     let params = BoxedMontyParams::new(Odd::new((**p).clone()).unwrap());
-    let form = BoxedMontyForm::new((**verifying_key.y()).clone(), params);
+    let form = BoxedMontyForm::new((**verifying_key.y()).clone(), &params);
 
     // Taken from the parameter validation from bouncy castle
     assert_eq!(form.pow(q).retrieve(), BoxedUint::one());


### PR DESCRIPTION
Includes changes to the `BoxedMontyForm::new` API, and also bumps `crypto-primes` to v0.7.0-rc.6 which includes the associated updates to that crate for the API change.