### PR TITLE
ecdsa: move `Array*` bounds to `EcdsaCurve`

### DIFF
--- a/ecdsa/src/hazmat.rs
+++ b/ecdsa/src/hazmat.rs
@@ -12,10 +12,9 @@
 //! FULL PRIVATE KEY RECOVERY!
 //! </div>
 
-use crate::{EcdsaCurve, Error, RecoveryId, Result, Signature, SignatureSize};
+use crate::{EcdsaCurve, Error, RecoveryId, Result, Signature};
 use elliptic_curve::{
     CurveArithmetic, FieldBytes, NonZeroScalar, ProjectivePoint, Scalar,
-    array::ArraySize,
     bigint::{BitOps, Encoding},
     ff::PrimeField,
     group::{Curve as _, Group},
@@ -58,7 +57,6 @@ pub fn sign_prehashed<C>(
 ) -> Result<(Signature<C>, RecoveryId)>
 where
     C: EcdsaCurve + CurveArithmetic,
-    SignatureSize<C>: ArraySize,
 {
     let z = bytes2scalar::<C>(z);
 
@@ -109,7 +107,6 @@ pub fn sign_prehashed_rfc6979<C, D>(
 where
     C: EcdsaCurve + CurveArithmetic,
     D: Digest + BlockSizeUser,
-    SignatureSize<C>: ArraySize,
 {
     let order = C::ORDER;
     let mut kgen = rfc6979::KGenerator::<D, C::Uint>::new(&d.to_repr(), z, ad, &order);
@@ -137,7 +134,6 @@ where
 pub fn verify_prehashed<C>(q: &ProjectivePoint<C>, z: &[u8], sig: &Signature<C>) -> Result<()>
 where
     C: EcdsaCurve + CurveArithmetic,
-    SignatureSize<C>: ArraySize,
 {
     if C::NORMALIZE_S && sig.s().is_high().into() {
         return Err(Error::new());

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -87,7 +87,7 @@ pub use crate::verifying::VerifyingKey;
 
 use core::{fmt, ops::Add};
 use elliptic_curve::{
-    FieldBytes, FieldBytesSize, ScalarValue,
+    Curve, FieldBytes, FieldBytesSize, ScalarValue,
     array::{Array, ArraySize, typenum::Unsigned},
 };
 
@@ -164,7 +164,9 @@ const SHA384_OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("2.16.840.1.10
 const SHA512_OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("2.16.840.1.101.3.4.2.3");
 
 /// Marker trait for elliptic curves intended for use with ECDSA.
-pub trait EcdsaCurve: PrimeCurve {
+pub trait EcdsaCurve:
+    Curve<FieldBytesSize: Add<Output: ArraySize<ArrayType<u8>: Copy>>> + PrimeCurve
+{
     /// Does this curve use low-S normalized signatures?
     ///
     /// This is typically `false`. See [`Signature::normalize_s`] for more information.
@@ -203,7 +205,7 @@ pub type SignatureBytes<C> = Array<u8, SignatureSize<C>>;
 /// "human readable" text formats, and a binary encoding otherwise.
 ///
 /// [IEEE P1363]: https://en.wikipedia.org/wiki/IEEE_P1363
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Copy, Eq, PartialEq)]
 pub struct Signature<C: EcdsaCurve> {
     r: ScalarValue<C>,
     s: ScalarValue<C>,
@@ -212,7 +214,6 @@ pub struct Signature<C: EcdsaCurve> {
 impl<C> Signature<C>
 where
     C: EcdsaCurve,
-    SignatureSize<C>: ArraySize,
 {
     /// Parse a signature from fixed-width bytes, i.e. 2 * the size of
     /// [`FieldBytes`] for a particular curve.
@@ -301,7 +302,6 @@ where
 impl<C> Signature<C>
 where
     C: EcdsaCurve + CurveArithmetic,
-    SignatureSize<C>: ArraySize,
 {
     /// Get the `r` component of this signature
     pub fn r(&self) -> NonZeroScalar<C> {
@@ -318,30 +318,20 @@ where
         (self.r(), self.s())
     }
 
-    /// Normalize signature into "low S" form as described in
-    /// [BIP 0062: Dealing with Malleability][1].
+    /// Normalize signature into "low S" form described in [BIP 0062: Dealing with Malleability][1].
     ///
     /// [1]: https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki
     pub fn normalize_s(&self) -> Self {
-        let mut result = self.clone();
+        let mut result = *self;
         let s_inv = ScalarValue::from(-self.s());
         result.s.conditional_assign(&s_inv, self.s.is_high());
         result
     }
 }
 
-impl<C> Copy for Signature<C>
-where
-    C: EcdsaCurve,
-    SignatureSize<C>: ArraySize,
-    <SignatureSize<C> as ArraySize>::ArrayType<u8>: Copy,
-{
-}
-
 impl<C> From<Signature<C>> for SignatureBytes<C>
 where
     C: EcdsaCurve,
-    SignatureSize<C>: ArraySize,
 {
     fn from(signature: Signature<C>) -> SignatureBytes<C> {
         signature.to_bytes()
@@ -351,7 +341,6 @@ where
 impl<C> SignatureEncoding for Signature<C>
 where
     C: EcdsaCurve,
-    SignatureSize<C>: ArraySize,
 {
     type Repr = SignatureBytes<C>;
 }
@@ -359,7 +348,6 @@ where
 impl<C> TryFrom<&[u8]> for Signature<C>
 where
     C: EcdsaCurve,
-    SignatureSize<C>: ArraySize,
 {
     type Error = Error;
 
@@ -371,7 +359,6 @@ where
 impl<C> fmt::Debug for Signature<C>
 where
     C: EcdsaCurve,
-    SignatureSize<C>: ArraySize,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "ecdsa::Signature<{:?}>(", C::default())?;
@@ -387,7 +374,6 @@ where
 impl<C> fmt::Display for Signature<C>
 where
     C: EcdsaCurve,
-    SignatureSize<C>: ArraySize,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{self:X}")
@@ -397,7 +383,6 @@ where
 impl<C> core::hash::Hash for Signature<C>
 where
     C: EcdsaCurve,
-    SignatureSize<C>: ArraySize,
 {
     fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
         self.to_bytes().hash(state);
@@ -407,7 +392,6 @@ where
 impl<C> fmt::LowerHex for Signature<C>
 where
     C: EcdsaCurve,
-    SignatureSize<C>: ArraySize,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for byte in self.to_bytes() {
@@ -420,7 +404,6 @@ where
 impl<C> fmt::UpperHex for Signature<C>
 where
     C: EcdsaCurve,
-    SignatureSize<C>: ArraySize,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for byte in self.to_bytes() {
@@ -434,7 +417,6 @@ where
 impl<C> str::FromStr for Signature<C>
 where
     C: EcdsaCurve + CurveArithmetic,
-    SignatureSize<C>: ArraySize,
 {
     type Err = Error;
 
@@ -494,7 +476,6 @@ where
 impl<C> Serialize for Signature<C>
 where
     C: EcdsaCurve,
-    SignatureSize<C>: ArraySize,
 {
     fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
@@ -508,7 +489,6 @@ where
 impl<'de, C> Deserialize<'de> for Signature<C>
 where
     C: EcdsaCurve,
-    SignatureSize<C>: ArraySize,
 {
     fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
@@ -540,7 +520,7 @@ impl<C: EcdsaCurve> Zeroize for Signature<C> {
 ///
 /// [RFC5758 § 3.2]: https://www.rfc-editor.org/rfc/rfc5758#section-3.2
 #[cfg(feature = "digest")]
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct SignatureWithOid<C: EcdsaCurve> {
     /// Inner signature type.
     signature: Signature<C>,
@@ -596,7 +576,6 @@ where
     pub fn from_bytes_with_digest<D>(bytes: &SignatureBytes<C>) -> Result<Self>
     where
         D: AssociatedOid + Digest,
-        SignatureSize<C>: ArraySize,
     {
         Self::new_with_digest::<D>(Signature::<C>::from_bytes(bytes)?)
     }
@@ -605,7 +584,6 @@ where
     pub fn from_slice_with_digest<D>(slice: &[u8]) -> Result<Self>
     where
         D: AssociatedOid + Digest,
-        SignatureSize<C>: ArraySize,
     {
         Self::new_with_digest::<D>(Signature::<C>::from_slice(slice)?)
     }
@@ -643,9 +621,7 @@ where
 
     /// Serialize this signature as fixed-width bytes.
     pub fn to_bytes(&self) -> SignatureBytes<C>
-    where
-        SignatureSize<C>: ArraySize,
-    {
+where {
         self.signature.to_bytes()
     }
 
@@ -660,7 +636,7 @@ where
         der::MaxSize<C>: ArraySize,
         <FieldBytesSize<C> as Add>::Output: Add<der::MaxOverhead> + ArraySize,
     {
-        self.signature.clone().into()
+        self.signature.into()
     }
 }
 
@@ -676,19 +652,9 @@ pub trait DigestAlgorithm: EcdsaCurve {
 }
 
 #[cfg(feature = "digest")]
-impl<C> Copy for SignatureWithOid<C>
-where
-    C: EcdsaCurve,
-    SignatureSize<C>: ArraySize,
-    <SignatureSize<C> as ArraySize>::ArrayType<u8>: Copy,
-{
-}
-
-#[cfg(feature = "digest")]
 impl<C> core::hash::Hash for SignatureWithOid<C>
 where
     C: EcdsaCurve,
-    SignatureSize<C>: ArraySize,
 {
     fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
         self.signature.hash(state);
@@ -710,7 +676,6 @@ where
 impl<C> From<SignatureWithOid<C>> for SignatureBytes<C>
 where
     C: EcdsaCurve,
-    SignatureSize<C>: ArraySize,
 {
     fn from(signature: SignatureWithOid<C>) -> SignatureBytes<C> {
         signature.to_bytes()
@@ -751,7 +716,6 @@ impl<C> SignatureEncoding for SignatureWithOid<C>
 where
     C: DigestAlgorithm,
     C::Digest: AssociatedOid,
-    SignatureSize<C>: ArraySize,
 {
     type Repr = SignatureBytes<C>;
 }
@@ -766,7 +730,6 @@ impl<C> TryFrom<&[u8]> for SignatureWithOid<C>
 where
     C: DigestAlgorithm,
     C::Digest: AssociatedOid,
-    SignatureSize<C>: ArraySize,
 {
     type Error = Error;
 

--- a/ecdsa/src/recovery.rs
+++ b/ecdsa/src/recovery.rs
@@ -5,14 +5,13 @@ use crate::{Error, Result};
 #[cfg(feature = "algorithm")]
 use {
     crate::{
-        DigestAlgorithm, EcdsaCurve, Signature, SignatureSize, SigningKey, VerifyingKey,
+        DigestAlgorithm, EcdsaCurve, Signature, SigningKey, VerifyingKey,
         hazmat::{bytes2scalar, sign_prehashed_rfc6979, verify_prehashed},
     },
     digest::{Digest, Update},
     elliptic_curve::{
         AffinePoint, CurveArithmetic, FieldBytes, FieldBytesSize, Group, PrimeField,
         ProjectivePoint, Scalar,
-        array::ArraySize,
         bigint::CheckedAdd,
         field,
         ops::Invert,
@@ -95,7 +94,6 @@ impl RecoveryId {
         C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
         AffinePoint<C>: DecompressPoint<C> + FromSec1Point<C> + ToSec1Point<C>,
         FieldBytesSize<C>: sec1::ModulusSize,
-        SignatureSize<C>: ArraySize,
     {
         Self::trial_recovery_from_digest(verifying_key, C::Digest::new_with_prefix(msg), signature)
     }
@@ -113,7 +111,6 @@ impl RecoveryId {
         D: Digest,
         AffinePoint<C>: DecompressPoint<C> + FromSec1Point<C> + ToSec1Point<C>,
         FieldBytesSize<C>: sec1::ModulusSize,
-        SignatureSize<C>: ArraySize,
     {
         Self::trial_recovery_from_prehash(verifying_key, &digest.finalize(), signature)
     }
@@ -130,7 +127,6 @@ impl RecoveryId {
         C: EcdsaCurve + CurveArithmetic,
         AffinePoint<C>: DecompressPoint<C> + FromSec1Point<C> + ToSec1Point<C>,
         FieldBytesSize<C>: sec1::ModulusSize,
-        SignatureSize<C>: ArraySize,
     {
         // Ensure signature verifies with the provided key
         verify_prehashed::<C>(
@@ -172,7 +168,6 @@ impl<C> SigningKey<C>
 where
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
 {
     /// Sign the given message prehash, using the given rng for the RFC6979 Section 3.6 "additional
     /// data", returning a signature and recovery ID.
@@ -220,7 +215,6 @@ where
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
     D: Digest + Update,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
 {
     fn try_sign_digest<F: Fn(&mut D) -> Result<()>>(
         &self,
@@ -237,7 +231,6 @@ impl<C> RandomizedPrehashSigner<(Signature<C>, RecoveryId)> for SigningKey<C>
 where
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
 {
     fn sign_prehash_with_rng<R: TryCryptoRng + ?Sized>(
         &self,
@@ -254,7 +247,6 @@ where
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
     D: Digest + Update,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
 {
     fn try_sign_digest_with_rng<R: TryCryptoRng + ?Sized, F: Fn(&mut D) -> Result<()>>(
         &self,
@@ -272,7 +264,6 @@ impl<C> PrehashSigner<(Signature<C>, RecoveryId)> for SigningKey<C>
 where
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
 {
     fn sign_prehash(&self, prehash: &[u8]) -> Result<(Signature<C>, RecoveryId)> {
         self.sign_prehash_recoverable(prehash)
@@ -284,7 +275,6 @@ impl<C> Signer<(Signature<C>, RecoveryId)> for SigningKey<C>
 where
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
 {
     fn try_sign(&self, msg: &[u8]) -> Result<(Signature<C>, RecoveryId)> {
         self.try_multipart_sign(&[msg])
@@ -296,7 +286,6 @@ impl<C> MultipartSigner<(Signature<C>, RecoveryId)> for SigningKey<C>
 where
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
 {
     fn try_multipart_sign(&self, msg: &[&[u8]]) -> Result<(Signature<C>, RecoveryId)> {
         let mut digest = C::Digest::new();
@@ -312,7 +301,6 @@ where
     C: EcdsaCurve + CurveArithmetic,
     AffinePoint<C>: DecompressPoint<C> + FromSec1Point<C> + ToSec1Point<C>,
     FieldBytesSize<C>: sec1::ModulusSize,
-    SignatureSize<C>: ArraySize,
 {
     /// Recover a [`VerifyingKey`] from the given message, signature, and [`RecoveryId`].
     ///

--- a/ecdsa/src/signing.rs
+++ b/ecdsa/src/signing.rs
@@ -1,14 +1,13 @@
 //! ECDSA signing: producing signatures using a [`SigningKey`].
 
 use crate::{
-    DigestAlgorithm, EcdsaCurve, Error, Result, Signature, SignatureSize, SignatureWithOid,
-    ecdsa_oid_for_digest, hazmat::sign_prehashed_rfc6979,
+    DigestAlgorithm, EcdsaCurve, Error, Result, Signature, SignatureWithOid, ecdsa_oid_for_digest,
+    hazmat::sign_prehashed_rfc6979,
 };
 use core::fmt::{self, Debug};
 use digest::{Digest, FixedOutput, const_oid::AssociatedOid};
 use elliptic_curve::{
     CurveArithmetic, FieldBytes, Generate, NonZeroScalar, Scalar, SecretKey,
-    array::ArraySize,
     group::ff::PrimeField,
     ops::Invert,
     rand_core::CryptoRng,
@@ -34,6 +33,8 @@ use crate::elliptic_curve::{
 };
 #[cfg(any(feature = "der", feature = "pem"))]
 use elliptic_curve::FieldBytesSize;
+#[cfg(feature = "der")]
+use elliptic_curve::array::ArraySize;
 #[cfg(all(feature = "alloc", feature = "pkcs8"))]
 use elliptic_curve::pkcs8::{EncodePrivateKey, SecretDocument};
 #[cfg(feature = "algorithm")]
@@ -43,9 +44,9 @@ use {crate::der, core::ops::Add};
 #[cfg(feature = "pem")]
 use {core::str::FromStr, elliptic_curve::pkcs8::DecodePrivateKey};
 
-/// ECDSA secret key used for signing. Generic over prime order elliptic curves
-/// (e.g. NIST P-curves).
+/// ECDSA secret key used for signing.
 ///
+/// Generic over prime order elliptic curves (e.g. NIST P-curves).
 /// Requires an [`elliptic_curve::CurveArithmetic`] impl on the curve.
 ///
 /// ## Usage
@@ -143,7 +144,6 @@ where
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
     D: Digest + FixedOutput,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
 {
     fn try_sign_digest<F: Fn(&mut D) -> Result<()>>(&self, f: F) -> Result<Signature<C>> {
         let mut digest = D::new();
@@ -160,7 +160,6 @@ impl<C> PrehashSigner<Signature<C>> for SigningKey<C>
 where
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
 {
     fn sign_prehash(&self, prehash: &[u8]) -> Result<Signature<C>> {
         Ok(sign_prehashed_rfc6979::<C, C::Digest>(&self.secret_scalar, prehash, &[]).0)
@@ -175,7 +174,6 @@ impl<C> Signer<Signature<C>> for SigningKey<C>
 where
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
 {
     fn try_sign(&self, msg: &[u8]) -> Result<Signature<C>> {
         self.try_multipart_sign(&[msg])
@@ -186,7 +184,6 @@ impl<C> MultipartSigner<Signature<C>> for SigningKey<C>
 where
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
 {
     fn try_multipart_sign(&self, msg: &[&[u8]]) -> core::result::Result<Signature<C>, Error> {
         self.try_sign_digest(|digest: &mut C::Digest| {
@@ -201,7 +198,6 @@ where
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
     D: Digest + FixedOutput,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
 {
     fn try_sign_digest_with_rng<R: TryCryptoRng + ?Sized, F: Fn(&mut D) -> Result<()>>(
         &self,
@@ -218,7 +214,6 @@ impl<C> RandomizedPrehashSigner<Signature<C>> for SigningKey<C>
 where
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
 {
     fn sign_prehash_with_rng<R: TryCryptoRng + ?Sized>(
         &self,
@@ -236,7 +231,6 @@ where
     Self: RandomizedDigestSigner<C::Digest, Signature<C>>,
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
 {
     fn try_sign_with_rng<R: TryCryptoRng + ?Sized>(
         &self,
@@ -252,7 +246,6 @@ where
     Self: RandomizedDigestSigner<C::Digest, Signature<C>>,
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
 {
     fn try_multipart_sign_with_rng<R: TryCryptoRng + ?Sized>(
         &self,
@@ -271,7 +264,6 @@ where
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
     D: AssociatedOid + Digest + FixedOutput,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
 {
     fn try_sign_digest<F: Fn(&mut D) -> Result<()>>(&self, f: F) -> Result<SignatureWithOid<C>> {
         let signature: Signature<C> = self.try_sign_digest(f)?;
@@ -285,7 +277,6 @@ where
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
     C::Digest: AssociatedOid,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
 {
     fn try_sign(&self, msg: &[u8]) -> Result<SignatureWithOid<C>> {
         self.try_multipart_sign(&[msg])
@@ -297,7 +288,6 @@ where
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
     C::Digest: AssociatedOid,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
 {
     fn try_multipart_sign(&self, msg: &[&[u8]]) -> Result<SignatureWithOid<C>> {
         self.try_sign_digest(|digest: &mut C::Digest| {
@@ -312,7 +302,6 @@ impl<C> PrehashSigner<der::Signature<C>> for SigningKey<C>
 where
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
     der::MaxSize<C>: ArraySize,
     <FieldBytesSize<C> as Add>::Output: Add<der::MaxOverhead> + ArraySize,
 {
@@ -326,7 +315,6 @@ impl<C> Signer<der::Signature<C>> for SigningKey<C>
 where
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
     der::MaxSize<C>: ArraySize,
     <FieldBytesSize<C> as Add>::Output: Add<der::MaxOverhead> + ArraySize,
 {
@@ -341,7 +329,6 @@ where
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
     D: Digest + FixedOutput,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
     der::MaxSize<C>: ArraySize,
     <FieldBytesSize<C> as Add>::Output: Add<der::MaxOverhead> + ArraySize,
 {
@@ -360,7 +347,6 @@ impl<C> RandomizedPrehashSigner<der::Signature<C>> for SigningKey<C>
 where
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
     der::MaxSize<C>: ArraySize,
     <FieldBytesSize<C> as Add>::Output: Add<der::MaxOverhead> + ArraySize,
 {
@@ -380,7 +366,6 @@ where
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
     D: Digest + FixedOutput,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
     der::MaxSize<C>: ArraySize,
     <FieldBytesSize<C> as Add>::Output: Add<der::MaxOverhead> + ArraySize,
 {
@@ -394,7 +379,6 @@ impl<C> RandomizedSigner<der::Signature<C>> for SigningKey<C>
 where
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
     der::MaxSize<C>: ArraySize,
     <FieldBytesSize<C> as Add>::Output: Add<der::MaxOverhead> + ArraySize,
 {
@@ -412,7 +396,6 @@ impl<C> RandomizedMultipartSigner<der::Signature<C>> for SigningKey<C>
 where
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
     der::MaxSize<C>: ArraySize,
     <FieldBytesSize<C> as Add>::Output: Add<der::MaxOverhead> + ArraySize,
 {
@@ -435,7 +418,6 @@ impl<C> AsRef<VerifyingKey<C>> for SigningKey<C>
 where
     C: EcdsaCurve + CurveArithmetic,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
 {
     fn as_ref(&self) -> &VerifyingKey<C> {
         &self.verifying_key
@@ -446,7 +428,6 @@ impl<C> ConstantTimeEq for SigningKey<C>
 where
     C: EcdsaCurve + CurveArithmetic,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
 {
     fn ct_eq(&self, other: &Self) -> Choice {
         self.secret_scalar.ct_eq(&other.secret_scalar)
@@ -476,14 +457,12 @@ impl<C> Eq for SigningKey<C>
 where
     C: EcdsaCurve + CurveArithmetic,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
 {
 }
 impl<C> PartialEq for SigningKey<C>
 where
     C: EcdsaCurve + CurveArithmetic,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
 {
     fn eq(&self, other: &SigningKey<C>) -> bool {
         self.ct_eq(other).into()
@@ -528,7 +507,6 @@ impl<C> From<SigningKey<C>> for SecretKey<C>
 where
     C: EcdsaCurve + CurveArithmetic,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
 {
     fn from(key: SigningKey<C>) -> Self {
         key.secret_scalar.into()
@@ -562,7 +540,6 @@ impl<C> From<SigningKey<C>> for VerifyingKey<C>
 where
     C: EcdsaCurve + CurveArithmetic,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
 {
     fn from(signing_key: SigningKey<C>) -> VerifyingKey<C> {
         signing_key.verifying_key
@@ -574,7 +551,6 @@ impl<C> From<&SigningKey<C>> for VerifyingKey<C>
 where
     C: EcdsaCurve + CurveArithmetic,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
 {
     fn from(signing_key: &SigningKey<C>) -> VerifyingKey<C> {
         signing_key.verifying_key
@@ -586,7 +562,6 @@ impl<C> KeypairRef for SigningKey<C>
 where
     C: EcdsaCurve + CurveArithmetic,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
 {
     type VerifyingKey = VerifyingKey<C>;
 }
@@ -596,7 +571,6 @@ impl<C> AssociatedAlgorithmIdentifier for SigningKey<C>
 where
     C: EcdsaCurve + AssociatedOid + CurveArithmetic,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
 {
     type Params = ObjectIdentifier;
 
@@ -609,7 +583,6 @@ impl<C> SignatureAlgorithmIdentifier for SigningKey<C>
 where
     C: EcdsaCurve + CurveArithmetic,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
     Signature<C>: AssociatedAlgorithmIdentifier<Params = AnyRef<'static>>,
 {
     type Params = AnyRef<'static>;
@@ -625,7 +598,6 @@ where
     AffinePoint<C>: FromSec1Point<C> + ToSec1Point<C>,
     FieldBytesSize<C>: sec1::ModulusSize,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
 {
     type Error = pkcs8::Error;
 
@@ -641,7 +613,6 @@ where
     AffinePoint<C>: FromSec1Point<C> + ToSec1Point<C>,
     FieldBytesSize<C>: sec1::ModulusSize,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
 {
     fn to_pkcs8_der(&self) -> pkcs8::Result<SecretDocument> {
         SecretKey::from(self.secret_scalar).to_pkcs8_der()
@@ -655,7 +626,6 @@ where
     AffinePoint<C>: FromSec1Point<C> + ToSec1Point<C>,
     FieldBytesSize<C>: sec1::ModulusSize,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
-    SignatureSize<C>: ArraySize,
 {
     type Err = Error;
 

--- a/ecdsa/src/verifying.rs
+++ b/ecdsa/src/verifying.rs
@@ -1,11 +1,10 @@
 //! ECDSA verifying: checking signatures are authentic using a [`VerifyingKey`].
 
-use crate::{DigestAlgorithm, EcdsaCurve, Error, Result, Signature, SignatureSize, hazmat};
+use crate::{DigestAlgorithm, EcdsaCurve, Error, Result, Signature, hazmat};
 use core::{cmp::Ordering, fmt::Debug};
 use digest::{Digest, Update};
 use elliptic_curve::{
     AffinePoint, CurveArithmetic, FieldBytesSize, PublicKey,
-    array::ArraySize,
     point::PointCompression,
     sec1::{self, CompressedPoint, FromSec1Point, Sec1Point, ToSec1Point},
 };
@@ -13,13 +12,8 @@ use signature::{DigestVerifier, MultipartVerifier, Verifier, hazmat::PrehashVeri
 
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
-
-#[cfg(feature = "der")]
-use {crate::der, core::ops::Add};
-
-#[cfg(feature = "pem")]
-use {core::str::FromStr, elliptic_curve::pkcs8::DecodePublicKey};
-
+#[cfg(all(feature = "alloc", feature = "pkcs8"))]
+use elliptic_curve::pkcs8::EncodePublicKey;
 #[cfg(feature = "pkcs8")]
 use elliptic_curve::pkcs8::{
     self, AssociatedOid, ObjectIdentifier,
@@ -28,10 +22,10 @@ use elliptic_curve::pkcs8::{
         self, AlgorithmIdentifier, AssociatedAlgorithmIdentifier, SignatureAlgorithmIdentifier,
     },
 };
-
 #[cfg(feature = "serde")]
 use serdect::serde::{Deserialize, Serialize, de, ser};
-
+#[cfg(feature = "der")]
+use {crate::der, core::ops::Add, elliptic_curve::array::ArraySize};
 #[cfg(feature = "sha2")]
 use {
     crate::{
@@ -39,9 +33,8 @@ use {
     },
     sha2::{Sha224, Sha256, Sha384, Sha512},
 };
-
-#[cfg(all(feature = "alloc", feature = "pkcs8"))]
-use elliptic_curve::pkcs8::EncodePublicKey;
+#[cfg(feature = "pem")]
+use {core::str::FromStr, elliptic_curve::pkcs8::DecodePublicKey};
 
 /// ECDSA public key used for verifying signatures. Generic over prime order
 /// elliptic curves (e.g. NIST P-curves).
@@ -141,7 +134,6 @@ impl<C, D> DigestVerifier<D, Signature<C>> for VerifyingKey<C>
 where
     C: EcdsaCurve + CurveArithmetic,
     D: Digest + Update,
-    SignatureSize<C>: ArraySize,
 {
     fn verify_digest<F: Fn(&mut D) -> Result<()>>(
         &self,
@@ -157,7 +149,6 @@ where
 impl<C> PrehashVerifier<Signature<C>> for VerifyingKey<C>
 where
     C: EcdsaCurve + CurveArithmetic,
-    SignatureSize<C>: ArraySize,
 {
     fn verify_prehash(&self, prehash: &[u8], signature: &Signature<C>) -> Result<()> {
         hazmat::verify_prehashed::<C>(&(*self.inner.as_affine()).into(), prehash, signature)
@@ -167,7 +158,6 @@ where
 impl<C> Verifier<Signature<C>> for VerifyingKey<C>
 where
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
-    SignatureSize<C>: ArraySize,
 {
     fn verify(&self, msg: &[u8], signature: &Signature<C>) -> Result<()> {
         self.multipart_verify(&[msg], signature)
@@ -177,7 +167,6 @@ where
 impl<C> MultipartVerifier<Signature<C>> for VerifyingKey<C>
 where
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
-    SignatureSize<C>: ArraySize,
 {
     fn multipart_verify(&self, msg: &[&[u8]], signature: &Signature<C>) -> Result<()> {
         self.verify_digest(
@@ -194,7 +183,6 @@ where
 impl<C> Verifier<SignatureWithOid<C>> for VerifyingKey<C>
 where
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
-    SignatureSize<C>: ArraySize,
 {
     fn verify(&self, msg: &[u8], sig: &SignatureWithOid<C>) -> Result<()> {
         self.multipart_verify(&[msg], sig)
@@ -205,7 +193,6 @@ where
 impl<C> MultipartVerifier<SignatureWithOid<C>> for VerifyingKey<C>
 where
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
-    SignatureSize<C>: ArraySize,
 {
     fn multipart_verify(&self, msg: &[&[u8]], sig: &SignatureWithOid<C>) -> Result<()> {
         match sig.oid() {
@@ -243,7 +230,6 @@ impl<C, D> DigestVerifier<D, der::Signature<C>> for VerifyingKey<C>
 where
     C: EcdsaCurve + CurveArithmetic,
     D: Digest + Update,
-    SignatureSize<C>: ArraySize,
     der::MaxSize<C>: ArraySize,
     <FieldBytesSize<C> as Add>::Output: Add<der::MaxOverhead> + ArraySize,
 {
@@ -261,7 +247,6 @@ where
 impl<C> PrehashVerifier<der::Signature<C>> for VerifyingKey<C>
 where
     C: EcdsaCurve + CurveArithmetic,
-    SignatureSize<C>: ArraySize,
     der::MaxSize<C>: ArraySize,
     <FieldBytesSize<C> as Add>::Output: Add<der::MaxOverhead> + ArraySize,
 {
@@ -275,7 +260,6 @@ where
 impl<C> Verifier<der::Signature<C>> for VerifyingKey<C>
 where
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
-    SignatureSize<C>: ArraySize,
     der::MaxSize<C>: ArraySize,
     <FieldBytesSize<C> as Add>::Output: Add<der::MaxOverhead> + ArraySize,
 {
@@ -289,7 +273,6 @@ where
 impl<C> MultipartVerifier<der::Signature<C>> for VerifyingKey<C>
 where
     C: EcdsaCurve + CurveArithmetic + DigestAlgorithm,
-    SignatureSize<C>: ArraySize,
     der::MaxSize<C>: ArraySize,
     <FieldBytesSize<C> as Add>::Output: Add<der::MaxOverhead> + ArraySize,
 {


### PR DESCRIPTION
Eliminates repetitive `SignatureSize<C>: ArraySize` bounds and `Copy`-related bounds by moving them all to `EcdsaCurve` and bounding on `Curve::FieldBytesSize`.

This even enables custom derive to work in places it didn't before.