### PR TITLE
ml-dsa: add `SigningKey::as_seed`

### DIFF
--- a/ml-dsa/src/pkcs8.rs
+++ b/ml-dsa/src/pkcs8.rs
@@ -120,7 +120,7 @@ where
         let seed_der = SeedString {
             tag_mode: TagMode::Implicit,
             tag_number: SEED_TAG_NUMBER,
-            value: OctetStringRef::new(&self.to_seed())?,
+            value: OctetStringRef::new(self.as_seed())?,
         }
         .to_der()?;
 

--- a/ml-dsa/src/signing.rs
+++ b/ml-dsa/src/signing.rs
@@ -90,10 +90,22 @@ impl<P: MlDsaParams> SigningKey<P> {
         }
     }
 
-    /// Serialize the [`Seed`] value: 32-bytes which can be used to reconstruct the
-    /// [`SigningKey`].
+    /// Borrow the [`Seed`] value: 32-bytes which can be used to reconstruct the [`SigningKey`].
     ///
-    /// <div class = "warning">
+    /// <div class="warning">
+    /// <b>Warning</b>
+    ///
+    /// This value is key material. Please treat it with care.
+    /// </div>
+    #[inline]
+    #[must_use]
+    pub fn as_seed(&self) -> &Seed {
+        &self.seed
+    }
+
+    /// Serialize the [`Seed`] value: 32-bytes which can be used to reconstruct the [`SigningKey`].
+    ///
+    /// <div class="warning">
     /// <b>Warning</b>
     ///
     /// This value is key material. Please treat it with care.


### PR DESCRIPTION
Provides a way of borrowing `&Seed` instead of making a copy as with `SigningKey::to_seed`.