### PR TITLE
ed25519 v3.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "3.0.0-rc.5"
+version = "3.0.0"
 dependencies = [
  "hex-literal",
  "pkcs8",
@@ -1433,7 +1433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys",

--- a/ed25519/CHANGELOG.md
+++ b/ed25519/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.0.0 (2026-05-03)
+### Added
+- `SignatureBitStringEncoding` support ([#889])
+- Implement `Zeroize` for `Signature` ([#952], [#1326])
+- Implement `MultipartSigner`/`MultipartVerifier` ([#982])
+- Optional `zerocopy` support ([#1134])
+- Implement `Hash` for `Signature` ([#1309])
+
+### Changed
+- Upgrade to the 2024 edition and bump MSRV to 1.85 ([#913])
+- Bump `pkcs8` dependency to v0.11 ([#1316])
+- Bump `signature` dependency to v3 ([#1321])
+- Use `serdect` for `serde` support ([#1324])
+
+### Removed
+- `std` feature ([#985])
+- `serde_bytes` feature ([#1324])
+
+[#889]: https://github.com/RustCrypto/signatures/pull/889
+[#913]: https://github.com/RustCrypto/signatures/pull/913
+[#952]: https://github.com/RustCrypto/signatures/pull/952
+[#982]: https://github.com/RustCrypto/signatures/pull/982
+[#985]: https://github.com/RustCrypto/signatures/pull/985
+[#1134]: https://github.com/RustCrypto/signatures/pull/1134
+[#1309]: https://github.com/RustCrypto/signatures/pull/1309
+[#1316]: https://github.com/RustCrypto/signatures/pull/1316
+[#1321]: https://github.com/RustCrypto/signatures/pull/1321
+[#1324]: https://github.com/RustCrypto/signatures/pull/1324
+[#1326]: https://github.com/RustCrypto/signatures/pull/1326
+
 ## 2.2.3 (2023-10-15)
 ### Changed
 - Bump `ring-compat` from 0.7 to 0.8 ([#744])

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed25519"
-version = "3.0.0-rc.5"
+version = "3.0.0"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """
@@ -33,7 +33,7 @@ hex-literal = "1"
 
 [features]
 default = ["alloc"]
-alloc = ["pkcs8?/alloc"]
+alloc = ["pkcs8?/alloc", "signature/alloc"]
 pem = ["alloc", "pkcs8/pem"]
 serde = ["dep:serdect"]
 


### PR DESCRIPTION
## Added
- `SignatureBitStringEncoding` support ([#889])
- Implement `Zeroize` for `Signature` ([#952], [#1326])
- Implement `MultipartSigner`/`MultipartVerifier` ([#982])
- Optional `zerocopy` support ([#1134])
- Implement `Hash` for `Signature` ([#1309])

## Changed
- Upgrade to the 2024 edition and bump MSRV to 1.85 ([#913])
- Bump `pkcs8` dependency to v0.11 ([#1316])
- Bump `signature` dependency to v3 ([#1321])
- Use `serdect` for `serde` support ([#1324])

## Removed
- `std` feature ([#985])
- `serde_bytes` feature ([#1324])

[#889]: https://github.com/RustCrypto/signatures/pull/889
[#913]: https://github.com/RustCrypto/signatures/pull/913
[#952]: https://github.com/RustCrypto/signatures/pull/952
[#982]: https://github.com/RustCrypto/signatures/pull/982
[#985]: https://github.com/RustCrypto/signatures/pull/985
[#1134]: https://github.com/RustCrypto/signatures/pull/1134
[#1309]: https://github.com/RustCrypto/signatures/pull/1309
[#1316]: https://github.com/RustCrypto/signatures/pull/1316
[#1321]: https://github.com/RustCrypto/signatures/pull/1321
[#1324]: https://github.com/RustCrypto/signatures/pull/1324
[#1326]: https://github.com/RustCrypto/signatures/pull/1326