### PR TITLE
slh-dsa: replace num-bigint with crypto-bigint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -832,25 +832,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1329,13 +1310,13 @@ dependencies = [
  "cipher",
  "const-oid",
  "criterion",
+ "crypto-bigint",
  "ctr",
  "digest",
  "hex",
  "hex-literal",
  "hmac",
  "hybrid-array",
- "num-bigint",
  "paste",
  "pkcs8",
  "proptest",

--- a/slh-dsa/Cargo.toml
+++ b/slh-dsa/Cargo.toml
@@ -38,7 +38,7 @@ cipher = "0.5"
 ctr = "0.10.0-rc.3"
 hex = { version = "0.4.1", features = ["serde"] }
 hex-literal = "1"
-num-bigint = "0.5.1"
+crypto-bigint = { version = "0.7", default-features = false, features = ["alloc"] }
 paste = "1.0.15"
 pkcs8 = { version = "0.11", features = ["pem"] }
 proptest = "1.11.0"

--- a/slh-dsa/src/util.rs
+++ b/slh-dsa/src/util.rs
@@ -90,7 +90,7 @@ pub(crate) mod macros {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use num_bigint::BigUint;
+    use crypto_bigint::BoxedUint;
     use proptest::prelude::*;
     use typenum::U;
 
@@ -100,14 +100,17 @@ mod tests {
         }
 
         let a = base_2b::<OutLen, B>(x);
-        let mut b = BigUint::from_bytes_be(&x[..(OutLen::USIZE * B::USIZE + 7) / 8]);
+        let mut b = BoxedUint::from_be_slice_vartime(&x[..(OutLen::USIZE * B::USIZE + 7) / 8]);
 
         if (B::USIZE * OutLen::USIZE) % 8 != 0 {
             // Clear lower bits of b
             b >>= 8 - ((B::USIZE * OutLen::USIZE) % 8);
         }
 
-        let c: BigUint = a.iter().fold(0u8.into(), |acc, x| (acc << B::U8) + x);
+        let c: BoxedUint = a.iter().fold(
+            BoxedUint::zero_with_precision(b.bits_precision()),
+            |acc, x| (acc << B::U32) + *x,
+        );
 
         assert_eq!(b, c);
     }


### PR DESCRIPTION
This replaces the test implementation of slh-dsa to use crypto-bigint instead of num-bigint.

This drops the num-bigint crate entirely from the workspace.