### PR TITLE
fix(ecdsa): correct error message for invalid vector.k in dev macro

### DIFF
--- a/ecdsa/src/dev.rs
+++ b/ecdsa/src/dev.rs
@@ -72,7 +72,7 @@ macro_rules! new_signing_test {
         fn ecdsa_signing() {
             for vector in $vectors {
                 let d = decode_scalar(vector.d).expect("invalid vector.d");
-                let k = decode_scalar(vector.k).expect("invalid vector.m");
+                let k = decode_scalar(vector.k).expect("invalid vector.k");
 
                 assert_eq!(
                     <$curve as Curve>::FieldBytesSize::USIZE,


### PR DESCRIPTION
Cause: The error message in the `new_signing_test` macro incorrectly referred to "vector.m" when checking the ephemeral scalar `k`, which was a copy-paste error from the line below. This would confuse developers debugging test failures since the message doesn't match the actual field.

Changes: Fixed the error message in `decode_scalar(vector.k).expect()` to correctly reference "invalid vector.k" instead of "invalid vector.m". 