### PR TITLE
rfc6979 v0.6.0-pre.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1187,13 +1187,13 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rfc6979"
-version = "0.5.0"
+version = "0.6.0-pre.0"
 dependencies = [
  "ctutils",
  "hex-literal",
  "hmac",
  "sha2",
- "sha3 0.12.0",
+ "sha3",
 ]
 
 [[package]]
@@ -1355,6 +1355,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sha3"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
+dependencies = [
+ "digest",
+ "keccak",
+ "sponge-cursor",
 ]
 
 [[package]]

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -21,7 +21,7 @@ digest = "0.11"
 crypto-bigint = { version = "0.7", default-features = false, features = ["alloc", "zeroize"] }
 crypto-common = { version = "0.2", default-features = false, features = ["rand_core"] }
 crypto-primes = { version = "0.7", default-features = false }
-rfc6979 = { version = "0.5" }
+rfc6979 = { version = "=0.6.0-pre.0" }
 sha2 = { version = "0.11", default-features = false }
 signature = { version = "3", default-features = false, features = ["alloc", "digest", "rand_core"] }
 zeroize = { version = "1", default-features = false, features = ["alloc"] }

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -24,7 +24,7 @@ zeroize = { version = "1.5", default-features = false }
 # optional dependencies
 der = { version = "0.8", optional = true }
 digest = { version = "0.11", optional = true, default-features = false, features = ["oid"] }
-rfc6979 = { version = "0.5", optional = true }
+rfc6979 = { version = "=0.6.0-pre.0", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false, features = ["alloc"] }
 sha2 = { version = "0.11", optional = true, default-features = false, features = ["oid"] }
 spki = { version = "0.8", optional = true, default-features = false }

--- a/rfc6979/Cargo.toml
+++ b/rfc6979/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rfc6979"
-version = "0.5.0"
+version = "0.6.0-pre.0"
 description = """
 Pure Rust implementation of RFC6979: Deterministic Usage of the
 Digital Signature Algorithm (DSA) and Elliptic Curve Digital Signature Algorithm (ECDSA)


### PR DESCRIPTION
The changes in #1360 were breaking, so this release bumps the minor version.

It might be possible to get some additional breaking changes in as well, if we can land RustCrypto/crypto-bigint#1266.