### PR TITLE
ed448 v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "ed448"
-version = "0.5.0-rc.6"
+version = "0.5.0"
 dependencies = [
  "hex-literal",
  "pkcs8",
@@ -1428,7 +1428,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys",

--- a/ed448/CHANGELOG.md
+++ b/ed448/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2026-04-06)
+Initial RustCrypto release.
+
 ## 0.4.0 and earlier
-The crate name was previously used for an implementation of the Ed448-Goldilocks
-elliptic curve, which has since been renamed to `ed448-goldilocks`
+The crate name was previously used for an implementation of the Ed448-Goldilocks elliptic curve,
+which has since been renamed to `ed448-goldilocks`.

--- a/ed448/Cargo.toml
+++ b/ed448/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed448"
-version = "0.5.0-rc.6"
+version = "0.5.0"
 edition = "2024"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
Initial RustCrypto release.

NOTE: the `ed448` crate name was previously used for an implementation of the Ed448-Goldilocks elliptic curve, which has since been renamed to [`ed448-goldilocks`](https://github.com/RustCrypto/elliptic-curves/tree/master/ed448-goldilocks).