### PR TITLE
rfc6979 v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1114,7 +1114,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rfc6979"
-version = "0.6.0-rc.0"
+version = "0.6.0"
 dependencies = [
  "crypto-bigint",
  "hex-literal",

--- a/dsa/Cargo.toml
+++ b/dsa/Cargo.toml
@@ -21,7 +21,7 @@ digest = "0.11"
 crypto-bigint = { version = "0.7", default-features = false, features = ["alloc", "zeroize"] }
 crypto-common = { version = "0.2", default-features = false, features = ["rand_core"] }
 crypto-primes = { version = "0.7", default-features = false }
-rfc6979 = "0.6.0-rc.0"
+rfc6979 = "0.6"
 sha2 = { version = "0.11", default-features = false }
 signature = { version = "3", default-features = false, features = ["alloc", "digest", "rand_core"] }
 zeroize = { version = "1", default-features = false, features = ["alloc"] }

--- a/ecdsa/Cargo.toml
+++ b/ecdsa/Cargo.toml
@@ -24,7 +24,7 @@ zeroize = { version = "1.5", default-features = false }
 # optional dependencies
 der = { version = "0.8", optional = true }
 digest = { version = "0.11", optional = true, default-features = false, features = ["oid"] }
-rfc6979 = { version = "0.6.0-rc.0", optional = true }
+rfc6979 = { version = "0.6", optional = true }
 serdect = { version = "0.4", optional = true, default-features = false, features = ["alloc"] }
 sha2 = { version = "0.11", optional = true, default-features = false, features = ["oid"] }
 spki = { version = "0.8", optional = true, default-features = false }

--- a/rfc6979/CHANGELOG.md
+++ b/rfc6979/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2026-06-29)
+### Changed
+- Replace `generate_k(_mut)` free functions with new `KGenerator` struct ([#1395])
+- Use `crypto-bigint` for representing `q` ([#1395])
+
+### Fixed
+- Allow the use of non-`block_api`-backed hashes ([#1360])
+
+### Removed
+- `generate_k` and `generate_k_mut` free functions ([#1395])
+
+[#1360]: https://github.com/RustCrypto/signatures/pull/1360
+[#1395]: https://github.com/RustCrypto/signatures/pull/1395
+
 ## 0.5.0 (2026-05-06)
 ### Added
 - `generate_k_mut` function ([#773])

--- a/rfc6979/Cargo.toml
+++ b/rfc6979/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rfc6979"
-version = "0.6.0-rc.0"
+version = "0.6.0"
 description = """
 Pure Rust implementation of RFC6979: Deterministic Usage of the Digital Signature Algorithm (DSA)
 and Elliptic Curve Digital Signature Algorithm (ECDSA)


### PR DESCRIPTION
## Changed
- Replace `generate_k(_mut)` free functions with new `KGenerator` struct ([#1395])
- Use `crypto-bigint` for representing `q` ([#1395])

## Fixed
- Allow the use of non-`block_api`-backed hashes ([#1360])

## Removed
- `generate_k` and `generate_k_mut` free functions ([#1395])

[#1360]: https://github.com/RustCrypto/signatures/pull/1360
[#1395]: https://github.com/RustCrypto/signatures/pull/1395