### PR TITLE
ml-dsa: implement `KeyInit`, `KeyExport`, `KeySizeUser`

### DIFF
--- a/.github/workflows/ml-dsa.yml
+++ b/.github/workflows/ml-dsa.yml
@@ -62,4 +62,4 @@ jobs:
           targets: ${{ matrix.target }}
 
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset
+      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features default,getrandom

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,6 +819,7 @@ version = "0.1.0-rc.9"
 dependencies = [
  "const-oid",
  "criterion",
+ "crypto-common",
  "ctutils",
  "getrandom 0.4.2",
  "hex",
@@ -827,7 +828,6 @@ dependencies = [
  "module-lattice",
  "pkcs8",
  "proptest",
- "rand_core 0.10.1",
  "serde",
  "serde_json",
  "sha3",

--- a/ml-dsa/Cargo.toml
+++ b/ml-dsa/Cargo.toml
@@ -25,13 +25,16 @@ exclude = [
 ]
 
 [features]
-default = ["rand_core", "alloc", "pkcs8"]
-zeroize = ["dep:zeroize", "hybrid-array/zeroize", "module-lattice/zeroize"]
-rand_core = ["dep:rand_core", "signature/rand_core"]
-alloc = ["pkcs8?/alloc"]
+default = ["alloc", "getrandom", "pkcs8"]
+alloc = ["hybrid-array/alloc", "pkcs8?/alloc", "signature/alloc"]
+
+getrandom = ["common/getrandom", "rand_core"]
 pkcs8 = ["dep:const-oid", "dep:pkcs8"]
+rand_core = ["common/rand_core", "signature/rand_core"]
+zeroize = ["dep:zeroize", "hybrid-array/zeroize", "module-lattice/zeroize"]
 
 [dependencies]
+common = { package = "crypto-common", version = "0.2", default-features = false }
 ctutils = { version = "0.4", default-features = false }
 hybrid-array = { version = "0.4", features = ["extra-sizes"] }
 module-lattice = { version = "0.2.2", features = ["ctutils"] }
@@ -41,7 +44,6 @@ signature = { version = "3", default-features = false, features = ["digest"] }
 # optional dependencies
 const-oid = { version = "0.10", features = ["db"], optional = true }
 pkcs8 = { version = "0.11", default-features = false, optional = true }
-rand_core = { version = "0.10", optional = true }
 zeroize = { version = "1.8.1", optional = true, default-features = false }
 
 [dev-dependencies]
@@ -57,6 +59,7 @@ serde_json = "1.0.132"
 [[bench]]
 name = "ml_dsa"
 harness = false
+required-features = ["getrandom"]
 
 [lints]
 workspace = true

--- a/ml-dsa/benches/ml_dsa.rs
+++ b/ml-dsa/benches/ml_dsa.rs
@@ -4,29 +4,18 @@
 #![allow(missing_docs, reason = "benchmarks")]
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use getrandom::SysRng;
-use hybrid_array::{Array, ArraySize};
 use ml_dsa::{
-    B32, ExpandedSigningKey, KeyGen, MlDsa65, Signature, VerifyingKey, signature::Keypair,
+    B32, ExpandedSigningKey, Generate, Keypair, MlDsa65, Signature, SigningKey, VerifyingKey,
 };
-use rand_core::{CryptoRng, UnwrapErr};
-
-/// Create a random array of the given length.
-pub fn rand<L: ArraySize, R: CryptoRng + ?Sized>(rng: &mut R) -> Array<u8, L> {
-    let mut val = Array::<u8, L>::default();
-    rng.fill_bytes(&mut val);
-    val
-}
 
 /// ML-DSA benchmarks.
 #[allow(deprecated)] // TODO(tarcieri): stop using expanded signing keys
 fn criterion_benchmark(c: &mut Criterion) {
-    let mut rng = UnwrapErr(SysRng);
-    let xi: B32 = rand(&mut rng);
-    let m: B32 = rand(&mut rng);
-    let ctx: B32 = rand(&mut rng);
+    let xi = B32::generate();
+    let m = B32::generate();
+    let ctx = B32::generate();
 
-    let kp = MlDsa65::from_seed(&xi);
+    let kp = SigningKey::<MlDsa65>::from_seed(&xi);
     let sk = kp.expanded_key();
     let vk = kp.verifying_key();
     let sig = sk.sign_deterministic(&m, &ctx).unwrap();
@@ -38,7 +27,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     // Key generation
     c.bench_function("keygen", |b| {
         b.iter(|| {
-            let kp = MlDsa65::from_seed(&xi);
+            let kp = SigningKey::<MlDsa65>::generate();
             let _sk_bytes = kp.expanded_key().to_expanded();
             let _vk_bytes = kp.verifying_key().encode();
         });
@@ -64,7 +53,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     // Round trip
     c.bench_function("round_trip", |b| {
         b.iter(|| {
-            let kp = MlDsa65::from_seed(&xi);
+            let kp = SigningKey::<MlDsa65>::from_seed(&xi);
             let sig = kp.expanded_key().sign_deterministic(&m, &ctx).unwrap();
             let _ver = kp.verifying_key().verify_with_context(&m, &ctx, &sig);
         });

--- a/ml-dsa/src/lib.rs
+++ b/ml-dsa/src/lib.rs
@@ -12,17 +12,13 @@
 
 //! # Usage
 //!
-#![cfg_attr(feature = "rand_core", doc = "```")]
-#![cfg_attr(not(feature = "rand_core"), doc = "```ignore")]
+#![cfg_attr(feature = "getrandom", doc = "```")]
+#![cfg_attr(not(feature = "getrandom"), doc = "```ignore")]
 //! # fn main() -> Result<(), signature::Error> {
-//! use ml_dsa::{
-//!     signature::{Keypair, Signer, Verifier},
-//!     MlDsa65, KeyGen,
-//! };
-//! use getrandom::{SysRng, rand_core::UnwrapErr};
+//! // NOTE: requires the `getrandom` feature is enabled
+//! use ml_dsa::{MlDsa65, Generate, Keypair, SigningKey, Signer, Verifier};
 //!
-//! let mut rng = UnwrapErr(SysRng);
-//! let sk = MlDsa65::key_gen(&mut rng);
+//! let sk = SigningKey::<MlDsa65>::generate();
 //!
 //! let msg = b"Hello world";
 //! let sig = sk.sign(msg);
@@ -52,7 +48,11 @@ pub use crate::{
     signing::{ExpandedSigningKey, SigningKey},
     verifying::VerifyingKey,
 };
-pub use signature::{self, Error};
+pub use common::{self, KeyExport, KeyInit, KeySizeUser};
+pub use signature::{self, Error, Keypair, Signer, Verifier};
+
+#[cfg(feature = "rand_core")]
+pub use common::Generate;
 
 use crate::algebra::{AlgebraExt, Vector};
 use crate::crypto::H;
@@ -73,7 +73,7 @@ use module_lattice::Truncate;
 use sha3::Shake256;
 
 #[cfg(feature = "rand_core")]
-use rand_core::CryptoRng;
+use signature::rand_core::CryptoRng;
 
 /// A 32-byte array, defined here for brevity because it is used several times
 pub type B32 = Array<u8, U32>;
@@ -240,10 +240,14 @@ impl ParameterSet for MlDsa87 {
     const TAU: usize = 60;
 }
 
-/// A parameter set that knows how to generate key pairs
+/// A parameter set that knows how to generate key pairs.
+#[deprecated(
+    since = "0.1.0",
+    note = "use the `KeyInit` or `Generate` traits instead"
+)]
 pub trait KeyGen: MlDsaParams {
     /// The type that is returned by key generation
-    type KeyPair: signature::Keypair;
+    type KeyPair: Keypair;
 
     /// Generate a signing key pair from the specified RNG
     #[cfg(feature = "rand_core")]
@@ -255,6 +259,7 @@ pub trait KeyGen: MlDsaParams {
     fn from_seed(xi: &B32) -> Self::KeyPair;
 }
 
+#[allow(deprecated, reason = "deprecated impl block")]
 impl<P> KeyGen for P
 where
     P: MlDsaParams,
@@ -262,7 +267,6 @@ where
     type KeyPair = SigningKey<P>;
 
     /// Generate a signing key pair from the specified RNG
-    // Algorithm 1 ML-DSA.KeyGen()
     #[cfg(feature = "rand_core")]
     fn key_gen<R: CryptoRng + ?Sized>(rng: &mut R) -> SigningKey<P> {
         let mut xi = B32::default();
@@ -347,7 +351,7 @@ mod test {
         P: MlDsaParams + PartialEq,
     {
         let seed = Array::default();
-        let ssk = P::from_seed(&seed);
+        let ssk = SigningKey::from_seed(&seed);
         assert_eq!(ssk.to_seed(), seed);
 
         let esk = ssk.expanded_key();
@@ -383,7 +387,7 @@ mod test {
     where
         P: MlDsaParams + PartialEq,
     {
-        let ssk = P::from_seed(&Array::default());
+        let ssk = SigningKey::<P>::from_seed(&Array::default());
         let esk = ssk.expanded_key();
         let vk = ssk.verifying_key();
         let vk_derived = esk.verifying_key();
@@ -402,7 +406,7 @@ mod test {
     where
         P: MlDsaParams,
     {
-        let ssk = P::from_seed(&Array::default());
+        let ssk = SigningKey::<P>::from_seed(&Array::default());
         let esk = ssk.expanded_key();
         let vk = ssk.verifying_key();
 
@@ -426,7 +430,7 @@ mod test {
         where
             P: MlDsaParams,
         {
-            let ssk = P::from_seed(&Array::default());
+            let ssk = SigningKey::<P>::from_seed(&Array::default());
             let esk = ssk.expanded_key();
             let vk = ssk.verifying_key();
 
@@ -448,7 +452,7 @@ mod test {
         where
             P: MlDsaParams,
         {
-            let ssk = P::from_seed(&Array::default());
+            let ssk = SigningKey::<P>::from_seed(&Array::default());
             let esk = ssk.expanded_key();
             let vk = ssk.verifying_key();
 
@@ -470,7 +474,7 @@ mod test {
         where
             P: MlDsaParams,
         {
-            let ssk = P::from_seed(&Array::default());
+            let ssk = SigningKey::<P>::from_seed(&Array::default());
             let esk = ssk.expanded_key();
             let vk = ssk.verifying_key();
 
@@ -493,7 +497,7 @@ mod test {
             P: MlDsaParams,
         {
             let seed = Seed::default();
-            let ssk = P::from_seed(&seed);
+            let ssk = SigningKey::<P>::from_seed(&seed);
             let sk1 = ExpandedSigningKey::<P>::from_seed(&seed);
             assert_eq!(ssk.expanded_key(), &sk1);
         }
@@ -509,7 +513,7 @@ mod test {
                 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
                 24, 25, 26, 27, 28, 29, 30, 31, 32,
             ]);
-            let kp = P::from_seed(&seed);
+            let kp = SigningKey::<P>::from_seed(&seed);
             assert_eq!(kp.to_seed(), seed);
         }
         test_to_seed::<MlDsa44>();
@@ -520,7 +524,7 @@ mod test {
     #[test]
     fn verification_rejects_invalid_signature() {
         fn test_invalid_sig<P: MlDsaParams>() {
-            let kp = P::from_seed(&Array::default());
+            let kp = SigningKey::<P>::from_seed(&Array::default());
             let vk = kp.verifying_key();
 
             let msg = b"Hello world";
@@ -538,7 +542,7 @@ mod test {
     #[test]
     fn verification_rejects_wrong_message() {
         fn test_wrong_msg<P: MlDsaParams>() {
-            let kp = P::from_seed(&Array::default());
+            let kp = SigningKey::<P>::from_seed(&Array::default());
             let vk = kp.verifying_key();
 
             let msg1 = b"Hello world";
@@ -556,7 +560,7 @@ mod test {
     #[test]
     fn context_length_validation() {
         fn test_ctx_length<P: MlDsaParams>() {
-            let ssk = P::from_seed(&Array::default());
+            let ssk = SigningKey::<P>::from_seed(&Array::default());
             let sk = ssk.expanded_key();
             let vk = ssk.verifying_key();
 
@@ -579,7 +583,7 @@ mod test {
     fn derived_verifying_key_validates_signatures() {
         fn test_derived_vk<P: MlDsaParams>() {
             let seed = Array([42u8; 32]);
-            let ssk = P::from_seed(&seed);
+            let ssk = SigningKey::<P>::from_seed(&seed);
             let sk = ssk.expanded_key();
             let derived_vk = sk.verifying_key();
 
@@ -602,7 +606,7 @@ mod test {
         use core::fmt::Write;
 
         fn test_debug<P: MlDsaParams>() {
-            let kp = P::from_seed(&Array::default());
+            let kp = SigningKey::<P>::from_seed(&Array::default());
 
             let mut kp_debug = alloc::string::String::new();
             write!(&mut kp_debug, "{:?}", kp).unwrap();

--- a/ml-dsa/src/pkcs8.rs
+++ b/ml-dsa/src/pkcs8.rs
@@ -1,8 +1,8 @@
 //! PKCS#8 private key encoding support.
 
 use crate::{
-    EncodedVerifyingKey, ExpandedSigningKey, KeyGen, MlDsa44, MlDsa65, MlDsa87, MlDsaParams,
-    Signature, SigningKey, VerifyingKey,
+    EncodedVerifyingKey, ExpandedSigningKey, MlDsa44, MlDsa65, MlDsa87, MlDsaParams, Signature,
+    SigningKey, VerifyingKey,
 };
 pub use ::pkcs8::*;
 use ::pkcs8::{
@@ -89,9 +89,9 @@ where
     P: MlDsaParams,
     P: AssociatedAlgorithmIdentifier<Params = AnyRef<'static>>,
 {
-    type Error = ::pkcs8::Error;
+    type Error = Error;
 
-    fn try_from(private_key_info: PrivateKeyInfoRef<'_>) -> ::pkcs8::Result<Self> {
+    fn try_from(private_key_info: PrivateKeyInfoRef<'_>) -> Result<Self> {
         private_key_info
             .algorithm
             .assert_algorithm_oid(P::ALGORITHM_IDENTIFIER.oid)?;
@@ -106,7 +106,7 @@ where
             .map_err(|_| KeyError::Invalid)?;
         reader.finish()?;
 
-        Ok(P::from_seed(&seed))
+        Ok(SigningKey::from_seed(&seed))
     }
 }
 
@@ -193,13 +193,13 @@ where
         spki.algorithm
             .assert_algorithm_oid(P::ALGORITHM_IDENTIFIER.oid)?;
 
-        Ok(Self::decode(
-            &EncodedVerifyingKey::<P>::try_from(
-                spki.subject_public_key
-                    .as_bytes()
-                    .ok_or_else(|| der::Tag::BitString.value_error().to_error())?,
-            )
-            .map_err(|_| spki::Error::KeyMalformed)?,
-        ))
+        let evk = EncodedVerifyingKey::<P>::try_from(
+            spki.subject_public_key
+                .as_bytes()
+                .ok_or_else(|| der::Tag::BitString.value_error().to_error())?,
+        )
+        .map_err(|_| spki::Error::KeyMalformed)?;
+
+        Ok(Self::decode(&evk))
     }
 }

--- a/ml-dsa/src/signing.rs
+++ b/ml-dsa/src/signing.rs
@@ -3,15 +3,16 @@
 //! These types implement signature generation.
 
 use crate::{
-    B32, B64, ExpandedSigningKeyBytes, KeyGen, MaybeBox, MlDsaParams, MuBuilder, Seed, Signature,
+    B32, B64, ExpandedSigningKeyBytes, MaybeBox, MlDsaParams, MuBuilder, Seed, Signature,
     VerifyingKey,
     algebra::{AlgebraExt, NttMatrix, NttVector, Vector},
     crypto::H,
     hint::Hint,
     ntt::{Ntt, NttInverse},
     param::{SamplingSize, SpecQ},
-    sampling::{expand_a, expand_mask, sample_in_ball},
+    sampling::{expand_a, expand_mask, expand_s, sample_in_ball},
 };
+use common::{KeyExport, KeyInit, KeySizeUser, typenum::U32};
 use core::fmt;
 use ctutils::{Choice, CtEq};
 use hybrid_array::typenum::Unsigned;
@@ -20,11 +21,13 @@ use signature::{DigestSigner, Error, MultipartSigner, Signer};
 
 #[cfg(feature = "rand_core")]
 use {
-    rand_core::TryCryptoRng,
-    signature::{RandomizedDigestSigner, RandomizedMultipartSigner, RandomizedSigner},
+    common::Generate,
+    signature::{
+        RandomizedDigestSigner, RandomizedMultipartSigner, RandomizedSigner,
+        rand_core::TryCryptoRng,
+    },
 };
 
-use crate::sampling::expand_s;
 #[cfg(feature = "zeroize")]
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
@@ -95,6 +98,31 @@ impl<P: MlDsaParams> SigningKey<P> {
     #[doc(hidden)]
     pub fn expanded_key(&self) -> &ExpandedSigningKey<P> {
         &self.expanded_key
+    }
+}
+
+impl<P: MlDsaParams> KeySizeUser for SigningKey<P> {
+    type KeySize = U32;
+}
+
+impl<P: MlDsaParams> KeyInit for SigningKey<P> {
+    fn new(seed: &Seed) -> Self {
+        Self::from_seed(seed)
+    }
+}
+
+impl<P: MlDsaParams> KeyExport for SigningKey<P> {
+    fn to_bytes(&self) -> Seed {
+        self.to_seed()
+    }
+}
+
+/// Algorithm 1: `ML-DSA.KeyGen()`.
+#[cfg(feature = "rand_core")]
+impl<P: MlDsaParams> Generate for SigningKey<P> {
+    fn try_generate_from_rng<R: TryCryptoRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+        let seed = Seed::try_generate_from_rng(rng)?;
+        Ok(Self::from_seed(&seed))
     }
 }
 
@@ -217,7 +245,7 @@ impl<P: MlDsaParams> ExpandedSigningKey<P> {
     /// signing key.
     #[must_use]
     pub fn from_seed(seed: &Seed) -> Self {
-        let kp = P::from_seed(seed);
+        let kp = SigningKey::from_seed(seed);
         kp.expanded_key
     }
 

--- a/ml-dsa/src/verifying.rs
+++ b/ml-dsa/src/verifying.rs
@@ -1,5 +1,6 @@
 //! ML-DSA signature verification.
 
+use crate::param::VerifyingKeySize;
 use crate::{
     B32, B64, EncodedVerifyingKey, MlDsaParams, MuBuilder, Signature,
     algebra::{Elem, NttMatrix, NttVector, Vector},
@@ -8,6 +9,7 @@ use crate::{
     param::ParameterSet,
     sampling::{expand_a, sample_in_ball},
 };
+use common::{Key, KeyExport, KeyInit, KeySizeUser};
 use sha3::Shake256;
 use signature::{DigestVerifier, Error, MultipartVerifier};
 
@@ -53,7 +55,6 @@ impl<P: MlDsaParams> VerifyingKey<P> {
     /// Computes µ according to FIPS 204 for use in ML-DSA.Sign and ML-DSA.Verify.
     ///
     /// # Errors
-    ///
     /// Returns [`Error`] if the given `Mp` returns one.
     pub fn compute_mu<F: FnOnce(&mut Shake256) -> Result<(), Error>>(
         &self,
@@ -65,10 +66,10 @@ impl<P: MlDsaParams> VerifyingKey<P> {
         Ok(mu.finish())
     }
 
-    /// This algorithm reflects the ML-DSA.Verify_internal algorithm from FIPS 204.  It does not
-    /// include the domain separator that distinguishes between the normal and pre-hashed cases,
-    /// and it does not separate the context string from the rest of the message.
-    // Algorithm 8 ML-DSA.Verify_internal
+    /// Implementation of Algorithm 8: `ML-DSA.Verify_internal` algorithm from FIPS 204.
+    ///
+    /// It does not include the domain separator that distinguishes between the normal and
+    /// pre-hashed cases, and it does not separate the context string from the rest of the message.
     pub fn verify_internal(&self, M: &[u8], sigma: &Signature<P>) -> bool
     where
         P: MlDsaParams,
@@ -101,14 +102,12 @@ impl<P: MlDsaParams> VerifyingKey<P> {
         sigma.c_tilde == cp_tilde
     }
 
-    /// This algorithm reflects the ML-DSA.Verify algorithm from FIPS 204.
-    // Algorithm 3 ML-DSA.Verify
+    /// Implementation of Algorithm 3: `ML-DSA.Verify` from FIPS 204.
     pub fn verify_with_context(&self, M: &[u8], ctx: &[u8], sigma: &Signature<P>) -> bool {
         self.raw_verify_with_context(&[M], ctx, sigma)
     }
 
-    /// This algorithm reflects the ML-DSA.Verify algorithm with a pre-computed μ from FIPS 204.
-    // Algorithm 3 ML-DSA.Verify (optional pre-computed μ variant)
+    /// Implementation of Algorithm 3: `ML-DSA.Verify` from FIPS 204 with a pre-computed μ.
     pub fn verify_mu(&self, mu: &B64, sigma: &Signature<P>) -> bool {
         self.raw_verify_mu(mu, sigma)
     }
@@ -128,17 +127,35 @@ impl<P: MlDsaParams> VerifyingKey<P> {
     }
 
     /// Encode the key in a fixed-size byte array.
-    // Algorithm 22 pkEncode
+    ///
+    /// Implementation of Algorithm 22: `pkEncode` from FIPS 204.
     pub fn encode(&self) -> EncodedVerifyingKey<P> {
         Self::encode_internal(&self.rho, &self.t1)
     }
 
     /// Decode the key from an appropriately sized byte array.
-    // Algorithm 23 pkDecode
+    ///
+    /// Implementation of Algorithm 23: `pkDecode` from FIPS 204.
     pub fn decode(enc: &EncodedVerifyingKey<P>) -> Self {
         let (rho, t1_enc) = P::split_vk(enc);
         let t1 = P::decode_t1(t1_enc);
         Self::new_expand_a(rho.clone(), t1, Some(enc.clone()))
+    }
+}
+
+impl<P: MlDsaParams> KeySizeUser for VerifyingKey<P> {
+    type KeySize = VerifyingKeySize<P>;
+}
+
+impl<P: MlDsaParams> KeyInit for VerifyingKey<P> {
+    fn new(key: &Key<Self>) -> Self {
+        Self::decode(key)
+    }
+}
+
+impl<P: MlDsaParams> KeyExport for VerifyingKey<P> {
+    fn to_bytes(&self) -> Key<Self> {
+        self.encode()
     }
 }
 

--- a/ml-dsa/tests/key-gen.rs
+++ b/ml-dsa/tests/key-gen.rs
@@ -35,7 +35,7 @@ fn verify<P: MlDsaParams>(tc: &acvp::TestCase) {
     let vk_bytes = EncodedVerifyingKey::<P>::try_from(tc.pk.as_slice()).unwrap();
     let sk_bytes = ExpandedSigningKeyBytes::<P>::try_from(tc.sk.as_slice()).unwrap();
 
-    let ssk = P::from_seed(&seed);
+    let ssk = SigningKey::from_seed(&seed);
     let sk = ssk.expanded_key().clone();
     let vk = ssk.verifying_key().clone();
 

--- a/ml-dsa/tests/proptests.rs
+++ b/ml-dsa/tests/proptests.rs
@@ -13,7 +13,7 @@ macro_rules! mldsa_proptests {
     ($name:ident, $alg:ident) => {
         mod $name {
             use ml_dsa::{
-                KeyGen, Signature,
+                Signature, SigningKey,
                 signature::{DigestSigner, DigestVerifier, Keypair, digest::Update},
                 $alg,
             };
@@ -29,7 +29,7 @@ macro_rules! mldsa_proptests {
                     msg in collection::vec(0u8..u8::MAX, 0..65536),
                     rnd in any::<[u8; 32]>()
                 ) {
-                    let kp = $alg::from_seed(&seed.into());
+                    let kp = SigningKey::<$alg>::from_seed(&seed.into());
                     let sk = kp.expanded_key();
                     let vk = kp.verifying_key();
 
@@ -43,7 +43,7 @@ macro_rules! mldsa_proptests {
                     seed in any::<[u8; 32]>(),
                     msg in collection::vec(0u8..u8::MAX, 0..65536),
                 ) {
-                    let kp = $alg::from_seed(&seed.into());
+                    let kp = SigningKey::<$alg>::from_seed(&seed.into());
                     let sk = kp.expanded_key();
                     let vk = kp.verifying_key();
 
@@ -59,11 +59,11 @@ macro_rules! mldsa_proptests {
                     seed in any::<[u8; 32]>(),
                     msg in collection::vec(0u8..u8::MAX, 0..65536),
                 ) {
-                    let kp = $alg::from_seed(&seed.into());
+                    let kp = SigningKey::<$alg>::from_seed(&seed.into());
                     let sk = kp.expanded_key();
                     let vk = kp.verifying_key();
 
-                    let mut rng = rand_core::UnwrapErr(getrandom::SysRng);
+                    let mut rng = signature::rand_core::UnwrapErr(getrandom::SysRng);
                     let sig = sk.sign_digest_with_rng(&mut rng, |digest| digest.update(&msg));
                     let sig_dec = signature_round_trip_encode!($alg, sig);
                     let verify_result = vk.verify_digest(|digest| Ok(digest.update(&msg)), &sig_dec);

--- a/ml-dsa/tests/wycheproof.rs
+++ b/ml-dsa/tests/wycheproof.rs
@@ -2,7 +2,7 @@
 
 // Implementation is based in part on `rsa` which is in turn based on Graviola.
 
-use ml_dsa::{KeyGen, MlDsa44, MlDsa65, MlDsa87, Signature, VerifyingKey};
+use ml_dsa::{MlDsa44, MlDsa65, MlDsa87, Signature, SigningKey, VerifyingKey};
 use serde::Deserialize;
 use signature::{SignatureEncoding, Signer, Verifier};
 use std::fs::File;
@@ -68,13 +68,15 @@ macro_rules! load_json_file {
 }
 
 macro_rules! mldsa_sign_seed_test {
-    ($name:ident, $json_file:expr, $keypair:ident) => {
+    ($name:ident, $json_file:expr, $params:ident) => {
         #[test]
         fn $name() {
             let tests = load_json_file!($json_file);
 
             for group in tests.groups {
-                let sk = $keypair::from_seed(&group.private_seed.as_slice().try_into().unwrap());
+                let sk = SigningKey::<$params>::from_seed(
+                    &group.private_seed.as_slice().try_into().unwrap(),
+                );
 
                 for test in &group.tests {
                     println!("Test #{}: {} ({:?})", test.id, &test.comment, &test.result);
@@ -105,7 +107,7 @@ macro_rules! mldsa_sign_seed_test {
 }
 
 macro_rules! mldsa_verify_test {
-    ($name:ident, $json_file:expr, $keypair:ident) => {
+    ($name:ident, $json_file:expr, $params:ident) => {
         #[test]
         fn $name() {
             let tests = load_json_file!($json_file);


### PR DESCRIPTION
Implements these traits sourced from the `crypto-common` crate.

Also implements the `Generate` trait for key generation, replacing the previous `KeyGen` trait, which this commit deprecates in favor of using `KeyInit` and `Generate`.

This also adds a `getrandom` feature that forwards through to `crypto-common`, making methods available on the `Generate` trait when enabled.