### PR TITLE
ml-dsa: fix constant time issues

### DIFF
--- a/ml-dsa/src/algebra.rs
+++ b/ml-dsa/src/algebra.rs
@@ -186,8 +186,7 @@ impl AlgebraExt for Polynomial {
         self.0
             .iter()
             .map(AlgebraExt::infinity_norm)
-            .max()
-            .expect("should have a maximum")
+            .fold(0, |acc, x| u32::ct_select(&x, &acc, acc.ct_gt(&x)))
     }
 
     fn power2round(&self) -> (Self, Self) {
@@ -229,8 +228,7 @@ impl<K: ArraySize> AlgebraExt for Vector<K> {
         self.0
             .iter()
             .map(AlgebraExt::infinity_norm)
-            .max()
-            .expect("should have a maximum")
+            .fold(0, |acc, x| u32::ct_select(&x, &acc, acc.ct_gt(&x)))
     }
 
     fn power2round(&self) -> (Self, Self) {

--- a/ml-dsa/src/sampling.rs
+++ b/ml-dsa/src/sampling.rs
@@ -3,6 +3,7 @@ use crate::{
     crypto::{G, H},
     param::{Eta, MaskSamplingSize},
 };
+use ctutils::{CtLt, CtSelect};
 use hybrid_array::Array;
 use module_lattice::{ArraySize, Field, Truncate};
 #[cfg(feature = "zeroize")]
@@ -31,26 +32,11 @@ fn coeff_from_three_bytes(b: [u8; 3]) -> Option<Elem> {
 fn coeff_from_half_byte(b: u8, eta: Eta) -> Option<Elem> {
     match eta {
         Eta::Two if b < 15 => {
-            let b = Int::from(match b {
-                b if b < 5 => b,
-                b if b < 10 => b - 5,
-                _ => b - 10,
-            });
-
-            if b <= 2 {
-                Some(Elem::new(2 - b))
-            } else {
-                Some(-Elem::new(b - 2))
-            }
-        }
-        Eta::Four if b < 9 => {
             let b = Int::from(b);
-            if b <= 4 {
-                Some(Elem::new(4 - b))
-            } else {
-                Some(-Elem::new(b - 4))
-            }
+            let sub = Int::ct_select(&10, &Int::ct_select(&5, &0, b.ct_lt(&5)), b.ct_lt(&10));
+            Some(Elem::new(2) - Elem::new(b - sub))
         }
+        Eta::Four if b < 9 => Some(Elem::new(4) - Elem::new(b.into())),
         _ => None,
     }
 }


### PR DESCRIPTION
I saw that these two spots still used non-constant time code, let's replace this with branchless implementations instead.

* We only call `coeff_from_half_byte` during key generation, which means it is a lot harder for an attacker to collect enough execution traces. But since we generally use private key seeds, it's usually not just a one-shot for a fixed input and there is a chance to collect more traces. So it's definitely worth fixing in my opinion.

* The change to `Vector::infinity_norm` is not absolutely required, since by https://pq-crystals.org/dilithium/data/dilithium-specification-round3.pdf, section 5.5, it is OK to leak which coefficient violates the bound as long as we do not leak the coefficient itself or its sign. The change to `Polynomial::infinity_norm` although is important since it fixes that potential leak of information about the individual coefficients. Let me know if you would want to keep `Vector::infinity_norm` as is, this would probably save a tiny amount of instruction cycles.