### PR TITLE
slh-dsa,xmss: replace sha3 with shake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1324,16 +1324,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha3"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
-dependencies = [
- "digest",
- "keccak",
-]
-
-[[package]]
 name = "shake"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1377,7 +1367,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "sha3",
+ "shake",
  "signature",
  "typenum",
  "zerocopy",
@@ -1757,7 +1747,7 @@ dependencies = [
  "serde_json",
  "serdect",
  "sha2",
- "sha3",
+ "shake",
  "signature",
  "spki",
  "subtle",

--- a/slh-dsa/Cargo.toml
+++ b/slh-dsa/Cargo.toml
@@ -23,7 +23,7 @@ hybrid-array = { version = "0.4", features = ["extra-sizes"] }
 pkcs8 = { version = "0.11", default-features = false }
 rand_core = "0.10"
 sha2 = { version = "0.11", default-features = false }
-sha3 = { version = "0.11", default-features = false }
+shake = { version = "0.1", default-features = false }
 signature = { version = "3", features = ["rand_core"] }
 typenum = { version = "1.20", features = ["const-generics"] }
 zerocopy = { version = "0.8", features = ["derive"] }

--- a/slh-dsa/src/hashes/shake.rs
+++ b/slh-dsa/src/hashes/shake.rs
@@ -7,12 +7,12 @@ use crate::hypertree::HypertreeParams;
 use crate::wots::WotsParams;
 use crate::xmss::XmssParams;
 use crate::{ParameterSet, PkSeed, SkPrf, SkSeed};
+use ::shake::Shake256;
 use const_oid::db::fips205;
 use digest::{ExtendableOutput, Update};
 use hybrid_array::typenum::consts::{U16, U30, U32};
 use hybrid_array::typenum::{U24, U34, U39, U42, U47, U49};
 use hybrid_array::{Array, ArraySize};
-use sha3::Shake256;
 use typenum::U;
 
 /// Implementation of the component hash functions using SHAKE256

--- a/slh-dsa/src/hypertree.rs
+++ b/slh-dsa/src/hypertree.rs
@@ -209,7 +209,7 @@ mod tests {
     #[cfg(feature = "alloc")]
     fn test_ht_sign_kat() {
         use hex_literal::hex;
-        use sha3::{Shake256, digest::ExtendableOutput};
+        use shake::{Shake256, digest::ExtendableOutput};
 
         let sk_seed = SkSeed(Array([1; 16]));
         let pk_seed = PkSeed(Array([2; 16]));

--- a/xmss/Cargo.toml
+++ b/xmss/Cargo.toml
@@ -28,7 +28,7 @@ hybrid-array = { version = "0.4", features = ["zeroize"] }
 pkcs8 = { version = "0.11", optional = true, default-features = false, features = ["alloc"] }
 rand = "0.10"
 sha2 = "0.11"
-sha3 = "0.11"
+shake = "0.1"
 serdect = { version = "0.4", features = ["alloc"], optional = true }
 signature = "3"
 spki = { version = "0.8", optional = true, default-features = false, features = ["alloc"] }

--- a/xmss/src/hash.rs
+++ b/xmss/src/hash.rs
@@ -1,5 +1,5 @@
 use sha2::{Digest, Sha256, Sha512};
-use sha3::{
+use shake::{
     Shake128, Shake256,
     digest::{ExtendableOutput, Update, XofReader},
 };


### PR DESCRIPTION
Shake has recently been split off from sha3 into a dedicated `shake` crate: https://github.com/RustCrypto/hashes/pull/869

This makes the adjustments in the downstream crates to reflect that change.