### PR TITLE
ml-dsa: activate `MaybeBox` with alloc feature

### DIFF
--- a/ml-dsa/Cargo.toml
+++ b/ml-dsa/Cargo.toml
@@ -26,7 +26,7 @@ exclude = [
 
 [features]
 default = ["alloc", "getrandom", "pkcs8"]
-alloc = ["hybrid-array/alloc", "pkcs8?/alloc", "signature/alloc"]
+alloc = ["hybrid-array/alloc", "module-lattice/alloc", "pkcs8?/alloc", "signature/alloc"]
 
 getrandom = ["common/getrandom", "rand_core"]
 pkcs8 = ["dep:const-oid", "dep:pkcs8"]


### PR DESCRIPTION
When the matrices were pushed on the stack in #1344 and #1345, it relies on the `MaybeBox` implementation of `module-lattice`.

`MaybeBox` will push the matrix on the heap only if `alloc` is enabled.

Because `alloc` never got activated in `ml-dsa` this effectively reverted the optimization on the stack size made in #1261 and #1259.

This commit fixes that by enabling `alloc` on `module-lattice` when `alloc` is enabled on `ml-dsa` and restoring the expected behavior of `MaybeBox`.