### PR TITLE
ecdsa: move low-S normalization check into `verify_prehashed`

### DIFF
--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -196,10 +196,6 @@ where
 /// - `z`: message digest to be verified. MUST BE OUTPUT OF A CRYPTOGRAPHICALLY SECURE DIGEST
 ///   ALGORITHM!!!
 /// - `sig`: signature to be verified against the key and message.
-///
-/// # Low-S Normalization
-///
-/// This is a low-level function that does *NOT* apply the `EcdsaCurve::NORMALIZE_S` checks.
 #[cfg(feature = "algorithm")]
 pub fn verify_prehashed<C>(
     q: &ProjectivePoint<C>,
@@ -210,6 +206,10 @@ where
     C: EcdsaCurve + CurveArithmetic,
     SignatureSize<C>: ArraySize,
 {
+    if C::NORMALIZE_S && sig.s().is_high().into() {
+        return Err(Error::new());
+    }
+
     let z = Scalar::<C>::reduce(z);
     let (r, s) = sig.split_scalars();
     let s_inv = *s.invert_vartime();

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -10,7 +10,6 @@ use elliptic_curve::{
     AffinePoint, CurveArithmetic, FieldBytesSize, ProjectivePoint, PublicKey,
     array::ArraySize,
     point::PointCompression,
-    scalar::IsHigh,
     sec1::{self, CompressedPoint, FromSec1Point, Sec1Point, ToSec1Point},
 };
 use signature::{DigestVerifier, MultipartVerifier, Verifier, hazmat::PrehashVerifier};
@@ -164,10 +163,6 @@ where
     SignatureSize<C>: ArraySize,
 {
     fn verify_prehash(&self, prehash: &[u8], signature: &Signature<C>) -> Result<()> {
-        if C::NORMALIZE_S && signature.s().is_high().into() {
-            return Err(Error::new());
-        }
-
         hazmat::verify_prehashed::<C>(
             &ProjectivePoint::<C>::from(*self.inner.as_affine()),
             &bits2field::<C>(prehash)?,


### PR DESCRIPTION
The behavior is otherwise inconsistent between this `hazmat` function and `VerifyingKey::verify_prehashed`.