### PR TITLE
refactor(ml-dsa): optimize rejection sampling in rej_ntt_poly and rej_bounded_poly

### DIFF
--- a/ml-dsa/src/sampling.rs
+++ b/ml-dsa/src/sampling.rs
@@ -5,6 +5,8 @@ use crate::{
 };
 use hybrid_array::Array;
 use module_lattice::{ArraySize, Field, Truncate};
+#[cfg(feature = "zeroize")]
+use zeroize::Zeroize;
 
 // Algorithm 13 BytesToBits
 fn bit_set(z: &[u8], i: usize) -> bool {
@@ -122,7 +124,11 @@ fn rej_ntt_poly(rho: &[u8], r: u8, s: u8) -> NttPolynomial {
             j += 1;
         }
     }
-
+    #[cfg(feature = "zeroize")]
+    {
+        buf.zeroize();
+        tmp.zeroize();
+    }
     a
 }
 
@@ -132,10 +138,8 @@ fn rej_bounded_poly(rho: &[u8], eta: Eta, r: u16) -> Polynomial {
     let mut ctx = H::default().absorb(rho).absorb(&r.to_le_bytes());
     let mut a = Polynomial::default();
 
-    // Squeeze 840 bytes in a single call rather than 1 byte at a time.  Each
-    // byte yields two half-byte candidates, and the acceptance probability per
-    // half-byte is ≥50%, so 1680 candidates are almost always sufficient.
-    let mut buf = [0u8; 840];
+    // The reference implementation uses 136 bytes (1 SHAKE256 block) for eta=2 and 272 bytes (2 blocks) for eta=4.
+    let mut buf = [0u8; 272];
     ctx.squeeze(&mut buf);
 
     for &byte in &buf {
@@ -172,7 +176,11 @@ fn rej_bounded_poly(rho: &[u8], eta: Eta, r: u16) -> Polynomial {
             }
         }
     }
-
+    #[cfg(feature = "zeroize")]
+    {
+        buf.zeroize();
+        tmp.zeroize();
+    }
     a
 }
 

