### PR TITLE
ed448: use `serdect` for `serde` support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,8 +490,8 @@ version = "0.5.0-rc.6"
 dependencies = [
  "hex-literal",
  "pkcs8",
- "serde",
  "serde_bytes",
+ "serdect",
  "signature",
  "zeroize",
 ]

--- a/ed448/Cargo.toml
+++ b/ed448/Cargo.toml
@@ -22,7 +22,7 @@ signature = { version = "3", default-features = false }
 
 # optional dependencies
 pkcs8 = { version = "0.11", optional = true }
-serde = { version = "1", optional = true, default-features = false }
+serdect = { version = "0.4", optional = true, default-features = false }
 serde_bytes = { version = "0.11", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
@@ -33,6 +33,7 @@ hex-literal = "1"
 default = ["alloc"]
 alloc = ["pkcs8?/alloc"]
 pem = ["alloc", "pkcs8/pem"]
+serde = ["dep:serdect"]
 serde_bytes = ["serde", "dep:serde_bytes"]
 
 [package.metadata.docs.rs]

--- a/ed448/src/serde.rs
+++ b/ed448/src/serde.rs
@@ -1,54 +1,28 @@
-//! `serde` support.
+//! `serde` support including optional `serde_bytes` support.
 
 use crate::{Signature, SignatureBytes};
-use ::serde::{Deserialize, Serialize, de, ser};
 use core::fmt;
+use serdect::serde::{Deserialize, Serialize, de, ser};
 
+#[cfg(feature = "serde")]
 impl Serialize for Signature {
-    fn serialize<S: ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        use ser::SerializeTuple;
-
-        let mut seq = serializer.serialize_tuple(Signature::BYTE_SIZE)?;
-
-        for byte in self.to_bytes() {
-            seq.serialize_element(&byte)?;
-        }
-
-        seq.end()
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        serdect::array::serialize_hex_upper_or_bin(&self.to_bytes(), serializer)
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for Signature {
-    fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        struct ByteArrayVisitor;
-
-        impl<'de> de::Visitor<'de> for ByteArrayVisitor {
-            type Value = [u8; Signature::BYTE_SIZE];
-
-            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-                formatter.write_str("bytestring of length 64")
-            }
-
-            fn visit_seq<A>(self, mut seq: A) -> Result<[u8; Signature::BYTE_SIZE], A::Error>
-            where
-                A: de::SeqAccess<'de>,
-            {
-                use de::Error;
-                let mut arr = [0u8; Signature::BYTE_SIZE];
-
-                for (i, byte) in arr.iter_mut().enumerate() {
-                    *byte = seq
-                        .next_element()?
-                        .ok_or_else(|| Error::invalid_length(i, &self))?;
-                }
-
-                Ok(arr)
-            }
-        }
-
-        deserializer
-            .deserialize_tuple(Signature::BYTE_SIZE, ByteArrayVisitor)
-            .map(Into::into)
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let mut bytes = [0u8; Signature::BYTE_SIZE];
+        serdect::array::deserialize_hex_or_bin(&mut bytes, deserializer)?;
+        Ok(bytes.into())
     }
 }
 
@@ -56,7 +30,7 @@ impl<'de> Deserialize<'de> for Signature {
 impl serde_bytes::Serialize for Signature {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: ser::Serializer,
     {
         serializer.serialize_bytes(&self.to_bytes())
     }


### PR DESCRIPTION
Like #1324 did for `ed25519`, this uses the `serdect` crate for the `serde` implementation, which is a breaking change.

See comments in #1324 for more information.