### PR TITLE
ed25519: fix `Zeroize` impl for `Signature`

### DIFF
--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -475,7 +475,7 @@ impl<'de> Deserialize<'de> for Signature {
 #[cfg(feature = "zeroize")]
 impl Zeroize for Signature {
     fn zeroize(&mut self) {
-        self.R = [0; 32];
-        self.s = [0; 32];
+        self.R.zeroize();
+        self.s.zeroize();
     }
 }


### PR DESCRIPTION
It wasn't actually using `Zeroize` on the underlying values