### PR TITLE
ml-dsa: expose `c_tilde` getter on Signature

### DIFF
--- a/ml-dsa/src/lib.rs
+++ b/ml-dsa/src/lib.rs
@@ -125,6 +125,11 @@ impl<P: MlDsaParams> Signature<P> {
 
         Some(Self { c_tilde, z, h })
     }
+
+    /// Access the challenge hash `c̃`.
+    pub fn c_tilde(&self) -> &Array<u8, P::Lambda> {
+        &self.c_tilde
+    }
 }
 
 impl<'a, P: MlDsaParams> TryFrom<&'a [u8]> for Signature<P> {


### PR DESCRIPTION
Hello!

Would be nice to have a public getter for c_tilde since it's a public component per FIPS 204.

Some implementations need direct access to it and encoding the whole signature just to grab it feels overkill.

Let me know what you think and have a nice day!