### PR TITLE
ml-dsa: migrate from `sha3` to `shake`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,7 +830,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_json",
- "sha3",
+ "shake",
  "signature",
  "zeroize",
 ]
@@ -1334,6 +1334,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "shake"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09057cb2149ad4cbd2da1e26b351f9a4c354219421229c69c3063e6f61947c4a"
+dependencies = [
+ "digest",
+ "keccak",
+ "sponge-cursor",
+]
+
+[[package]]
 name = "signature"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1391,6 +1402,12 @@ dependencies = [
  "base64ct",
  "der",
 ]
+
+[[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
 
 [[package]]
 name = "stable_deref_trait"

--- a/ml-dsa/Cargo.toml
+++ b/ml-dsa/Cargo.toml
@@ -38,7 +38,7 @@ common = { package = "crypto-common", version = "0.2", default-features = false 
 ctutils = { version = "0.4", default-features = false }
 hybrid-array = { version = "0.4", features = ["extra-sizes"] }
 module-lattice = { version = "0.2.3", features = ["ctutils"] }
-sha3 = { version = "0.11", default-features = false }
+shake = { version = "0.1", default-features = false }
 signature = { version = "3", default-features = false, features = ["digest"] }
 
 # optional dependencies

--- a/ml-dsa/src/crypto.rs
+++ b/ml-dsa/src/crypto.rs
@@ -1,6 +1,6 @@
 use hybrid_array::Array;
 use module_lattice::ArraySize;
-use sha3::{
+use shake::{
     Shake128, Shake256,
     digest::{ExtendableOutput, XofReader},
 };

--- a/ml-dsa/src/lib.rs
+++ b/ml-dsa/src/lib.rs
@@ -80,7 +80,7 @@ use hybrid_array::{
     typenum::{Diff, Length, Prod, Quot, Shleft},
 };
 use module_lattice::{MaybeBox, Truncate};
-use sha3::Shake256;
+use shake::Shake256;
 
 /// A 32-byte array, defined here for brevity because it is used several times
 pub type B32 = Array<u8, U32>;

--- a/ml-dsa/src/signing.rs
+++ b/ml-dsa/src/signing.rs
@@ -16,7 +16,7 @@ use core::fmt;
 use ctutils::{Choice, CtEq};
 use hybrid_array::typenum::Unsigned;
 use module_lattice::MaybeBox;
-use sha3::Shake256;
+use shake::Shake256;
 use signature::{DigestSigner, Error, MultipartSigner, Signer};
 
 #[cfg(feature = "rand_core")]

--- a/ml-dsa/src/verifying.rs
+++ b/ml-dsa/src/verifying.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use common::{Key, KeyExport, KeyInit, KeySizeUser};
 use module_lattice::MaybeBox;
-use sha3::Shake256;
+use shake::Shake256;
 use signature::{DigestVerifier, Error, MultipartVerifier};
 
 /// An ML-DSA verification key.


### PR DESCRIPTION
See: RustCrypto/hashes#869