### PR TITLE
ml-dsa: `alloc` feature implies `module-lattice/alloc`

### DIFF
--- a/ml-dsa/Cargo.toml
+++ b/ml-dsa/Cargo.toml
@@ -26,7 +26,7 @@ exclude = [
 
 [features]
 default = ["alloc", "getrandom", "pkcs8"]
-alloc = ["hybrid-array/alloc", "pkcs8?/alloc", "signature/alloc"]
+alloc = ["hybrid-array/alloc", "module-lattice/alloc", "pkcs8?/alloc", "signature/alloc"]
 
 getrandom = ["common/getrandom", "rand_core"]
 pkcs8 = ["dep:const-oid", "dep:pkcs8"]


### PR DESCRIPTION
Enable `module-lattice/alloc` feature when the `alloc` feature is enabled. With this change, users don't need to add an explicit entry `module-lattice` at `Cargo.toml` to enable the `alloc` feature of the `module-lattice` crate.

This also aligns with the behavior of the `ml-kem` crate.