--- a/ml-dsa/src/sampling.rs
+++ b/ml-dsa/src/sampling.rs
@@ -138,7 +138,7 @@ fn rej_bounded_poly(rho: &[u8], eta: Eta, r: u16) -> Polynomial {
     let mut buf = [0u8; 840];
     ctx.squeeze(&mut buf);
 
-    for &byte in buf.iter() {
+    for &byte in &buf {
         let (z0, z1) = coeffs_from_byte(byte, eta);
         if let Some(x) = z0 {
             a.0[j] = x;

--- a/ml-dsa/src/sampling.rs
+++ b/ml-dsa/src/sampling.rs
@@ -148,7 +148,7 @@ fn rej_bounded_poly(rho: &[u8], eta: Eta, r: u16) -> Polynomial {
             a.0[j] = x;
             j += 1;
             if j == 256 {
-                return a;
+                break;
             }
         }
         if let Some(x) = z1 {

--- a/ml-dsa/src/sampling.rs
+++ b/ml-dsa/src/sampling.rs
@@ -95,12 +95,29 @@ pub(crate) fn sample_in_ball(rho: &[u8], tau: usize) -> Polynomial {
 fn rej_ntt_poly(rho: &[u8], r: u8, s: u8) -> NttPolynomial {
     let mut j = 0;
     let mut ctx = G::default().absorb(rho).absorb(&[s]).absorb(&[r]);
-
     let mut a = NttPolynomial::default();
-    let mut s = [0u8; 3];
+
+    // Squeeze 840 bytes (5 SHAKE128 blocks) in a single call rather than 3 bytes
+    // at a time.  The rejection probability is ~0.098%, so 280 candidates are
+    // almost always sufficient while requiring the same 5 Keccak-f permutations.
+    let mut buf = [0u8; 840];
+    ctx.squeeze(&mut buf);
+
+    for chunk in buf.chunks_exact(3) {
+        if let Some(x) = coeff_from_three_bytes([chunk[0], chunk[1], chunk[2]]) {
+            a.0[j] = x;
+            j += 1;
+            if j == 256 {
+                return a;
+            }
+        }
+    }
+
+    // Fallback: astronomically unlikely (~10^-44), but required for correctness.
+    let mut tmp = [0u8; 3];
     while j < 256 {
-        ctx.squeeze(&mut s);
-        if let Some(x) = coeff_from_three_bytes(s) {
+        ctx.squeeze(&mut tmp);
+        if let Some(x) = coeff_from_three_bytes(tmp) {
             a.0[j] = x;
             j += 1;
         }
@@ -113,25 +130,46 @@ fn rej_ntt_poly(rho: &[u8], r: u8, s: u8) -> NttPolynomial {
 fn rej_bounded_poly(rho: &[u8], eta: Eta, r: u16) -> Polynomial {
     let mut j = 0;
     let mut ctx = H::default().absorb(rho).absorb(&r.to_le_bytes());
-
     let mut a = Polynomial::default();
-    let mut z = [0u8];
+
+    // Squeeze 840 bytes in a single call rather than 1 byte at a time.  Each
+    // byte yields two half-byte candidates, and the acceptance probability per
+    // half-byte is ≥50%, so 1680 candidates are almost always sufficient.
+    let mut buf = [0u8; 840];
+    ctx.squeeze(&mut buf);
+
+    for &byte in buf.iter() {
+        let (z0, z1) = coeffs_from_byte(byte, eta);
+        if let Some(x) = z0 {
+            a.0[j] = x;
+            j += 1;
+            if j == 256 {
+                return a;
+            }
+        }
+        if let Some(x) = z1 {
+            a.0[j] = x;
+            j += 1;
+            if j == 256 {
+                return a;
+            }
+        }
+    }
+
+    // Fallback: astronomically unlikely, but required for correctness.
+    let mut tmp = [0u8; 1];
     while j < 256 {
-        ctx.squeeze(&mut z);
-        let (z0, z1) = coeffs_from_byte(z[0], eta);
-
-        if let Some(z) = z0 {
-            a.0[j] = z;
+        ctx.squeeze(&mut tmp);
+        let (z0, z1) = coeffs_from_byte(tmp[0], eta);
+        if let Some(x) = z0 {
+            a.0[j] = x;
             j += 1;
         }
-
-        if j == 256 {
-            break;
-        }
-
-        if let Some(z) = z1 {
-            a.0[j] = z;
-            j += 1;
+        if j < 256 {
+            if let Some(x) = z1 {
+                a.0[j] = x;
+                j += 1;
+            }
         }
     }
 

--- a/ml-dsa/src/sampling.rs
+++ b/ml-dsa/src/sampling.rs
@@ -110,7 +110,7 @@ fn rej_ntt_poly(rho: &[u8], r: u8, s: u8) -> NttPolynomial {
             a.0[j] = x;
             j += 1;
             if j == 256 {
-                return a;
+                break;
             }
         }
     }

--- a/ml-dsa/src/sampling.rs
+++ b/ml-dsa/src/sampling.rs
@@ -155,7 +155,7 @@ fn rej_bounded_poly(rho: &[u8], eta: Eta, r: u16) -> Polynomial {
             a.0[j] = x;
             j += 1;
             if j == 256 {
-                return a;
+                break;
             }
         }
     }

--- a/xmss/src/params.rs
+++ b/xmss/src/params.rs
@@ -1173,13 +1173,13 @@ impl XmssOid {
         self.initialize(&mut params)?;
 
         let expected = params.get_seed_length();
-        if let Some(seed) = seed
-            && seed.len() != expected
-        {
-            return Err(Error::InvalidSeedLength {
-                expected,
-                got: seed.len(),
-            });
+        if let Some(seed) = seed {
+            if seed.len() != expected {
+                return Err(Error::InvalidSeedLength {
+                    expected,
+                    got: seed.len(),
+                });
+            }
         }
 
         let oid = self.raw_oid();

--- a/xmss/src/params.rs
+++ b/xmss/src/params.rs
@@ -1173,13 +1173,13 @@ impl XmssOid {
         self.initialize(&mut params)?;
 
         let expected = params.get_seed_length();
-        if let Some(seed) = seed {
-            if seed.len() != expected {
-                return Err(Error::InvalidSeedLength {
-                    expected,
-                    got: seed.len(),
-                });
-            }
+        if let Some(seed) = seed
+            && seed.len() != expected
+        {
+            return Err(Error::InvalidSeedLength {
+                expected,
+                got: seed.len(),
+            });
         }
 
         let oid = self.raw_oid();


### PR DESCRIPTION
It seems like filling matrix is a bottleneck of decoding key. With simple changes, it gets good performance.

Original benchmark with `cargo bench --bench ml_dsa -- "verify"`:

```
verify                  time:   [83.450 µs 83.685 µs 84.061 µs]
```

After:
```
verify                  time:   [63.170 µs 64.008 µs 65.218 µs]
                        change: [−25.381% −24.161% −22.702%] (p = 0.00 < 0.05)
                        Performance has improved.
```

              