### PR TITLE
CI: add workspace-level `doc` check

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -11,6 +11,7 @@ on:
 env:
   CARGO_INCREMENTAL: 0
   RUSTFLAGS: "-Dwarnings"
+  RUSTDOCFLAGS: "-Dwarnings"
 
 # Cancels CI jobs when new commits are pushed to a PR branch
 concurrency:
@@ -18,16 +19,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  rustfmt:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-          components: rustfmt
-      - run: cargo fmt --all -- --check
-
   clippy:
     runs-on: ubuntu-latest
     steps:
@@ -37,6 +28,25 @@ jobs:
           toolchain: 1.95.0
           components: clippy
       - run: cargo clippy --all-features -- -D warnings
+
+  doc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - run: cargo doc --workspace --all-features --no-deps
+
+  rustfmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          components: rustfmt
+      - run: cargo fmt --all -- --check
 
   typos:
     runs-on: ubuntu-latest

--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -33,7 +33,7 @@ use {
 #[cfg(feature = "digest")]
 use digest::block_api::EagerHash;
 
-/// Bind a preferred [`Digest`] algorithm to an elliptic curve type.
+/// Bind a preferred [`EagerHash`] algorithm to an elliptic curve type.
 ///
 /// Generally there is a preferred variety of the SHA-2 family used with ECDSA
 /// for a particular elliptic curve.

--- a/ecdsa/src/signing.rs
+++ b/ecdsa/src/signing.rs
@@ -59,7 +59,7 @@ use elliptic_curve::pkcs8::{EncodePrivateKey, SecretDocument};
 /// primary API for signing:
 ///
 /// - [`Signer`]: sign a message using this key
-/// - [`DigestSigner`]: sign the output of a [`Digest`] using this key
+/// - [`DigestSigner`]: sign the output of a digest using this key
 /// - [`PrehashSigner`]: sign the low-level raw output bytes of a message digest
 ///
 /// See the [`p256` crate](https://docs.rs/p256/latest/p256/ecdsa/index.html)

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -58,7 +58,7 @@ use elliptic_curve::pkcs8::EncodePublicKey;
 /// primary API for verifying:
 ///
 /// - [`Verifier`]: verify a message against a provided key and signature
-/// - [`DigestVerifier`]: verify a message [`Digest`] against a provided key and signature
+/// - [`DigestVerifier`]: verify a message digest against a provided key and signature
 /// - [`PrehashVerifier`]: verify the low-level raw output bytes of a message digest
 ///
 /// See the [`p256` crate](https://docs.rs/p256/latest/p256/ecdsa/index.html)

--- a/lms/src/lms/private.rs
+++ b/lms/src/lms/private.rs
@@ -144,7 +144,7 @@ impl<Mode: LmsMode> RandomizedMultipartSignerMut<Signature<Mode>> for SigningKey
     }
 }
 
-/// Converts a [PrivateKey] into its byte representation
+/// Converts a [`SigningKey`] into its byte representation.
 impl<Mode: LmsMode> From<SigningKey<Mode>>
     for Array<u8, Sum<<Mode::Hasher as OutputSizeUser>::OutputSize, U28>>
 where
@@ -165,7 +165,7 @@ where
     }
 }
 
-/// Tries to parse a [PrivateKey] from an exact slice
+/// Tries to parse a [`SigningKey`] from an exact slice.
 impl<'a, Mode: LmsMode> TryFrom<&'a [u8]> for SigningKey<Mode> {
     type Error = LmsDeserializeError;
 


### PR DESCRIPTION
Ensures the docs for all crates build without warnings