### PR TITLE
ecdsa: bump `elliptic-curve` to v0.14.0-rc.32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,9 +505,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.31"
+version = "0.14.0-rc.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b148a81cede8f4023248f980cffdf7611c46f2add469c6980e815b7c5b764ba5"
+checksum = "cda94f31325c4275e9706adecbb6f0650dee2f904c915a98e3d81adaaaa757aa"
 dependencies = [
  "base16ct",
  "crypto-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ opt-level = 2
 [patch.crates-io]
 # A global patch crates-io block is used to avoid duplicate dependencies
 # when pulling a member crate through git
+bign-genk = { path = "./bign-genk" }
 dsa = { path = "./dsa" }
 ecdsa = { path = "./ecdsa" }
 ed448 = { path = "./ed448" }
@@ -28,4 +29,3 @@ ml-dsa = { path = "./ml-dsa" }
 rfc6979 = { path = "./rfc6979" }
 slh-dsa = { path = "./slh-dsa" }
 xmss = { path = "./xmss" }
-bign-genk = { path = "./bign-genk" }

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-elliptic-curve = { version = "0.14.0-rc.31", default-features = false, features = ["sec1"] }
+elliptic-curve = { version = "0.14.0-rc.32", default-features = false, features = ["sec1"] }
 signature = { version = "3.0.0-rc.10", default-features = false, features = ["rand_core"] }
 zeroize = { version = "1.5", default-features = false }
 
@@ -30,7 +30,7 @@ sha2 = { version = "0.11", optional = true, default-features = false, features =
 spki = { version = "0.8", optional = true, default-features = false }
 
 [dev-dependencies]
-elliptic-curve = { version = "0.14.0-rc.31", default-features = false, features = ["dev"] }
+elliptic-curve = { version = "0.14.0-rc.32", default-features = false, features = ["dev"] }
 hex-literal = "1"
 sha2 = { version = "0.11", default-features = false }
 


### PR DESCRIPTION
This version requires `pkcs8` v0.11