### PR TITLE
Cut new releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,7 +405,7 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "3.0.0-rc.2"
+version = "3.0.0-rc.3"
 dependencies = [
  "hex-literal",
  "pkcs8",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "ed448"
-version = "0.5.0-rc.2"
+version = "0.5.0-rc.3"
 dependencies = [
  "hex-literal",
  "pkcs8",
@@ -674,7 +674,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lms-signature"
-version = "0.1.0-rc.0"
+version = "0.1.0-rc.1"
 dependencies = [
  "digest",
  "getrandom 0.4.0-rc.1",
@@ -703,7 +703,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "ml-dsa"
-version = "0.1.0-rc.3"
+version = "0.1.0-rc.4"
 dependencies = [
  "const-oid",
  "criterion",
@@ -989,7 +989,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rfc6979"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 dependencies = [
  "hex-literal",
  "hmac",
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "slh-dsa"
-version = "0.2.0-rc.2"
+version = "0.2.0-rc.3"
 dependencies = [
  "aes",
  "cipher",

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -20,7 +20,7 @@ der = { version = "0.8.0-rc.10", features = ["alloc"] }
 digest = "0.11.0-rc.9"
 crypto-bigint = { version = "0.7.0-rc.22", default-features = false, features = ["alloc", "zeroize"] }
 crypto-primes = { version = "0.7.0-pre.8", default-features = false }
-rfc6979 = { version = "0.5.0-rc.3" }
+rfc6979 = { version = "0.5.0-rc.4" }
 sha2 = { version = "0.11.0-rc.4", default-features = false }
 signature = { version = "3.0.0-rc.9", default-features = false, features = ["alloc", "digest", "rand_core"] }
 zeroize = { version = "1", default-features = false, features = ["alloc"] }

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -24,7 +24,7 @@ zeroize = { version = "1.5", default-features = false }
 # optional dependencies
 der = { version = "0.8.0-rc.10", optional = true }
 digest = { version = "0.11.0-rc.9", optional = true, default-features = false, features = ["oid"] }
-rfc6979 = { version = "0.5.0-rc.3", optional = true }
+rfc6979 = { version = "0.5.0-rc.4", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false, features = ["alloc"] }
 sha2 = { version = "0.11.0-rc.4", optional = true, default-features = false, features = ["oid"] }
 spki = { version = "0.8.0-rc.4", optional = true, default-features = false }

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed25519"
-version = "3.0.0-rc.2"
+version = "3.0.0-rc.3"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """

--- a/ed448/Cargo.toml
+++ b/ed448/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed448"
-version = "0.5.0-rc.2"
+version = "0.5.0-rc.3"
 edition = "2024"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"

--- a/lms/Cargo.toml
+++ b/lms/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lms-signature"
 description = "Pure Rust implementation of Leighton-Micali Hash-Based Signatures (RFC 8554)"
-version = "0.1.0-rc.0"
+version = "0.1.0-rc.1"
 edition = "2024"
 license = "Apache-2.0 OR MIT"
 homepage = "https://github.com/RustCrypto/signatures/tree/master/lms"
@@ -12,10 +12,10 @@ categories = ["cryptography"]
 keywords = ["crypto", "signature"]
 
 [dependencies]
-digest = "0.11.0-rc.7"
+digest = "0.11.0-rc.9"
 hybrid-array = { version = "0.4", features = ["extra-sizes", "zeroize"] }
-getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }
-sha2 = "0.11.0-rc.3"
+getrandom = { version = "0.4.0-rc.1", features = ["sys_rng"] }
+sha2 = "0.11.0-rc.4"
 static_assertions = "1.1"
 rand_core = "0.10.0-rc-6"
 signature = { version = "3.0.0-rc.9", features = ["alloc", "digest", "rand_core"] }

--- a/ml-dsa/Cargo.toml
+++ b/ml-dsa/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Pure Rust implementation of ML-DSA (formerly known as CRYSTALS-Dilithium) as
 described in FIPS-204 (final)
 """
-version = "0.1.0-rc.3"
+version = "0.1.0-rc.4"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"
@@ -45,7 +45,7 @@ zeroize = { version = "1.8.1", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "0.7"
-getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }
+getrandom = { version = "0.4.0-rc.1", features = ["sys_rng"] }
 hex = { version = "0.4", features = ["serde"] }
 hex-literal = "1"
 pkcs8 = { version = "0.11.0-rc.10", features = ["pem"] }

--- a/rfc6979/Cargo.toml
+++ b/rfc6979/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rfc6979"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 description = """
 Pure Rust implementation of RFC6979: Deterministic Usage of the
 Digital Signature Algorithm (DSA) and Elliptic Curve Digital Signature Algorithm (ECDSA)
@@ -16,7 +16,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-hmac = { version = "0.13.0-rc.3", default-features = false }
+hmac = { version = "0.13.0-rc.4", default-features = false }
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]

--- a/slh-dsa/Cargo.toml
+++ b/slh-dsa/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Pure Rust implementation of SLH-DSA (aka SPHINCS+) as described in the
 FIPS-205 standard
 """
-version = "0.2.0-rc.2"
+version = "0.2.0-rc.3"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
Releases new versions of everything except `dsa` and `ecdsa` (since we previously released those) which include the `rand_core` v0.10.0-rc-6 upgrade (as well as the associated `signature` v3.0.0-rc.9 release).

The `ml-dsa` crate contains a fix for #1176.

Releases the following:
- `ed25519` v3.0.0-rc.3
- `ed448` v0.5.0-rc.3
- `lms-signature` v0.1.0-rc.1
- `ml-dsa` v0.1.0-rc.4
- `rfc6979` v0.5.0-rc.4
- `slh-dsa` v0.2.0-rc.3