### PR TITLE
dsa: bump `crypto-bigint` to v0.7.0-rc.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,9 +201,9 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "cpubits"
-version = "0.1.0-rc.3"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a8c0210fa48ba3ea04ac1e9c6e72ae66009db3b1f1745635d4ff2e58eaadd0"
+checksum = "5ef0c543070d296ea414df2dd7625d1b24866ce206709d8a4a424f28377f5861"
 
 [[package]]
 name = "cpufeatures"
@@ -289,9 +289,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.25"
+version = "0.7.0-rc.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cba9eeeb213f7fd29353032f71f7c173e5f6d95d85151cb3a47197b0ea7e8be7"
+checksum = "8e8d50190c5aeb459e0c974f7f00c3fe2e770ef18d1abe32adb87ad8d9108f89"
 dependencies = [
  "cpubits",
  "ctutils",

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.85"
 [dependencies]
 der = { version = "0.8.0-rc.10", features = ["alloc"] }
 digest = "0.11.0-rc.11"
-crypto-bigint = { version = "0.7.0-rc.25", default-features = false, features = ["alloc", "zeroize"] }
+crypto-bigint = { version = "0.7.0-rc.26", default-features = false, features = ["alloc", "zeroize"] }
 crypto-primes = { version = "0.7.0-pre.8", default-features = false }
 rfc6979 = { version = "0.5.0-rc.5" }
 sha2 = { version = "0.11.0-rc.5", default-features = false }

--- a/dsa/src/signing_key.rs
+++ b/dsa/src/signing_key.rs
@@ -10,7 +10,7 @@ use core::{
     fmt::{self, Debug},
 };
 use crypto_bigint::{
-    BoxedUint, NonZero, Resize,
+    BoxedUint, ConcatenatingMul, NonZero, Resize,
     modular::{BoxedMontyForm, BoxedMontyParams},
 };
 use digest::{Update, block_api::EagerHash};
@@ -132,7 +132,10 @@ impl SigningKey {
         let z = BoxedUint::from_be_slice(&hash[..z_len], z_len as u32 * 8)
             .expect("invariant violation");
 
-        let s = inv_k.mul_mod(&(z + &**x * &r), &q.resize(key_size.l_aligned()));
+        let s = inv_k.mul_mod(
+            &z.concatenating_add(x.concatenating_mul(r)),
+            &q.resize(key_size.l_aligned()),
+        );
         let s = s.resize(key_size.n_aligned());
 
         debug_assert_eq!(key_size.n_aligned(), r_short.bits_precision());


### PR DESCRIPTION
Includes changes to the default `Mul` and `Add` impls so they are no longer widening, necessitating a switch to
`concatenating_add`/`concatenating_mul`.

See RustCrypto/crypto-bigint#1177