### PR TITLE
Cut new prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "dsa"
-version = "0.7.0-rc.14"
+version = "0.7.0-rc.15"
 dependencies = [
  "chacha20",
  "crypto-bigint",
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.17"
+version = "0.17.0-rc.18"
 dependencies = [
  "der",
  "digest",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "3.0.0-rc.4"
+version = "3.0.0-rc.5"
 dependencies = [
  "hex-literal",
  "pkcs8",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "ed448"
-version = "0.5.0-rc.5"
+version = "0.5.0-rc.6"
 dependencies = [
  "hex-literal",
  "pkcs8",
@@ -816,7 +816,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "ml-dsa"
-version = "0.1.0-rc.8"
+version = "0.1.0-rc.9"
 dependencies = [
  "const-oid",
  "criterion",
@@ -1352,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "slh-dsa"
-version = "0.2.0-rc.4"
+version = "0.2.0-rc.5"
 dependencies = [
  "aes",
  "cipher",
@@ -1435,7 +1435,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1735,7 +1735,7 @@ dependencies = [
 
 [[package]]
 name = "xmss"
-version = "0.1.0-pre.0"
+version = "0.1.0-pre.1"
 dependencies = [
  "const-oid",
  "der",

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsa"
-version = "0.7.0-rc.14"
+version = "0.7.0-rc.15"
 description = """
 Pure Rust implementation of the Digital Signature Algorithm (DSA) as specified
 in FIPS 186-4 (Digital Signature Standard), providing RFC6979 deterministic

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecdsa"
-version = "0.17.0-rc.17"
+version = "0.17.0-rc.18"
 description = """
 Pure Rust implementation of the Elliptic Curve Digital Signature Algorithm
 (ECDSA) as specified in FIPS 186-4 (Digital Signature Standard), providing

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed25519"
-version = "3.0.0-rc.4"
+version = "3.0.0-rc.5"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """

--- a/ed448/Cargo.toml
+++ b/ed448/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed448"
-version = "0.5.0-rc.5"
+version = "0.5.0-rc.6"
 edition = "2024"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"

--- a/ml-dsa/Cargo.toml
+++ b/ml-dsa/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Pure Rust implementation of ML-DSA (formerly known as CRYSTALS-Dilithium) as
 described in FIPS-204 (final)
 """
-version = "0.1.0-rc.8"
+version = "0.1.0-rc.9"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"

--- a/slh-dsa/Cargo.toml
+++ b/slh-dsa/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Pure Rust implementation of SLH-DSA (aka SPHINCS+) as described in the
 FIPS-205 standard
 """
-version = "0.2.0-rc.4"
+version = "0.2.0-rc.5"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"

--- a/xmss/Cargo.toml
+++ b/xmss/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "xmss"
+version = "0.1.0-pre.1"
 authors = ["Michael Lodder <redmike7@gmail.com>"]
 description = """
 Pure Rust implementation of XMSS (eXtended Merkle Signature Scheme)
 as described in RFC 8391 and SP 800-208
 """
+license = "Apache-2.0 OR MIT"
 edition = "2024"
 homepage = "https://github.com/RustCrypto/signature/tree/master/xmss"
 repository = "https://github.com/RustCrypto/signatures"
 readme = "README.md"
 categories = ["cryptography"]
 keywords = ["xmss", "signature", "crypto", "cryptography", "rfc8391"]
-license = "MIT/Apache-2.0"
-version = "0.1.0-pre.0"
 
 [features]
 default = []


### PR DESCRIPTION
Releases the following, which all now depend either directly or transitively on `pkcs8` v0.11 (which had breaking changes in the final release)

- `dsa` v0.7.0-rc.15
- `ecdsa` v0.17.0-rc.18
- `ed25519` v3.0.0-rc.5
- `ed448` v0.5.0-rc.6
- `ml-dsa` v0.1.0-rc.9
- `slh-dsa` v0.2.0-rc.5
- `xmss` v0.1.0-pre.1