### PR TITLE
slh-dsa: v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1323,7 +1323,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slh-dsa"
-version = "0.2.0-rc.5"
+version = "0.2.0"
 dependencies = [
  "aes",
  "cipher",

--- a/slh-dsa/CHANGELOG.md
+++ b/slh-dsa/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (UNRELEASED)
+
+### Added
+
+- `pkcs8` support ([#867])
+- `Zeroize` support for `SigningKey` ([#938])
+- `no_std` support ([#956])
+- Implement `MultipartSigner/Verifier` ([#982])
+
+### Changed
+
+- Upgrade to the 2024 edition; bump MSRV to 1.85 ([#913])
+- Bump `zerocopy` to v0.8 ([#1071])
+- Bump `rand_core` to v0.10 ([#1197])
+- Bump `digest` to v0.11 ([#1263])
+- Bump `sha2` to v0.11 ([#1267])
+- Bump `hmac` to v0.13 ([#1274])
+- Bump `pkcs8` to v0.11 ([#1316])
+- Bump `signature` to v3 ([#1321])
+- Migrate from `sha3` to `shake` ([#1359])
+
+### Fixed
+
+- PK.SEed state caching ([#1116])
+
+[#867]: https://github.com/RustCrypto/signatures/pull/867
+[#913]: https://github.com/RustCrypto/signatures/pull/913
+[#938]: https://github.com/RustCrypto/signatures/pull/938
+[#956]: https://github.com/RustCrypto/signatures/pull/956
+[#982]: https://github.com/RustCrypto/signatures/pull/982
+[#1071]: https://github.com/RustCrypto/signatures/pull/1071
+[#1116]: https://github.com/RustCrypto/signatures/pull/1116
+[#1197]: https://github.com/RustCrypto/signatures/pull/1197
+[#1263]: https://github.com/RustCrypto/signatures/pull/1263
+[#1267]: https://github.com/RustCrypto/signatures/pull/1267
+[#1274]: https://github.com/RustCrypto/signatures/pull/1274
+[#1316]: https://github.com/RustCrypto/signatures/pull/1316
+[#1321]: https://github.com/RustCrypto/signatures/pull/1321
+[#1359]: https://github.com/RustCrypto/signatures/pull/1359
+
 ## 0.1.0 (2024-08-18)
 ### Changed
 - Implement changes from FIP 205 Initial Public Draft -> FIPS 205 Final ([#844])

--- a/slh-dsa/Cargo.toml
+++ b/slh-dsa/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Pure Rust implementation of SLH-DSA (aka SPHINCS+) as described in the
 FIPS-205 standard
 """
-version = "0.2.0-rc.5"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
Added

- `pkcs8` support ([#867])
- `Zeroize` support for `SigningKey` ([#938])
- `no_std` support ([#956])
- Implement `MultipartSigner/Verifier` ([#982])

Changed

- Upgrade to the 2024 edition; bump MSRV to 1.85 ([#913])
- Bump `zerocopy` to v0.8 ([#1071])
- Bump `rand_core` to v0.10 ([#1197])
- Bump `digest` to v0.11 ([#1263])
- Bump `sha2` to v0.11 ([#1267])
- Bump `hmac` to v0.13 ([#1274])
- Bump `pkcs8` to v0.11 ([#1316])
- Bump `signature` to v3 ([#1321])
- Migrate from `sha3` to `shake` ([#1359])

Fixed

- PK.SEed state caching ([#1116])

[#867]: https://github.com/RustCrypto/signatures/pull/867
[#913]: https://github.com/RustCrypto/signatures/pull/913
[#938]: https://github.com/RustCrypto/signatures/pull/938
[#956]: https://github.com/RustCrypto/signatures/pull/956
[#982]: https://github.com/RustCrypto/signatures/pull/982
[#1071]: https://github.com/RustCrypto/signatures/pull/1071
[#1116]: https://github.com/RustCrypto/signatures/pull/1116
[#1197]: https://github.com/RustCrypto/signatures/pull/1197
[#1263]: https://github.com/RustCrypto/signatures/pull/1263
[#1267]: https://github.com/RustCrypto/signatures/pull/1267
[#1274]: https://github.com/RustCrypto/signatures/pull/1274
[#1316]: https://github.com/RustCrypto/signatures/pull/1316
[#1321]: https://github.com/RustCrypto/signatures/pull/1321
[#1359]: https://github.com/RustCrypto/signatures/pull/1359