### PR TITLE
dsa: add Wycheproof verification test vectors

### DIFF
--- a/.github/workflows/dsa.yml
+++ b/.github/workflows/dsa.yml
@@ -58,6 +58,8 @@ jobs:
           git config --global core.eol lf
 
       - uses: actions/checkout@v6.0.2
+        with:
+          submodules: recursive
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,6 +449,8 @@ dependencies = [
  "proptest",
  "rand_core 0.10.1",
  "rfc6979",
+ "serde",
+ "serde_json",
  "sha1",
  "sha2",
  "signature",

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -31,12 +31,14 @@ pkcs8 = { version = "0.11", optional = true, default-features = false, features 
 [dev-dependencies]
 chacha20 = { version = "0.10", features = ["rng"] }
 der = { version = "0.8", features = ["derive"] }
-hex = "0.4"
+hex = { version = "0.4", features = ["serde"] }
 hex-literal = "1"
 getrandom = { version = "0.4", features = ["sys_rng"] }
 pkcs8 = { version = "0.11", default-features = false, features = ["pem"] }
 proptest = "1"
 rand_core = "0.10"
+serde = { version = "1.0.215", features = ["derive"] }
+serde_json = "1.0.132"
 sha1 = "0.11"
 
 [features]

--- a/dsa/tests/wycheproof.rs
+++ b/dsa/tests/wycheproof.rs
@@ -1,0 +1,196 @@
+//! Test the DSA verification against the Wycheproof test vectors.
+//!
+//! The vectors live in the `thirdparty/wycheproof` submodule (the C2SP project).
+//! Run `git submodule update --init` to fetch them before running this suite.
+//!
+//! Only the standard DER-encoded signature groups (`DsaVerify`) are exercised here.
+//! The `*_p1363_test.json` files use the raw (r || s) IEEE P1363 signature encoding,
+//! which the `dsa` crate does not parse, so they are intentionally not loaded.
+
+#![cfg(feature = "pkcs8")]
+
+use dsa::{Signature, VerifyingKey};
+use pkcs8::{DecodePublicKey, der::Decode};
+use serde::Deserialize;
+use sha2::{Sha224, Sha256};
+use signature::{DigestVerifier, hazmat::PrehashVerifier};
+use std::fs::File;
+
+#[derive(Deserialize, Debug)]
+struct TestFile {
+    algorithm: String,
+    #[serde(rename(deserialize = "testGroups"))]
+    groups: Vec<TestGroup>,
+}
+
+#[derive(Deserialize, Debug)]
+struct TestGroup {
+    /// DER-encoded `SubjectPublicKeyInfo` for the DSA public key.
+    #[serde(rename(deserialize = "publicKeyDer"), with = "hex::serde")]
+    public_key_der: Vec<u8>,
+    /// Hash function used by this group, e.g. `SHA-224` or `SHA-256`.
+    sha: String,
+    tests: Vec<Test>,
+}
+
+#[derive(Deserialize, Debug)]
+struct Test {
+    #[serde(rename(deserialize = "tcId"))]
+    id: usize,
+    comment: String,
+    #[serde(with = "hex::serde")]
+    msg: Vec<u8>,
+    #[serde(with = "hex::serde")]
+    sig: Vec<u8>,
+    result: ExpectedResult,
+}
+
+#[derive(Copy, Clone, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "lowercase")]
+enum ExpectedResult {
+    Valid,
+    Invalid,
+    /// Wycheproof "acceptable": legal but discouraged inputs (e.g. non-canonical
+    /// signature encodings). Implementations are free to accept or reject these,
+    /// so the test only requires the call not to panic.
+    Acceptable,
+}
+
+/// Run a single Wycheproof verification test against the `dsa` crate and assert
+/// the observed result matches the expected one. Returns whether the case passed.
+fn run_test(vk: &VerifyingKey, hash: &str, test: &Test) -> bool {
+    // The `dsa` crate parses signatures from the DER `SEQUENCE { r, s }` encoding.
+    // A signature that fails to parse is treated as a verification failure, which
+    // is the correct behaviour for the malformed-encoding test cases.
+    let signature = match Signature::try_from(test.sig.as_slice()) {
+        Ok(sig) => sig,
+        Err(_) => {
+            // The signature did not parse as canonical DER `SEQUENCE { r, s }`.
+            //
+            // The only "acceptable" vectors in these files carry the `MissingZero`
+            // flag (a legacy ASN.1 integer for r that drops its leading 0x00 padding
+            // byte). The `dsa` crate requires canonical DER integers, so it rejects
+            // these. Wycheproof permits either choice for "acceptable", so a parse
+            // failure here is conformant. For "invalid" vectors a parse failure is
+            // exactly what we want; for "valid" vectors it would be a real bug.
+            return test.result != ExpectedResult::Valid;
+        }
+    };
+
+    let verified = match hash {
+        "SHA-224" => vk
+            .verify_digest(
+                |d: &mut Sha224| {
+                    use digest::Update;
+                    d.update(&test.msg);
+                    Ok(())
+                },
+                &signature,
+            )
+            .is_ok(),
+        "SHA-256" => vk
+            .verify_digest(
+                |d: &mut Sha256| {
+                    use digest::Update;
+                    d.update(&test.msg);
+                    Ok(())
+                },
+                &signature,
+            )
+            .is_ok(),
+        other => panic!("test #{}: unsupported hash {other}", test.id),
+    };
+
+    match test.result {
+        ExpectedResult::Valid => verified,
+        ExpectedResult::Invalid => !verified,
+        // An "acceptable" vector that still parsed: Wycheproof allows the
+        // implementation to either accept or reject it, so either answer conforms.
+        ExpectedResult::Acceptable => true,
+    }
+}
+
+/// Sanity-check the prehash verification entrypoint against a known-good vector.
+fn run_prehash_smoke(vk: &VerifyingKey, hash: &str, test: &Test) {
+    if test.result != ExpectedResult::Valid {
+        return;
+    }
+
+    let Ok(signature) = Signature::try_from(test.sig.as_slice()) else {
+        return;
+    };
+
+    let prehash = match hash {
+        "SHA-224" => {
+            use digest::Digest;
+            Sha224::digest(&test.msg).to_vec()
+        }
+        "SHA-256" => {
+            use digest::Digest;
+            Sha256::digest(&test.msg).to_vec()
+        }
+        _ => return,
+    };
+
+    assert!(
+        vk.verify_prehash(&prehash, &signature).is_ok(),
+        "test #{}: prehash verification disagreed with digest verification",
+        test.id
+    );
+}
+
+fn run_file(json_file: &str) {
+    let path = format!("../thirdparty/wycheproof/testvectors_v1/{json_file}");
+    let data_file = File::open(&path)
+        .expect("failed to open test vector file (try running `git submodule update --init`)");
+    let tests: TestFile = serde_json::from_reader(data_file).expect("invalid test JSON");
+    assert_eq!(tests.algorithm, "DSA");
+
+    let mut passed = 0usize;
+    let mut total = 0usize;
+
+    for group in &tests.groups {
+        // Decode the DER `SubjectPublicKeyInfo`. A group whose key the crate cannot
+        // load means there is nothing to verify against, so flag it loudly rather
+        // than silently skipping coverage.
+        let spki = pkcs8::SubjectPublicKeyInfoRef::from_der(&group.public_key_der)
+            .expect("failed to parse SubjectPublicKeyInfo DER");
+        let vk = VerifyingKey::try_from(spki)
+            .or_else(|_| VerifyingKey::from_public_key_der(&group.public_key_der))
+            .expect("failed to load DSA verifying key from group");
+
+        for test in &group.tests {
+            total += 1;
+            let ok = run_test(&vk, &group.sha, test);
+            assert!(
+                ok,
+                "{json_file} test #{} ({}): expected {:?} but the crate disagreed",
+                test.id, test.comment, test.result
+            );
+            passed += 1;
+            run_prehash_smoke(&vk, &group.sha, test);
+        }
+    }
+
+    println!("{json_file}: {passed}/{total} vectors matched");
+}
+
+#[test]
+fn dsa_2048_224_sha224() {
+    run_file("dsa_2048_224_sha224_test.json");
+}
+
+#[test]
+fn dsa_2048_224_sha256() {
+    run_file("dsa_2048_224_sha256_test.json");
+}
+
+#[test]
+fn dsa_2048_256_sha256() {
+    run_file("dsa_2048_256_sha256_test.json");
+}
+
+#[test]
+fn dsa_3072_256_sha256() {
+    run_file("dsa_3072_256_sha256_test.json");
+}


### PR DESCRIPTION
Closes #816

The `dsa` test suite previously only covered a handful of RFC vectors. This adds a `dsa/tests/wycheproof.rs` suite that runs the C2SP Wycheproof DSA test vectors through the crate's verification path, which gives much broader coverage of the malformed-input and edge-case space.

## What it does

The vectors come from the `thirdparty/wycheproof` submodule that is already wired into this repo (the same source the `ml-dsa` Wycheproof tests use), so there is no new vendored data and no new runtime dependency. Run `git submodule update --init` before running the suite.

Four test groups are exercised, 1432 vectors in total:

- `dsa_2048_224_sha224_test.json` (336 vectors)
- `dsa_2048_224_sha256_test.json` (364 vectors)
- `dsa_2048_256_sha256_test.json` (366 vectors)
- `dsa_3072_256_sha256_test.json` (366 vectors)

For each group the test loads the DER `SubjectPublicKeyInfo` into a `VerifyingKey`, parses the DER-encoded signature into a `Signature`, and verifies it with the group's hash (SHA-224 or SHA-256) through `DigestVerifier`. The observed accept/reject result is asserted against the Wycheproof expected result. Valid vectors that parse are additionally cross-checked through the `PrehashVerifier` entrypoint so both verification APIs stay in agreement.

Breakdown across the four files: 296 `valid`, 1132 `invalid`, 4 `acceptable`.

## Edge cases handled explicitly

- **`acceptable` / `MissingZero`**: the only `acceptable`-class vectors in these files carry the `MissingZero` flag, a legacy ASN.1 integer for `r` that omits its leading `0x00` padding byte. The crate requires canonical DER integers (`UintRef`) and rejects these, which is conformant because Wycheproof allows an implementation to either accept or reject an `acceptable` vector. This is handled with a comment rather than skipped silently.
- **Malformed signature encodings**: a signature that fails to parse as canonical DER `SEQUENCE { r, s }` is treated as a verification failure. That is the desired behaviour for the `invalid` cases and would only be a regression for a `valid` case (which the assertion catches).
- **P1363 files not loaded**: the sibling `*_p1363_test.json` files use the raw `r || s` IEEE P1363 signature encoding. The `dsa` crate parses only DER signatures, so those files are intentionally not loaded; this is documented at the top of the test file.

## Testing

```
cargo test -p dsa --test wycheproof
```

```
running 4 tests
test dsa_2048_224_sha224 ... ok
test dsa_2048_224_sha256 ... ok
test dsa_2048_256_sha256 ... ok
test dsa_3072_256_sha256 ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

The full `cargo test -p dsa` suite and `cargo clippy -p dsa --tests --all-features` are both green.

Two small dev-dependencies were added to support the JSON loading (`serde` and `serde_json`, matching the versions already used by the `ml-dsa` Wycheproof tests), and the `serde` feature was enabled on the existing `hex` dev-dependency.
