### PR TITLE
ml-dsa: use `MaybeBox` from `module-lattice` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,9 +837,9 @@ dependencies = [
 
 [[package]]
 name = "module-lattice"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc7c90d33a0dac244570c26461d761ffaeadb3bfc2b17cc625ae2185cafdffae"
+checksum = "0c61b87c9683ab7cb1c6871d261ad5479b6b10ceb52c4352aaca3b5d35a8febe"
 dependencies = [
  "ctutils",
  "hybrid-array",

--- a/ml-dsa/Cargo.toml
+++ b/ml-dsa/Cargo.toml
@@ -37,7 +37,7 @@ zeroize = ["dep:zeroize", "hybrid-array/zeroize", "module-lattice/zeroize"]
 common = { package = "crypto-common", version = "0.2", default-features = false }
 ctutils = { version = "0.4", default-features = false }
 hybrid-array = { version = "0.4", features = ["extra-sizes"] }
-module-lattice = { version = "0.2.2", features = ["ctutils"] }
+module-lattice = { version = "0.2.3", features = ["ctutils"] }
 sha3 = { version = "0.11", default-features = false }
 signature = { version = "3", default-features = false, features = ["digest"] }
 

--- a/ml-dsa/src/lib.rs
+++ b/ml-dsa/src/lib.rs
@@ -67,22 +67,19 @@ pub use signature::{self, Error, Keypair, SignatureEncoding, Signer, Verifier};
 #[cfg(feature = "rand_core")]
 pub use common::Generate;
 
-use crate::algebra::{AlgebraExt, Vector};
-use crate::crypto::H;
-use crate::hint::Hint;
-use crate::param::{ParameterSet, QMinus1};
-use core::{
-    convert::{TryFrom, TryInto},
-    ops::{Deref, DerefMut},
+use crate::{
+    algebra::{AlgebraExt, Vector},
+    crypto::H,
+    hint::Hint,
+    param::{ParameterSet, QMinus1},
 };
+use core::convert::{TryFrom, TryInto};
 use hybrid_array::{
     Array,
-    typenum::{
-        Diff, Length, Prod, Quot, Shleft, U1, U2, U4, U5, U6, U7, U8, U17, U19, U32, U48, U55, U64,
-        U75, U80, U88,
-    },
+    sizes::{U1, U2, U4, U5, U6, U7, U8, U17, U19, U32, U48, U55, U64, U75, U80, U88},
+    typenum::{Diff, Length, Prod, Quot, Shleft},
 };
-use module_lattice::Truncate;
+use module_lattice::{MaybeBox, Truncate};
 use sha3::Shake256;
 
 /// A 32-byte array, defined here for brevity because it is used several times
@@ -253,45 +250,6 @@ impl ParameterSet for MlDsa87 {
     type Lambda = U64;
     type Omega = U75;
     const TAU: usize = 60;
-}
-
-/// Type which opportunistically uses `Box` when the `alloc` feature is available but falls back to
-/// a stack-allocated type when it's unavailable.
-#[derive(Clone, Debug, PartialEq)]
-pub(crate) struct MaybeBox<T> {
-    #[cfg(not(feature = "alloc"))]
-    inner: T,
-    #[cfg(feature = "alloc")]
-    inner: alloc::boxed::Box<T>,
-}
-
-impl<T> MaybeBox<T> {
-    /// Create a new `MaybeBox`, using `Box` if `alloc` is available.
-    #[inline]
-    pub(crate) fn new(inner: T) -> Self {
-        #[cfg(not(feature = "alloc"))]
-        {
-            Self { inner }
-        }
-        #[cfg(feature = "alloc")]
-        Self {
-            inner: alloc::boxed::Box::new(inner),
-        }
-    }
-}
-
-impl<T> Deref for MaybeBox<T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        &self.inner
-    }
-}
-
-impl<T> DerefMut for MaybeBox<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.inner
-    }
 }
 
 #[cfg(test)]

--- a/ml-dsa/src/signing.rs
+++ b/ml-dsa/src/signing.rs
@@ -3,8 +3,7 @@
 //! These types implement signature generation.
 
 use crate::{
-    B32, B64, ExpandedSigningKeyBytes, MaybeBox, MlDsaParams, MuBuilder, Seed, Signature,
-    VerifyingKey,
+    B32, B64, ExpandedSigningKeyBytes, MlDsaParams, MuBuilder, Seed, Signature, VerifyingKey,
     algebra::{AlgebraExt, NttMatrix, NttVector, Vector},
     crypto::H,
     hint::Hint,
@@ -16,6 +15,7 @@ use common::{KeyExport, KeyInit, KeySizeUser, typenum::U32};
 use core::fmt;
 use ctutils::{Choice, CtEq};
 use hybrid_array::typenum::Unsigned;
+use module_lattice::MaybeBox;
 use sha3::Shake256;
 use signature::{DigestSigner, Error, MultipartSigner, Signer};
 

--- a/ml-dsa/src/verifying.rs
+++ b/ml-dsa/src/verifying.rs
@@ -1,7 +1,7 @@
 //! ML-DSA signature verification.
 
 use crate::{
-    B32, B64, EncodedVerifyingKey, MaybeBox, MlDsaParams, MuBuilder, Signature,
+    B32, B64, EncodedVerifyingKey, MlDsaParams, MuBuilder, Signature,
     algebra::{Elem, NttMatrix, NttVector, Vector},
     crypto::H,
     ntt::{Ntt, NttInverse},
@@ -10,6 +10,7 @@ use crate::{
     sampling::{expand_a, sample_in_ball},
 };
 use common::{Key, KeyExport, KeyInit, KeySizeUser};
+use module_lattice::MaybeBox;
 use sha3::Shake256;
 use signature::{DigestVerifier, Error, MultipartVerifier};
 


### PR DESCRIPTION
The `MaybeBox` type was moved to `module-lattice` so it could also be used with the `ml-kem` crate.

See RustCrypto/KEMs#309