### PR TITLE
rfc6979 v0.6.0-rc.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,10 +1097,9 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rfc6979"
-version = "0.6.0-pre.0"
+version = "0.6.0-rc.0"
 dependencies = [
  "crypto-bigint",
- "ctutils",
  "hex-literal",
  "hmac",
  "sha2",

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -21,7 +21,7 @@ digest = "0.11"
 crypto-bigint = { version = "0.7", default-features = false, features = ["alloc", "zeroize"] }
 crypto-common = { version = "0.2", default-features = false, features = ["rand_core"] }
 crypto-primes = { version = "0.7", default-features = false }
-rfc6979 = { version = "=0.6.0-pre.0" }
+rfc6979 = "0.6.0-rc.0"
 sha2 = { version = "0.11", default-features = false }
 signature = { version = "3", default-features = false, features = ["alloc", "digest", "rand_core"] }
 zeroize = { version = "1", default-features = false, features = ["alloc"] }

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -24,7 +24,7 @@ zeroize = { version = "1.5", default-features = false }
 # optional dependencies
 der = { version = "0.8", optional = true }
 digest = { version = "0.11", optional = true, default-features = false, features = ["oid"] }
-rfc6979 = { version = "=0.6.0-pre.0", optional = true }
+rfc6979 = { version = "0.6.0-rc.0", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false, features = ["alloc"] }
 sha2 = { version = "0.11", optional = true, default-features = false, features = ["oid"] }
 spki = { version = "0.8", optional = true, default-features = false }

--- a/rfc6979/Cargo.toml
+++ b/rfc6979/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rfc6979"
-version = "0.6.0-pre.0"
+version = "0.6.0-rc.0"
 description = """
 Pure Rust implementation of RFC6979: Deterministic Usage of the Digital Signature Algorithm (DSA)
 and Elliptic Curve Digital Signature Algorithm (ECDSA)
@@ -17,7 +17,6 @@ rust-version = "1.85"
 
 [dependencies]
 bigint = { package = "crypto-bigint", version = "0.7.5", default-features = false }
-ctutils = "0.4"
 hmac = { version = "0.13", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
This release is a significant rewrite that includes the new `KGenerator` API and integration with `crypto-bigint`.

See #1395.