### PR TITLE
ml-dsa: fix `use_hint` when 𝓇₀ = 0

### DIFF
--- a/ml-dsa/src/hint.rs
+++ b/ml-dsa/src/hint.rs
@@ -21,10 +21,17 @@ fn use_hint<TwoGamma2: Unsigned>(h: bool, r: Elem) -> Elem {
     let m: u32 = (BaseField::Q - 1) / TwoGamma2::U32;
     let (r1, r0) = r.decompose::<TwoGamma2>();
     let gamma2 = TwoGamma2::U32 / 2;
-    if h && r0.0 > 0 && r0.0 <= gamma2 {
-        Elem::new((r1.0 + 1) % m)
-    } else if h {
-        Elem::new((r1.0 + m - 1) % m)
+
+    if h {
+        if r0.0 > 0 && r0.0 <= gamma2 {
+            Elem::new((r1.0 + 1) % m)
+        } else if (r0.0 == 0) || (r0.0 >= BaseField::Q - gamma2) {
+            Elem::new((r1.0 + m - 1) % m)
+        } else {
+            // We use the Elem encoding even for signed integers.  Since r0 is computed
+            // mod+- 2*gamma2 (possibly minus 1), it is guaranteed to be in [-gamma2, gamma2].
+            unreachable!();
+        }
     } else {
         r1
     }


### PR DESCRIPTION
Originally reported as [GHSA-h37v-hp6w-2pp8](https://github.com/RustCrypto/signatures/security/advisories/GHSA-h37v-hp6w-2pp8) by @XoifaiI

According to FIPS 204 Algorithm 40:

    3: if h = 1 and r0 > 0  return (r1 + 1) mod m
    4: if h = 1 and r0 <= 0  return (r1 − 1) mod m

The check that `r0 > 0` was missing, and so values were being miscomputed in the case that `r0 = 0`.

Likewise, while there were comprehensive tests for other cases, this case was also untested.

This adds the necessary check as well as a test that covers the case.