### PR TITLE
ml-dsa v0.1.0-rc.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -703,7 +703,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "ml-dsa"
-version = "0.1.0-rc.4"
+version = "0.1.0-rc.5"
 dependencies = [
  "const-oid",
  "criterion",

--- a/ml-dsa/Cargo.toml
+++ b/ml-dsa/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Pure Rust implementation of ML-DSA (formerly known as CRYSTALS-Dilithium) as
 described in FIPS-204 (final)
 """
-version = "0.1.0-rc.4"
+version = "0.1.0-rc.5"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
Includes fix for [GHSA-h37v-hp6w-2pp8](https://github.com/RustCrypto/signatures/security/advisories/GHSA-h37v-hp6w-2pp8)