### PR TITLE
ml-dsa: impl `MultiplyNtt` trait from `module-lattice`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,8 +725,7 @@ dependencies = [
 [[package]]
 name = "module-lattice"
 version = "0.1.0-pre.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f95b02843c605c5c6d4747f07a1171645be22ce1fb42629e2cf0c5ba199ed640"
+source = "git+https://github.com/RustCrypto/KEMs#5a2b2ae2003bd6c6f5ff5944ef07b3cd84a4d252"
 dependencies = [
  "hybrid-array",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,5 @@ lms-signature = { path = "./lms" }
 ml-dsa = { path = "./ml-dsa" }
 rfc6979 = { path = "./rfc6979" }
 slh-dsa = { path = "./slh-dsa" }
+
+module-lattice = { git = "https://github.com/RustCrypto/KEMs" }

--- a/ml-dsa/src/ntt.rs
+++ b/ml-dsa/src/ntt.rs
@@ -1,4 +1,7 @@
-use module_lattice::{algebra::Field, encode::ArraySize};
+use module_lattice::{
+    algebra::{Field, MultiplyNtt},
+    encode::ArraySize,
+};
 
 use crate::algebra::{BaseField, Elem, NttPolynomial, NttVector, Polynomial, Vector};
 
@@ -158,6 +161,19 @@ impl<K: ArraySize> NttInverse for NttVector<K> {
 
     fn ntt_inverse(&self) -> Self::Output {
         Vector::new(self.0.iter().map(NttPolynomial::ntt_inverse).collect())
+    }
+}
+
+impl MultiplyNtt for BaseField {
+    // Algorithm 45 MultiplyNTT
+    fn multiply_ntt(lhs: &NttPolynomial, rhs: &NttPolynomial) -> NttPolynomial {
+        NttPolynomial::new(
+            lhs.0
+                .iter()
+                .zip(rhs.0.iter())
+                .map(|(&x, &y)| x * y)
+                .collect(),
+        )
     }
 }
 


### PR DESCRIPTION
Previously Algorithm 45: `MultiplyNTT` from FIPS 204 was implemented in the `module-lattice` crate, but for `ml-kem` we need to plug in Algorithm 11: `MultiplyNTTs` from FIPS 203 instead, so `module-lattice` now defines a new `MultiplyNTT` trait that lets either crate plug in their own algorithm that will also work with the `Mul` impls on `NttVector` and `NttMatrix`.

This adds a temporary git dependency on `module-lattice` until it gets another crate release.