### PR TITLE
rfc6979 v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,7 +1133,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rfc6979"
-version = "0.5.0-rc.5"
+version = "0.5.0"
 dependencies = [
  "hex-literal",
  "hmac",
@@ -1428,7 +1428,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -20,7 +20,7 @@ der = { version = "0.8", features = ["alloc"] }
 digest = "0.11"
 crypto-bigint = { version = "0.7", default-features = false, features = ["alloc", "zeroize"] }
 crypto-primes = { version = "0.7", default-features = false }
-rfc6979 = { version = "0.5.0-rc.5" }
+rfc6979 = { version = "0.5" }
 sha2 = { version = "0.11", default-features = false }
 signature = { version = "3", default-features = false, features = ["alloc", "digest", "rand_core"] }
 zeroize = { version = "1", default-features = false, features = ["alloc"] }

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -24,7 +24,7 @@ zeroize = { version = "1.5", default-features = false }
 # optional dependencies
 der = { version = "0.8", optional = true }
 digest = { version = "0.11", optional = true, default-features = false, features = ["oid"] }
-rfc6979 = { version = "0.5.0-rc.5", optional = true }
+rfc6979 = { version = "0.5", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false, features = ["alloc"] }
 sha2 = { version = "0.11", optional = true, default-features = false, features = ["oid"] }
 spki = { version = "0.8", optional = true, default-features = false }

--- a/rfc6979/CHANGELOG.md
+++ b/rfc6979/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2026-05-06)
+### Added
+- `generate_k_mut` function ([#773])
+- P-521 + SHA-512 test vectors ([#775])
+- Upgrade to 2024 edition and bump MSRV to 1.85 ([#913])
+
+### Changed
+- Replace `Digest` bounds with `EagerHash` ([#1076])
+- Bump `sha2` dependency to v0.11 ([#1267])
+- Bump `hmac` to v0.13 ([#1274])
+
+### Removed
+- Output size bounds on digest functions ([#773])
+
+### Fixed
+- Handling of inputs which are not the same size as the digest output ([#781])
+
+[#773]: https://github.com/RustCrypto/signatures/pull/773
+[#775]: https://github.com/RustCrypto/signatures/pull/775
+[#781]: https://github.com/RustCrypto/signatures/pull/781
+[#913]: https://github.com/RustCrypto/signatures/pull/913
+[#1076]: https://github.com/RustCrypto/signatures/pull/1076
+[#1267]: https://github.com/RustCrypto/signatures/pull/1267
+[#1274]: https://github.com/RustCrypto/signatures/pull/1274
+
 ## 0.4.0 (2023-02-28)
 ### Changed
 - MSRV 1.60 ([#628])

--- a/rfc6979/Cargo.toml
+++ b/rfc6979/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rfc6979"
-version = "0.5.0-rc.5"
+version = "0.5.0"
 description = """
 Pure Rust implementation of RFC6979: Deterministic Usage of the
 Digital Signature Algorithm (DSA) and Elliptic Curve Digital Signature Algorithm (ECDSA)


### PR DESCRIPTION
## Added
- `generate_k_mut` function ([#773])
- P-521 + SHA-512 test vectors ([#775])
- Upgrade to 2024 edition and bump MSRV to 1.85 ([#913])

## Changed
- Replace `Digest` bounds with `EagerHash` ([#1076])
- Bump `sha2` dependency to v0.11 ([#1267])
- Bump `hmac` to v0.13 ([#1274])

## Removed
- Output size bounds on digest functions ([#773])

## Fixed
- Handling of inputs which are not the same size as the digest output ([#781])

[#773]: https://github.com/RustCrypto/signatures/pull/773
[#775]: https://github.com/RustCrypto/signatures/pull/775
[#781]: https://github.com/RustCrypto/signatures/pull/781
[#913]: https://github.com/RustCrypto/signatures/pull/913
[#1076]: https://github.com/RustCrypto/signatures/pull/1076
[#1267]: https://github.com/RustCrypto/signatures/pull/1267
[#1274]: https://github.com/RustCrypto/signatures/pull/1274