### PR TITLE
ml-dsa: bump `module-lattice` to v0.1.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,7 +709,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "ml-dsa"
-version = "0.1.0-rc.6"
+version = "0.1.0-rc.7"
 dependencies = [
  "const-oid",
  "criterion",
@@ -730,8 +730,9 @@ dependencies = [
 
 [[package]]
 name = "module-lattice"
-version = "0.1.0-rc.0"
-source = "git+https://github.com/RustCrypto/KEMs#9404362c9180fd142c251502ca32dffe1ff0a4e4"
+version = "0.1.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f053ae0c0c619f9d9e145edd3a06785e21d340a28967f4ebbdf60df88ee548"
 dependencies = [
  "hybrid-array",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,4 @@ ml-dsa = { path = "./ml-dsa" }
 rfc6979 = { path = "./rfc6979" }
 slh-dsa = { path = "./slh-dsa" }
 
-module-lattice = { git = "https://github.com/RustCrypto/KEMs" }
 rand = { git = "https://github.com/rust-random/rand" }

--- a/ml-dsa/Cargo.toml
+++ b/ml-dsa/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Pure Rust implementation of ML-DSA (formerly known as CRYSTALS-Dilithium) as
 described in FIPS-204 (final)
 """
-version = "0.1.0-rc.6"
+version = "0.1.0-rc.7"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"
@@ -33,7 +33,7 @@ pkcs8 = ["dep:const-oid", "dep:pkcs8"]
 
 [dependencies]
 hybrid-array = { version = "0.4", features = ["extra-sizes"] }
-module-lattice = "0.1.0-rc.0"
+module-lattice = "0.1.0-rc.1"
 sha3 = { version = "0.11.0-rc.7", default-features = false }
 signature = { version = "3.0.0-rc.10", default-features = false, features = ["digest"] }
 


### PR DESCRIPTION
Also cuts an `ml-dsa` v0.1.0-rc.7 release