### PR TITLE
dsa: bump dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,8 +301,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-primes"
-version = "0.7.0-pre.7"
-source = "git+https://github.com/entropyxyz/crypto-primes#ba1024f4985d351d83dc588ee2607604ad19dba6"
+version = "0.7.0-pre.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "334a79c97c0b7fa536716dc132fd417d0afbf471440a41fc25a5d9f66d8771cd"
 dependencies = [
  "crypto-bigint",
  "libm",
@@ -778,9 +779,9 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.11.0-rc.9"
+version = "0.11.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80f8fa6196ede5a9f9ee95b44ca134bddc9b70e8913f9297bd58c909f5889a09"
+checksum = "b226d2cc389763951db8869584fd800cbbe2962bf454e2edeb5172b31ee99774"
 dependencies = [
  "der",
  "spki",
@@ -1142,9 +1143,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0-rc.3"
+version = "0.11.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa1ae819b9870cadc959a052363de870944a1646932d274a4e270f64bf79e5ef"
+checksum = "9c777f0a122a53fddb0beb6e706771197000b8eb5c9f42b5b850f450ef48c788"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,6 @@ ml-dsa = { path = "./ml-dsa" }
 rfc6979 = { path = "./rfc6979" }
 slh-dsa = { path = "./slh-dsa" }
 
-[patch.crates-io.crypto-primes]
-git = "https://github.com/entropyxyz/crypto-primes"
-
 [patch.crates-io.rand]
 git = "https://github.com/rust-random/rand"
 branch = "rand_core/v0.10.0-rc-6"

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -17,25 +17,25 @@ rust-version = "1.85"
 
 [dependencies]
 der = { version = "0.8.0-rc.10", features = ["alloc"] }
-digest = "0.11.0-rc.7"
-crypto-bigint = { version = "0.7.0-rc.21", default-features = false, features = ["alloc", "zeroize"] }
-crypto-primes = { version = "0.7.0-pre.7", default-features = false }
+digest = "0.11.0-rc.8"
+crypto-bigint = { version = "0.7.0-rc.22", default-features = false, features = ["alloc", "zeroize"] }
+crypto-primes = { version = "0.7.0-pre.8", default-features = false }
 rfc6979 = { version = "0.5.0-rc.3" }
-sha2 = { version = "0.11.0-rc.3", default-features = false }
-signature = { version = "3.0.0-rc.8", default-features = false, features = ["alloc", "digest", "rand_core"] }
+sha2 = { version = "0.11.0-rc.4", default-features = false }
+signature = { version = "3.0.0-rc.9", default-features = false, features = ["alloc", "digest", "rand_core"] }
 zeroize = { version = "1", default-features = false, features = ["alloc"] }
 
 # optional dependencies
-pkcs8 = { version = "0.11.0-rc.8", optional = true, default-features = false, features = ["alloc"] }
+pkcs8 = { version = "0.11.0-rc.10", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 chacha20 = { version = "0.10.0-rc.9", features = ["rng"] }
 hex = "0.4"
 hex-literal = "1"
-pkcs8 = { version = "0.11.0-rc.8", default-features = false, features = ["pem"] }
+pkcs8 = { version = "0.11.0-rc.10", default-features = false, features = ["pem"] }
 proptest = "1"
-getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }
-sha1 = "0.11.0-rc.2"
+getrandom = { version = "0.4.0-rc.1", features = ["sys_rng"] }
+sha1 = "0.11.0-rc.4"
 der = { version = "0.8.0-rc.10", features = ["derive"] }
 rand_core = "0.10.0-rc-6"
 


### PR DESCRIPTION
Upgrades the following dependency requirements:
- `digest` v0.11.0-rc.8
- `crypto-bigint` v0.7.0-rc.22
- `crypto-primes` v0.7.0-pre.8
- `getrandom` v0.4.0-rc.1
- `pkcs8` v0.11.0-rc.10
- `sha2` v0.11.0-rc.4
- `signature` v3.0.0-rc.9