### PR TITLE
ml-dsa v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,7 +815,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "ml-dsa"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "const-oid",
  "criterion",

--- a/ml-dsa/CHANGELOG.md
+++ b/ml-dsa/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.1 (2026-06-05)
+### Fixed
+- Enable `module-lattice/alloc` when `alloc` feature is enabled ([#1365])
+
+[#1365]: https://github.com/RustCrypto/signatures/pull/1365
+
 ## 0.1.0 (2026-05-17)
 ### Added
 - Implement `MultipartSigner/Verifier` ([#982])

--- a/ml-dsa/Cargo.toml
+++ b/ml-dsa/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Pure Rust implementation of ML-DSA (formerly known as CRYSTALS-Dilithium) as
 described in FIPS-204 (final)
 """
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
## Fixed
- Enable `module-lattice/alloc` when `alloc` feature is enabled ([#1365])

[#1365]: https://github.com/RustCrypto/signatures/pull/1365