### PR TITLE
ml-dsa: add `reason` to all `clippy` div/rem `allow`s

### DIFF
--- a/ml-dsa/src/algebra.rs
+++ b/ml-dsa/src/algebra.rs
@@ -44,7 +44,7 @@ where
 {
     #[allow(clippy::as_conversions)]
     const SHIFT: usize = 2 * (M::U64.ilog2() + 1) as usize;
-    #[allow(clippy::integer_division_remainder_used)]
+    #[allow(clippy::integer_division_remainder_used, reason = "constant")]
     const MULTIPLIER: u64 = (1 << Self::SHIFT) / M::U64;
 }
 
@@ -91,7 +91,7 @@ where
 
     // Precompute the multiplier at compile time
     // We add (M-1) before dividing to get ceiling division, ensuring we never underestimate
-    #[allow(clippy::integer_division_remainder_used)]
+    #[allow(clippy::integer_division_remainder_used, reason = "constant")]
     const CT_DIV_MULTIPLIER: u64 = (1u64 << Self::CT_DIV_SHIFT).div_ceil(M::U64);
 }
 
@@ -258,7 +258,7 @@ impl<K: ArraySize> AlgebraExt for Vector<K> {
 }
 
 #[cfg(test)]
-#[allow(clippy::integer_division_remainder_used)]
+#[allow(clippy::integer_division_remainder_used, reason = "tests")]
 mod test {
     use super::*;
 

--- a/ml-dsa/src/encode.rs
+++ b/ml-dsa/src/encode.rs
@@ -106,7 +106,8 @@ where
 }
 
 #[cfg(test)]
-pub(crate) mod test {
+#[allow(clippy::integer_division_remainder_used, reason = "tests")]
+pub(crate) mod tests {
     use super::*;
     use crate::algebra::*;
     use core::ops::Rem;
@@ -133,13 +134,11 @@ pub(crate) mod test {
         D: ArraySize + Rem<N>,
         Mod<D, N>: Zero,
     {
-        #[allow(clippy::integer_division_remainder_used)]
         fn repeat(&self) -> Array<T, D> {
             Array::from_fn(|i| self[i % N::USIZE].clone())
         }
     }
 
-    #[allow(clippy::integer_division_remainder_used)]
     fn simple_bit_pack_test<D>(b: u32, decoded: &Polynomial, encoded: &EncodedPolynomial<D>)
     where
         D: EncodingSize,
@@ -207,7 +206,6 @@ pub(crate) mod test {
         simple_bit_pack_test::<U6>(b, &decoded, &encoded);
     }
 
-    #[allow(clippy::integer_division_remainder_used)]
     fn bit_pack_test<A, B>(decoded: &Polynomial, encoded: &RangeEncodedPolynomial<A, B>)
     where
         A: Unsigned,

--- a/ml-dsa/src/hint.rs
+++ b/ml-dsa/src/hint.rs
@@ -156,7 +156,7 @@ where
 }
 
 #[cfg(test)]
-#[allow(clippy::integer_division_remainder_used)]
+#[allow(clippy::integer_division_remainder_used, reason = "tests")]
 mod test {
     use super::*;
     use crate::{MlDsa44, MlDsa65, ParameterSet};

--- a/ml-dsa/src/ntt.rs
+++ b/ml-dsa/src/ntt.rs
@@ -17,7 +17,7 @@ use crate::algebra::{BaseField, Elem, NttPolynomial, NttVector, Polynomial, Vect
 // The values computed here match those provided in Appendix B of FIPS 204.
 #[allow(clippy::cast_possible_truncation)]
 #[allow(clippy::as_conversions)]
-#[allow(clippy::integer_division_remainder_used)]
+#[allow(clippy::integer_division_remainder_used, reason = "constant")]
 const ZETA_POW_BITREV: [Elem; 256] = {
     const ZETA: u64 = 1753;
     const fn bitrev8(x: usize) -> usize {


### PR DESCRIPTION
For allow instances of `allow(clippy::integer_division_remainder_used)` adds a `reason` field which is now one of "constant" (as in bound to an all-caps-named `const` value) or "tests".