### PR TITLE
ml-dsa: zeroize NTT-domain derived values in ExpandedSigningKey Drop

### DIFF
--- a/ml-dsa/src/lib.rs
+++ b/ml-dsa/src/lib.rs
@@ -301,6 +301,9 @@ impl<P: MlDsaParams> Drop for ExpandedSigningKey<P> {
         self.s1.zeroize();
         self.s2.zeroize();
         self.t0.zeroize();
+        self.s1_hat.zeroize();
+        self.s2_hat.zeroize();
+        self.t0_hat.zeroize();
     }
 }
 


### PR DESCRIPTION
## Summary

The `Drop` impl for `ExpandedSigningKey` (when the `zeroize` feature is enabled) zeroizes `rho`, `K`, `tr`, `s1`, `s2`, and `t0`, but currently does not zeroize the cached NTT-domain values `s1_hat`, `s2_hat`, and `t0_hat`.

These `_hat` fields are reversible transforms of secret key components, so leaving them uncleared means recoverable secret-derived material remains in memory after drop.

This change zeroizes those secret-derived cached values as well.

Note: `ExpandedSigningKey` also stores `A_hat`, but addressing zeroization for that value likely requires support in the underlying `module_lattice` types, so it is left for separate follow-up work.