### PR TITLE
ecdsa: use `mul_by_generator_and_mul_add_vartime` for verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,8 +506,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "elliptic-curve"
 version = "0.14.0-rc.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d7a0bfd012613a7bcfe02cbfccf2b846e9ef9e1bccb641c48d461253cfb034d"
+source = "git+https://github.com/RustCrypto/traits#4aa20faef303aa04f61892d33c229314bdcea43f"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -1435,7 +1434,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,5 @@ rfc6979 = { path = "./rfc6979" }
 slh-dsa = { path = "./slh-dsa" }
 xmss = { path = "./xmss" }
 bign-genk = { path = "./bign-genk" }
+
+elliptic-curve = { git = "https://github.com/RustCrypto/traits" }

--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -24,7 +24,7 @@ use {
         CurveArithmetic, NonZeroScalar, ProjectivePoint, Scalar,
         ff::PrimeField,
         group::{Curve as _, Group},
-        ops::{Invert, LinearCombination, Reduce},
+        ops::{Invert, MulByGeneratorVartime, Reduce},
         point::AffineCoordinates,
         scalar::IsHigh,
     },
@@ -213,7 +213,7 @@ where
     let s_inv = *s.invert_vartime();
     let u1 = z * s_inv;
     let u2 = *r * s_inv;
-    let x = ProjectivePoint::<C>::lincomb(&[(ProjectivePoint::<C>::generator(), u1), (*q, u2)])
+    let x = ProjectivePoint::<C>::mul_by_generator_and_mul_add_vartime(&u1, &u2, q)
         .to_affine()
         .x();
 


### PR DESCRIPTION
This high-level method can plug into various strategies for efficiently implementing `aG + bP`, including using basepoint tables, wNAF, or linear combinations, depending on what crate features are enabled and what curve-specific optimizations have been implemented.