### PR TITLE
dsa: bump `crypto-bigint` to v0.7.0-rc.27

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,9 +289,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.26"
+version = "0.7.0-rc.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d50190c5aeb459e0c974f7f00c3fe2e770ef18d1abe32adb87ad8d9108f89"
+checksum = "b43308b9b6a47554f4612d5b1fb95ff935040aa3927dd42b1d6cbc015a262d96"
 dependencies = [
  "cpubits",
  "ctutils",
@@ -317,9 +317,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-primes"
-version = "0.7.0-pre.8"
+version = "0.7.0-pre.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "334a79c97c0b7fa536716dc132fd417d0afbf471440a41fc25a5d9f66d8771cd"
+checksum = "6081ce8b60c0e533e2bba42771b94eb6149052115f4179744d5779883dc98583"
 dependencies = [
  "crypto-bigint",
  "libm",

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -18,8 +18,8 @@ rust-version = "1.85"
 [dependencies]
 der = { version = "0.8.0-rc.10", features = ["alloc"] }
 digest = "0.11.0-rc.11"
-crypto-bigint = { version = "0.7.0-rc.26", default-features = false, features = ["alloc", "zeroize"] }
-crypto-primes = { version = "0.7.0-pre.8", default-features = false }
+crypto-bigint = { version = "0.7.0-rc.27", default-features = false, features = ["alloc", "zeroize"] }
+crypto-primes = { version = "0.7.0-pre.9", default-features = false }
 rfc6979 = { version = "0.5.0-rc.5" }
 sha2 = { version = "0.11.0-rc.5", default-features = false }
 signature = { version = "3.0.0-rc.10", default-features = false, features = ["alloc", "digest", "rand_core"] }


### PR DESCRIPTION
Also bumps `crypto-primes` to v0.7.0-pre.9