### PR TITLE
ml-dsa: bump `module-lattice` dependency to v0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,9 +730,9 @@ dependencies = [
 
 [[package]]
 name = "module-lattice"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f053ae0c0c619f9d9e145edd3a06785e21d340a28967f4ebbdf60df88ee548"
+checksum = "6dfecc750073acc09af2f8899b2342d520d570392ba1c3aed53eeb0d84ca4103"
 dependencies = [
  "hybrid-array",
  "num-traits",

--- a/ml-dsa/Cargo.toml
+++ b/ml-dsa/Cargo.toml
@@ -33,7 +33,7 @@ pkcs8 = ["dep:const-oid", "dep:pkcs8"]
 
 [dependencies]
 hybrid-array = { version = "0.4", features = ["extra-sizes"] }
-module-lattice = "0.1.0-rc.1"
+module-lattice = "0.1"
 sha3 = { version = "0.11.0-rc.7", default-features = false }
 signature = { version = "3.0.0-rc.10", default-features = false, features = ["digest"] }
 


### PR DESCRIPTION
Initial stable release