### PR TITLE
rfc6979: cleanups for `HMAC_DRBG` implementation

### DIFF
--- a/dsa/src/generate/secret_number.rs
+++ b/dsa/src/generate/secret_number.rs
@@ -6,7 +6,7 @@ use crate::{Components, signing_key::SigningKey};
 use alloc::vec;
 use core::cmp::min;
 use crypto_bigint::{BoxedUint, NonZero, RandomBits, Resize};
-use digest::{Digest, FixedOutputReset, common::BlockSizeUser};
+use digest::{Digest, common::BlockSizeUser};
 use signature::rand_core::TryCryptoRng;
 use zeroize::Zeroizing;
 
@@ -25,7 +25,7 @@ pub(crate) fn secret_number_rfc6979<D>(
     hash: &[u8],
 ) -> Result<(BoxedUint, BoxedUint), signature::Error>
 where
-    D: Digest + BlockSizeUser + FixedOutputReset,
+    D: BlockSizeUser + Digest,
 {
     let q = signing_key.verifying_key().components().q();
     let size = (q.bits() / 8) as usize;

--- a/dsa/src/signing_key.rs
+++ b/dsa/src/signing_key.rs
@@ -14,7 +14,7 @@ use crypto_bigint::{
     modular::{BoxedMontyForm, BoxedMontyParams},
 };
 use crypto_common::Generate;
-use digest::{Digest, FixedOutputReset, common::BlockSizeUser};
+use digest::{Digest, Update, common::BlockSizeUser};
 use signature::{
     DigestSigner, MultipartSigner, RandomizedDigestSigner, Signer,
     hazmat::{PrehashSigner, RandomizedPrehashSigner},
@@ -96,7 +96,7 @@ impl SigningKey {
     #[cfg(feature = "hazmat")]
     pub fn sign_prehashed_rfc6979<D>(&self, prehash: &[u8]) -> Result<Signature, signature::Error>
     where
-        D: Digest + BlockSizeUser + FixedOutputReset,
+        D: BlockSizeUser + Digest,
     {
         let k_kinv = crate::generate::secret_number_rfc6979::<D>(self, prehash)?;
         self.sign_prehashed(k_kinv, prehash)
@@ -170,7 +170,7 @@ impl Signer<Signature> for SigningKey {
 impl MultipartSigner<Signature> for SigningKey {
     fn try_multipart_sign(&self, msg: &[&[u8]]) -> Result<Signature, signature::Error> {
         self.try_sign_digest(|digest: &mut sha2::Sha256| {
-            msg.iter().for_each(|slice| digest.update(slice));
+            msg.iter().for_each(|slice| Update::update(digest, slice));
             Ok(())
         })
     }
@@ -202,7 +202,7 @@ impl RandomizedPrehashSigner<Signature> for SigningKey {
 
 impl<D> DigestSigner<D, Signature> for SigningKey
 where
-    D: Digest + FixedOutputReset + BlockSizeUser,
+    D: BlockSizeUser + Digest + Update,
 {
     fn try_sign_digest<F: Fn(&mut D) -> Result<(), signature::Error>>(
         &self,
@@ -219,7 +219,7 @@ where
 
 impl<D> RandomizedDigestSigner<D, Signature> for SigningKey
 where
-    D: Digest + FixedOutputReset + BlockSizeUser,
+    D: BlockSizeUser + Digest + Update,
 {
     fn try_sign_digest_with_rng<
         R: TryCryptoRng + ?Sized,

--- a/dsa/tests/deterministic.rs
+++ b/dsa/tests/deterministic.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "hazmat")]
 use crypto_bigint::BoxedUint;
-use digest::{Digest, FixedOutputReset, common::BlockSizeUser};
+use digest::{Digest, Update, common::BlockSizeUser};
 use dsa::{Components, Signature, SigningKey, VerifyingKey};
 use sha1::Sha1;
 use sha2::{Sha224, Sha256, Sha384, Sha512};
@@ -100,15 +100,15 @@ fn dsa_2048_signing_key() -> SigningKey {
 /// Generate a signature given the unhashed message and a private key
 fn generate_signature<D>(signing_key: SigningKey, data: &[u8]) -> Signature
 where
-    D: Digest + FixedOutputReset + BlockSizeUser,
+    D: BlockSizeUser + Digest + Update,
 {
-    signing_key.sign_digest(|digest: &mut D| Digest::update(digest, data))
+    signing_key.sign_digest(|digest: &mut D| Update::update(digest, data))
 }
 
 /// Generate a signature using the 1024-bit DSA key
 fn generate_1024_signature<D>(data: &[u8]) -> Signature
 where
-    D: Digest + FixedOutputReset + BlockSizeUser,
+    D: BlockSizeUser + Digest + Update,
 {
     generate_signature::<D>(dsa_1024_signing_key(), data)
 }
@@ -116,7 +116,7 @@ where
 /// Generate a signature using the 2048-bit DSA key
 fn generate_2048_signature<D>(data: &[u8]) -> Signature
 where
-    D: Digest + FixedOutputReset + BlockSizeUser,
+    D: BlockSizeUser + Digest + Update,
 {
     generate_signature::<D>(dsa_2048_signing_key(), data)
 }

--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -25,7 +25,7 @@ use elliptic_curve::{
 };
 
 #[cfg(feature = "digest")]
-use digest::{Digest, FixedOutputReset, block_api::BlockSizeUser};
+use digest::{Digest, block_api::BlockSizeUser};
 
 /// Sign a prehashed message digest using the provided secret scalar and
 /// ephemeral scalar, returning an ECDSA signature.
@@ -108,7 +108,7 @@ pub fn sign_prehashed_rfc6979<C, D>(
 ) -> (Signature<C>, RecoveryId)
 where
     C: EcdsaCurve + CurveArithmetic,
-    D: Digest + BlockSizeUser + FixedOutputReset,
+    D: Digest + BlockSizeUser,
     SignatureSize<C>: ArraySize,
 {
     let order = C::ORDER;

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -95,7 +95,7 @@ use elliptic_curve::{
 use alloc::vec::Vec;
 #[cfg(feature = "digest")]
 use digest::{
-    Digest, FixedOutputReset,
+    Digest, FixedOutput,
     common::BlockSizeUser,
     const_oid::{AssociatedOid, ObjectIdentifier},
 };
@@ -672,7 +672,7 @@ where
 pub trait DigestAlgorithm: EcdsaCurve {
     /// Preferred digest to use when computing ECDSA signatures for this
     /// elliptic curve. This is typically a member of the SHA-2 family.
-    type Digest: BlockSizeUser + Digest + FixedOutputReset;
+    type Digest: BlockSizeUser + Digest + FixedOutput;
 }
 
 #[cfg(feature = "digest")]

--- a/ecdsa/src/recovery.rs
+++ b/ecdsa/src/recovery.rs
@@ -8,7 +8,7 @@ use {
         DigestAlgorithm, EcdsaCurve, Signature, SignatureSize, SigningKey, VerifyingKey,
         hazmat::{bytes2scalar, sign_prehashed_rfc6979, verify_prehashed},
     },
-    digest::{Digest, FixedOutputReset, Update},
+    digest::{Digest, Update},
     elliptic_curve::{
         AffinePoint, CurveArithmetic, FieldBytes, FieldBytesSize, Group, PrimeField,
         ProjectivePoint, Scalar,
@@ -252,7 +252,7 @@ where
 impl<C, D> RandomizedDigestSigner<D, (Signature<C>, RecoveryId)> for SigningKey<C>
 where
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
-    D: Digest + Update + FixedOutputReset,
+    D: Digest + Update,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
     SignatureSize<C>: ArraySize,
 {
@@ -263,7 +263,7 @@ where
     ) -> Result<(Signature<C>, RecoveryId)> {
         let mut digest = D::new();
         f(&mut digest)?;
-        self.sign_prehash_with_rng(rng, &digest.finalize_reset())
+        self.sign_prehash_with_rng(rng, &digest.finalize())
     }
 }
 

--- a/rfc6979/src/hmac_drbg.rs
+++ b/rfc6979/src/hmac_drbg.rs
@@ -1,21 +1,19 @@
 use core::fmt::{self, Debug};
 use hmac::{
-    KeyInit, SimpleHmacReset,
-    digest::{Digest, FixedOutputReset, Mac, array::Array, block_api::BlockSizeUser},
+    KeyInit, SimpleHmac,
+    digest::{Digest, Mac, OutputSizeUser, array::Array, block_api::BlockSizeUser},
 };
 
-/// Implementation of `HMAC_DRBG` as described in NIST SP800-90A.
+/// Implementation of [NIST SP800-90A]'s `HMAC_DRBG` HMAC-based deterministic random bit generator.
 ///
-/// <https://csrc.nist.gov/publications/detail/sp/800-90a/rev-1/final>
-///
-/// This is a HMAC-based deterministic random bit generator.
-// TODO(tarcieri): extract this into its own crate
+/// [NIST SP800-90A]: https://csrc.nist.gov/publications/detail/sp/800-90a/rev-1/final
+// TODO(tarcieri): extract this into the `hmacdrbg` crate: RustCrypto/CSRNGs#7
 pub(crate) struct HmacDrbg<D>
 where
-    D: Digest + BlockSizeUser + FixedOutputReset,
+    D: OutputSizeUser,
 {
     /// HMAC key `K` (see RFC 6979 Section 3.2.c)
-    k: SimpleHmacReset<D>,
+    k: Array<u8, D::OutputSize>,
 
     /// Chaining value `V` (see RFC 6979 Section 3.2.c)
     v: Array<u8, D::OutputSize>,
@@ -23,63 +21,67 @@ where
 
 impl<D> HmacDrbg<D>
 where
-    D: Digest + BlockSizeUser + FixedOutputReset,
+    D: BlockSizeUser + Digest,
 {
     /// Initialize `HMAC_DRBG`.
     #[must_use]
-    #[allow(clippy::missing_panics_doc, reason = "should not panic")]
     pub(crate) fn new(entropy_input: &[u8], nonce: &[u8], personalization_string: &[u8]) -> Self {
-        let mut k = SimpleHmacReset::new(&Default::default());
-        let mut v = Array::default();
-
-        v.fill(0x01);
-
-        for i in 0..=1 {
-            k.update(&v);
-            k.update(&[i]);
-            k.update(entropy_input);
-            k.update(nonce);
-            k.update(personalization_string);
-            k = SimpleHmacReset::new_from_slice(&k.finalize().into_bytes()).expect("should work");
-
-            // Steps 3.2.e,g: v = HMAC_k(v)
-            k.update(&v);
-            v = k.finalize_reset().into_bytes();
-        }
-
-        Self { k, v }
+        let mut drbg = Self {
+            k: Array::default(),
+            v: Array::default(),
+        };
+        drbg.v.fill(0x01);
+        drbg.update(&[entropy_input, nonce, personalization_string]);
+        drbg
     }
 
     /// Write the next `HMAC_DRBG` output to the given byte slice.
-    #[allow(clippy::missing_panics_doc, reason = "should not panic")]
     pub(crate) fn fill_bytes(&mut self, out: &mut [u8]) {
-        let mut out_chunks = out.chunks_exact_mut(self.v.len());
-
-        for out_chunk in &mut out_chunks {
-            self.k.update(&self.v);
-            self.v = self.k.finalize_reset().into_bytes();
+        for out_chunk in out.chunks_mut(self.v.len()) {
+            self.update_v();
             out_chunk.copy_from_slice(&self.v[..out_chunk.len()]);
         }
 
-        let out_remainder = out_chunks.into_remainder();
-        if !out_remainder.is_empty() {
-            self.k.update(&self.v);
-            self.v = self.k.finalize_reset().into_bytes();
-            out_remainder.copy_from_slice(&self.v[..out_remainder.len()]);
-        }
+        self.update(&[]);
+    }
 
-        self.k.update(&self.v);
-        self.k.update(&[0x00]);
-        self.k = SimpleHmacReset::new_from_slice(&self.k.finalize_reset().into_bytes())
-            .expect("should work");
-        self.k.update(&self.v);
-        self.v = self.k.finalize_reset().into_bytes();
+    /// Update `K` and `V` using the provided seed material.
+    fn update(&mut self, inputs: &[&[u8]]) {
+        let mut hmac = self.hmac_k();
+        hmac.update(&self.v);
+        hmac.update(&[0x00]);
+        inputs.iter().for_each(|&input| hmac.update(input));
+
+        self.k = hmac.finalize().into_bytes();
+        self.update_v();
+
+        if !inputs.is_empty() {
+            let mut hmac = self.hmac_k();
+            hmac.update(&self.v);
+            hmac.update(&[0x01]);
+            inputs.iter().for_each(|&input| hmac.update(input));
+
+            self.k = hmac.finalize().into_bytes();
+            self.update_v();
+        }
+    }
+
+    /// Update `V = HMAC(K, V)`.
+    fn update_v(&mut self) {
+        let mut hmac = self.hmac_k();
+        hmac.update(&self.v);
+        self.v = hmac.finalize().into_bytes();
+    }
+
+    /// Initialize HMAC using the current value of `K`.
+    fn hmac_k(&self) -> SimpleHmac<D> {
+        SimpleHmac::<D>::new_from_slice(&self.k).expect("HMAC key should be valid")
     }
 }
 
 impl<D> Debug for HmacDrbg<D>
 where
-    D: Digest + BlockSizeUser + FixedOutputReset,
+    D: OutputSizeUser,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("HmacDrbg").finish_non_exhaustive()

--- a/rfc6979/src/lib.rs
+++ b/rfc6979/src/lib.rs
@@ -55,20 +55,17 @@ pub use hmac::digest::array::typenum::consts;
 use crate::hmac_drbg::HmacDrbg;
 use bigint::{Encoding, Limb, Unsigned};
 use core::fmt;
-use hmac::digest::{Digest, FixedOutput, FixedOutputReset, block_api::BlockSizeUser};
+use hmac::digest::{Digest, OutputSizeUser, block_api::BlockSizeUser};
 
 /// Deterministic generator for the ephemeral scalar `k` as used by (EC)DSA.
-pub struct KGenerator<'a, D, U>
-where
-    D: Digest + BlockSizeUser + FixedOutput + FixedOutputReset,
-{
+pub struct KGenerator<'a, D: OutputSizeUser, U> {
     drbg: HmacDrbg<D>,
     q: &'a U,
 }
 
 impl<'a, D, U> KGenerator<'a, D, U>
 where
-    D: Digest + BlockSizeUser + FixedOutput + FixedOutputReset,
+    D: BlockSizeUser + Digest,
     U: Unsigned + Encoding,
 {
     /// Initialize `k` generator.
@@ -109,7 +106,7 @@ where
 
 impl<'a, D, U> fmt::Debug for KGenerator<'a, D, U>
 where
-    D: Digest + BlockSizeUser + FixedOutput + FixedOutputReset,
+    D: BlockSizeUser + Digest,
     U: Unsigned + Encoding,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
These are inspired by part from feedback on RustCrypto/CSRNGs#7