### PR TITLE
ed25519: remove `rand_core` dev-dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,7 +477,6 @@ version = "3.0.0-rc.5"
 dependencies = [
  "hex-literal",
  "pkcs8",
- "rand_core 0.9.5",
  "serdect",
  "signature 3.0.0",
  "zerocopy",

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -30,7 +30,6 @@ zerocopy = { version = "0.8", optional = true, features = ["derive"] }
 #ed25519-dalek = { version = "2", features = ["rand_core"] }
 hex-literal = "1"
 #ring-compat = { version = "0.8", default-features = false, features = ["signature"] }
-rand_core = { version = "0.9", features = ["std"] }
 
 [features]
 default = ["alloc"]


### PR DESCRIPTION
It's out-of-date and seemingly unused, possibly tied to the interop documentation which is currently disabled, but we can cross that bridge when we get there