### PR TITLE
Implement Hash on non-secret Signature and VerifyingKey types

### DIFF
--- a/ecdsa/src/der.rs
+++ b/ecdsa/src/der.rs
@@ -151,6 +151,17 @@ where
     }
 }
 
+impl<C> core::hash::Hash for Signature<C>
+where
+    C: EcdsaCurve,
+    MaxSize<C>: ArraySize,
+    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArraySize,
+{
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.as_bytes().hash(state);
+    }
+}
+
 impl<C> AsRef<[u8]> for Signature<C>
 where
     C: EcdsaCurve,

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -398,6 +398,16 @@ where
     }
 }
 
+impl<C> core::hash::Hash for Signature<C>
+where
+    C: EcdsaCurve,
+    SignatureSize<C>: ArraySize,
+{
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.to_bytes().hash(state);
+    }
+}
+
 impl<C> fmt::LowerHex for Signature<C>
 where
     C: EcdsaCurve,
@@ -665,6 +675,18 @@ where
     SignatureSize<C>: ArraySize,
     <SignatureSize<C> as ArraySize>::ArrayType<u8>: Copy,
 {
+}
+
+#[cfg(feature = "digest")]
+impl<C> core::hash::Hash for SignatureWithOid<C>
+where
+    C: EcdsaCurve,
+    SignatureSize<C>: ArraySize,
+{
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.signature.hash(state);
+        self.oid.hash(state);
+    }
 }
 
 #[cfg(feature = "digest")]

--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -316,7 +316,7 @@ pub type SignatureBytes = [u8; Signature::BYTE_SIZE];
 ///
 /// Signature verification libraries are expected to reject invalid field
 /// elements at the time a signature is verified.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, Hash, PartialEq)]
 #[cfg_attr(
     feature = "zerocopy",
     derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)

--- a/ed25519/src/pkcs8.rs
+++ b/ed25519/src/pkcs8.rs
@@ -229,7 +229,7 @@ impl str::FromStr for KeypairBytes {
 ///
 /// Note that this type operates on raw bytes and performs no validation that
 /// public keys represent valid compressed Ed25519 y-coordinates.
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Eq, Hash, PartialEq)]
 #[cfg_attr(
     feature = "zerocopy",
     derive(IntoBytes, FromBytes, Unaligned, KnownLayout, Immutable,)

--- a/ed448/src/lib.rs
+++ b/ed448/src/lib.rs
@@ -115,7 +115,7 @@ pub type SignatureBytes = [u8; Signature::BYTE_SIZE];
 ///
 /// Signature verification libraries are expected to reject invalid field
 /// elements at the time a signature is verified.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, Hash, PartialEq)]
 #[repr(C)]
 pub struct Signature {
     R: ComponentBytes,

--- a/ed448/src/pkcs8.rs
+++ b/ed448/src/pkcs8.rs
@@ -205,7 +205,7 @@ impl fmt::Debug for KeypairBytes {
 ///
 /// Note that this type operates on raw bytes and performs no validation that
 /// public keys represent valid compressed Ed448 y-coordinates.
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Eq, Hash, PartialEq)]
 pub struct PublicKeyBytes(pub [u8; Self::BYTE_SIZE]);
 
 impl PublicKeyBytes {

--- a/ml-dsa/src/lib.rs
+++ b/ml-dsa/src/lib.rs
@@ -151,6 +151,12 @@ impl<P: MlDsaParams> signature::SignatureEncoding for Signature<P> {
     type Repr = EncodedSignature<P>;
 }
 
+impl<P: MlDsaParams> core::hash::Hash for Signature<P> {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.encode().hash(state);
+    }
+}
+
 struct MuBuilder(H);
 
 impl MuBuilder {
@@ -831,6 +837,12 @@ impl<P: MlDsaParams> VerifyingKey<P> {
         let (rho, t1_enc) = P::split_vk(enc);
         let t1 = P::decode_t1(t1_enc);
         Self::new_expand_a(rho.clone(), t1, Some(enc.clone()))
+    }
+}
+
+impl<P: MlDsaParams> core::hash::Hash for VerifyingKey<P> {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.encode().hash(state);
     }
 }
 

--- a/slh-dsa/src/signature_encoding.rs
+++ b/slh-dsa/src/signature_encoding.rs
@@ -71,6 +71,12 @@ impl<P: ParameterSet> Signature<P> {
     }
 }
 
+impl<P: ParameterSet> core::hash::Hash for Signature<P> {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.to_bytes().hash(state);
+    }
+}
+
 impl<P: ParameterSet> TryFrom<&[u8]> for Signature<P> {
     type Error = Error;
 

--- a/slh-dsa/src/verifying_key.rs
+++ b/slh-dsa/src/verifying_key.rs
@@ -136,6 +136,12 @@ impl<P: ParameterSet + VerifyingKeyLen> VerifyingKey<P> {
     }
 }
 
+impl<P: ParameterSet> core::hash::Hash for VerifyingKey<P> {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.to_bytes().hash(state);
+    }
+}
+
 impl<P: ParameterSet> Clone for VerifyingKey<P> {
     fn clone(&self) -> Self {
         VerifyingKey {


### PR DESCRIPTION
  Per #1229: Signature and public-key types lack `Hash`, which prevents
  use in `HashMap` / `HashSet` keys and similar collections.

  - ecdsa: Signature, DER Signature, SignatureWithOid
  - ed25519: Signature, pkcs8::PublicKeyBytes
  - ed448: Signature, pkcs8::PublicKeyBytes
  - ml-dsa: Signature, VerifyingKey
  - slh-dsa: Signature, VerifyingKey

  Where a trivial derive works (ed25519, ed448), uses derive. Where
  generic bounds or upstream gaps require it, uses a manual impl over
  the canonical serialized bytes (`to_bytes` / `encode` / `as_bytes`),
  which is the natural Hash domain for these types anyway.

  Followups (separate PRs, blocked on upstream):
  - ecdsa VerifyingKey (needs PublicKey<C>: Hash in elliptic-curve)
  - dsa types (need BoxedUint: Hash in crypto-bigint)
  - lms types (need Mode-generic trait bound threading)

  Closes #1229